### PR TITLE
Fix Ul'dah DoW item purchase

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup Condition="$(MSBuildProjectName) != 'GatheringPathRenderer'">
-        <Version>6.9</Version>
+        <Version>6.5.0.1</Version>
     </PropertyGroup>
 </Project>

--- a/QuestPaths/2.x - A Realm Reborn/MSQ-1/Ul'dah/3852_Prudence at This Junction.json
+++ b/QuestPaths/2.x - A Realm Reborn/MSQ-1/Ul'dah/3852_Prudence at This Junction.json
@@ -71,7 +71,7 @@
             "ExcelSheet": "GilShop",
             "Key": 262357
           },
-          "ItemId": 2654,
+          "ItemId": 2653,
           "ItemCount": 1,
           "RequiredCurrentJob": [
             "DoW"
@@ -106,7 +106,7 @@
         {
           "TerritoryId": 141,
           "InteractionType": "EquipItem",
-          "ItemId": 2654,
+          "ItemId": 2653,
           "SkipConditions": {
             "StepIf": {
               "Item": {


### PR DESCRIPTION
Path for DoW in Ul'dah MSQ attempts to purchase level 8 item for quest, but MSQ may not provide enough experience to equip this. This results in an unexpected dialog and stops the path.

Changed purchase and equip item id to a level 5 DoW item instead.