### PR TITLE
Fix semver display for quest window

### DIFF
--- a/Questionable/Windows/QuestWindow.cs
+++ b/Questionable/Windows/QuestWindow.cs
@@ -46,7 +46,7 @@ internal sealed class QuestWindow : LWindow, IPersistableWindowConfig
         IFramework framework,
         InteractionUiController interactionUiController,
         ConfigWindow configWindow)
-        : base($"Questionable v{PluginVersion.ToString(2)}###Questionable",
+        : base($"Questionable v{PluginVersion.ToString(4)}###Questionable",
             ImGuiWindowFlags.AlwaysAutoResize)
     {
         _pluginInterface = pluginInterface;


### PR DESCRIPTION
Fixes version display in Questionable quest window not displaying the full version since switching to full [SemVer](https://semver.org/) schema.

Before:
<img width="102" height="22" alt="image" src="https://github.com/user-attachments/assets/1e289f22-1685-4d69-b3ba-6d6f297ed544" />
After:
<img width="124" height="22" alt="image" src="https://github.com/user-attachments/assets/985732ee-282d-4533-b725-f08caa2978a2" />
