### PR TITLE
Rework Event Management (by @Cryotechnic)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup Condition="$(MSBuildProjectName) != 'GatheringPathRenderer'">
-        <Version>6.5.0.1</Version>
+        <Version>6.5.1.1</Version>
     </PropertyGroup>
 </Project>

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/All Saints' Wake (2024)/5184_The Aether-starved Ahriman.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/All Saints' Wake (2024)/5184_The Aether-starved Ahriman.json
@@ -1,5 +1,5 @@
 ﻿{
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "liza",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2024-11-04",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/All Saints' Wake (2024)/5184_The Aether-starved Ahriman.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/All Saints' Wake (2024)/5184_The Aether-starved Ahriman.json
@@ -1,6 +1,8 @@
 ﻿{
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2024-11-04",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/All Saints' Wake (2024)/5185_All Fiends Sated on All Saints' Wake.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/All Saints' Wake (2024)/5185_All Fiends Sated on All Saints' Wake.json
@@ -1,5 +1,5 @@
 ﻿{
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "liza",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2024-11-04",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/All Saints' Wake (2024)/5185_All Fiends Sated on All Saints' Wake.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/All Saints' Wake (2024)/5185_All Fiends Sated on All Saints' Wake.json
@@ -1,6 +1,8 @@
 ﻿{
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2024-11-04",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Hatching-tide (2025)/5242_In Pursuit of Eggcellence.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Hatching-tide (2025)/5242_In Pursuit of Eggcellence.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "liza",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2025-04-24",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Hatching-tide (2025)/5242_In Pursuit of Eggcellence.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Hatching-tide (2025)/5242_In Pursuit of Eggcellence.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2025-04-24",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Hatching-tide (2025)/5243_Eggceeding Expectations.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Hatching-tide (2025)/5243_Eggceeding Expectations.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "liza",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2025-04-24",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Hatching-tide (2025)/5243_Eggceeding Expectations.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Hatching-tide (2025)/5243_Eggceeding Expectations.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2025-04-24",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Heavensturn (2025)/5186_Heavensssturn Trivia.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Heavensturn (2025)/5186_Heavensssturn Trivia.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "Starr",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2025-01-16T14:59:59Z",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Heavensturn (2025)/5186_Heavensssturn Trivia.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Heavensturn (2025)/5186_Heavensssturn Trivia.json
@@ -2,7 +2,7 @@
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "Starr",
   "IsSeasonalQuest": true,
-  "SeasonalQuestExpiry": "2025-01-16T14:59:59Z",
+  "SeasonalQuestExpiry": "2025-01-16",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Heavensturn (2025)/5186_Heavensssturn Trivia.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Heavensturn (2025)/5186_Heavensssturn Trivia.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "Starr",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2025-01-16",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Little Ladies' Day (2025)/5237_A Princely Persona.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Little Ladies' Day (2025)/5237_A Princely Persona.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2025-03-17T14:59:59Z",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Little Ladies' Day (2025)/5237_A Princely Persona.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Little Ladies' Day (2025)/5237_A Princely Persona.json
@@ -2,7 +2,7 @@
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
   "IsSeasonalQuest": true,
-  "SeasonalQuestExpiry": "2025-03-17T14:59:59Z",
+  "SeasonalQuestExpiry": "2025-03-17",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Little Ladies' Day (2025)/5237_A Princely Persona.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Little Ladies' Day (2025)/5237_A Princely Persona.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "liza",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2025-03-17",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Little Ladies' Day (2025)/5238_A Princely Debut.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Little Ladies' Day (2025)/5238_A Princely Debut.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2025-03-11T14:59:59Z",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Little Ladies' Day (2025)/5238_A Princely Debut.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Little Ladies' Day (2025)/5238_A Princely Debut.json
@@ -2,7 +2,7 @@
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
   "IsSeasonalQuest": true,
-  "SeasonalQuestExpiry": "2025-03-11T14:59:59Z",
+  "SeasonalQuestExpiry": "2025-03-11",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Little Ladies' Day (2025)/5238_A Princely Debut.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Little Ladies' Day (2025)/5238_A Princely Debut.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "liza",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2025-03-11",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Make It Rain (2025)/5322_Royal Rumblings.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Make It Rain (2025)/5322_Royal Rumblings.json
@@ -2,7 +2,7 @@
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
   "IsSeasonalQuest": true,
-  "SeasonalQuestExpiry": "2025-06-11T14:59:59Z",
+  "SeasonalQuestExpiry": "2025-06-11",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Make It Rain (2025)/5322_Royal Rumblings.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Make It Rain (2025)/5322_Royal Rumblings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "liza",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2025-06-11",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Make It Rain (2025)/5322_Royal Rumblings.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Make It Rain (2025)/5322_Royal Rumblings.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2025-06-11T14:59:59Z",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2024)/5182_Fire Red, Beast Green.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2024)/5182_Fire Red, Beast Green.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "JerryWester",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2024-08-26T14:59:59Z",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2024)/5182_Fire Red, Beast Green.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2024)/5182_Fire Red, Beast Green.json
@@ -2,7 +2,7 @@
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "JerryWester",
   "IsSeasonalQuest": true,
-  "SeasonalQuestExpiry": "2024-08-26T14:59:59Z",
+  "SeasonalQuestExpiry": "2024-08-26",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2024)/5182_Fire Red, Beast Green.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2024)/5182_Fire Red, Beast Green.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "JerryWester",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2024-08-26",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2024)/5183_Festival Fan Frenzy.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2024)/5183_Festival Fan Frenzy.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "JerryWester",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2024-08-26T14:59:59Z",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2024)/5183_Festival Fan Frenzy.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2024)/5183_Festival Fan Frenzy.json
@@ -2,7 +2,7 @@
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "JerryWester",
   "IsSeasonalQuest": true,
-  "SeasonalQuestExpiry": "2024-08-26T14:59:59Z",
+  "SeasonalQuestExpiry": "2024-08-26",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2024)/5183_Festival Fan Frenzy.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2024)/5183_Festival Fan Frenzy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "JerryWester",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2024-08-26",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2025)/5321_Dressed to Protect.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2025)/5321_Dressed to Protect.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "liza",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2025-08-26",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2025)/5321_Dressed to Protect.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2025)/5321_Dressed to Protect.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2025-08-26T14:59:59Z",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2025)/5321_Dressed to Protect.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Moonfire Faire (2025)/5321_Dressed to Protect.json
@@ -2,7 +2,7 @@
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
   "IsSeasonalQuest": true,
-  "SeasonalQuestExpiry": "2025-08-26T14:59:59Z",
+  "SeasonalQuestExpiry": "2025-08-26",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2024)/5015_Rising to the Call.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2024)/5015_Rising to the Call.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "liza",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2024-09-11T14:59:59Z",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2024)/5015_Rising to the Call.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2024)/5015_Rising to the Call.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2024-09-11T14:59:59Z",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2024)/5016_We Who Are About to Set Sail Salute You.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2024)/5016_We Who Are About to Set Sail Salute You.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "liza",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2024-09-11",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2024)/5016_We Who Are About to Set Sail Salute You.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2024)/5016_We Who Are About to Set Sail Salute You.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
-  "IsSeasonalEvent": true,
+  "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2024-09-11T14:59:59Z",
   "QuestSequence": [
     {

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2024)/5016_We Who Are About to Set Sail Salute You.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2024)/5016_We Who Are About to Set Sail Salute You.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
+  "IsSeasonalEvent": true,
+  "SeasonalQuestExpiry": "2024-09-11T14:59:59Z",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2024)/5016_We Who Are About to Set Sail Salute You.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2024)/5016_We Who Are About to Set Sail Salute You.json
@@ -2,7 +2,7 @@
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
   "IsSeasonalQuest": true,
-  "SeasonalQuestExpiry": "2024-09-11T14:59:59Z",
+  "SeasonalQuestExpiry": "2024-09-11",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2025)/5297_An Adventurous Ambition.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2025)/5297_An Adventurous Ambition.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "WigglyMuffin",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2025-09-11",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2025)/5297_An Adventurous Ambition.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2025)/5297_An Adventurous Ambition.json
@@ -2,7 +2,7 @@
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "WigglyMuffin",
   "IsSeasonalQuest": true,
-  "SeasonalQuestExpiry": "2025-09-11T14:59:59Z",
+  "SeasonalQuestExpiry": "2025-09-11",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2025)/5297_An Adventurous Ambition.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2025)/5297_An Adventurous Ambition.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "WigglyMuffin",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2025-09-11T14:59:59Z",
   "QuestSequence": [
     {
       "Sequence": 0,
@@ -50,9 +52,9 @@
       "Steps": [
         {
           "Position": {
-              "X": 25.724976,
-              "Y": 44.5,
-              "Z": 186.5
+            "X": 25.724976,
+            "Y": 44.5,
+            "Z": 186.5
           },
           "TerritoryId": 128,
           "InteractionType": "WalkTo"
@@ -76,9 +78,9 @@
         {
           "DataId": 1053663,
           "Position": {
-              "X": -34.01245,
-              "Y": 71.548134,
-              "Z": 135.63745
+            "X": -34.01245,
+            "Y": 71.548134,
+            "Z": 135.63745
           },
           "TerritoryId": 135,
           "InteractionType": "CompleteQuest",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2025)/5298_A Light That Ever Burns.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2025)/5298_A Light That Ever Burns.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "WigglyMuffin",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2025-09-11T23:59:59Z",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2025)/5298_A Light That Ever Burns.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Rising (2025)/5298_A Light That Ever Burns.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "WigglyMuffin",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2025-09-11T23:59:59Z",
   "QuestSequence": [
     {
       "Sequence": 0,
@@ -8,9 +10,9 @@
         {
           "DataId": 1053663,
           "Position": {
-              "X": -34.01245,
-              "Y": 71.548134,
-              "Z": 135.63745
+            "X": -34.01245,
+            "Y": 71.548134,
+            "Z": 135.63745
           },
           "TerritoryId": 135,
           "InteractionType": "AcceptQuest",
@@ -36,9 +38,9 @@
         {
           "DataId": 1053666,
           "Position": {
-              "X": 184.40515,
-              "Y": 32.156242,
-              "Z": 112.962524
+            "X": 184.40515,
+            "Y": 32.156242,
+            "Z": 112.962524
           },
           "TerritoryId": 135,
           "InteractionType": "Interact",
@@ -52,9 +54,9 @@
         {
           "DataId": 1053667,
           "Position": {
-              "X": 76.24927,
-              "Y": 71.28403,
-              "Z": 366.3844
+            "X": 76.24927,
+            "Y": 71.28403,
+            "Z": 366.3844
           },
           "TerritoryId": 135,
           "InteractionType": "Interact",
@@ -75,9 +77,9 @@
         {
           "DataId": 1053669,
           "Position": {
-              "X": -43.47296,
-              "Y": 55.10932,
-              "Z": 488.1819
+            "X": -43.47296,
+            "Y": 55.10932,
+            "Z": 488.1819
           },
           "TerritoryId": 135,
           "InteractionType": "Interact",
@@ -91,9 +93,9 @@
         {
           "DataId": 1053671,
           "Position": {
-              "X": 6.6071167,
-              "Y": 44.311028,
-              "Z": 797.3906
+            "X": 6.6071167,
+            "Y": 44.311028,
+            "Z": 797.3906
           },
           "TerritoryId": 135,
           "InteractionType": "Interact",
@@ -106,9 +108,9 @@
       "Steps": [
         {
           "Position": {
-              "X": 134.80649,
-              "Y": 58.968193,
-              "Z": 935.78265
+            "X": 134.80649,
+            "Y": 58.968193,
+            "Z": 935.78265
           },
           "TerritoryId": 135,
           "InteractionType": "WalkTo",
@@ -117,9 +119,9 @@
         {
           "DataId": 1002445,
           "Position": {
-              "X": 136.82764,
-              "Y": 58.937588,
-              "Z": 937.43787
+            "X": 136.82764,
+            "Y": 58.937588,
+            "Z": 937.43787
           },
           "TerritoryId": 135,
           "InteractionType": "Interact",
@@ -133,9 +135,9 @@
         {
           "DataId": 1053676,
           "Position": {
-              "X": 24.39917,
-              "Y": 44.499973,
-              "Z": 163.07312
+            "X": 24.39917,
+            "Y": 44.499973,
+            "Z": 163.07312
           },
           "TerritoryId": 128,
           "InteractionType": "Interact",
@@ -149,9 +151,9 @@
         {
           "DataId": 1053677,
           "Position": {
-              "X": -178.4848,
-              "Y": 40.99994,
-              "Z": 185.44287
+            "X": -178.4848,
+            "Y": 40.99994,
+            "Z": 185.44287
           },
           "TerritoryId": 128,
           "InteractionType": "CompleteQuest"

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Starlight Celebration (2024)/5227_Reach for the Stalls.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Starlight Celebration (2024)/5227_Reach for the Stalls.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "Starr",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2024-12-31",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Starlight Celebration (2024)/5227_Reach for the Stalls.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Starlight Celebration (2024)/5227_Reach for the Stalls.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "Starr",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2024-12-31",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Starlight Celebration (2024)/5228_Spreading the Warmth and Cheer.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Starlight Celebration (2024)/5228_Spreading the Warmth and Cheer.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "Starr",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2024-12-31",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Starlight Celebration (2024)/5228_Spreading the Warmth and Cheer.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Starlight Celebration (2024)/5228_Spreading the Warmth and Cheer.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "Starr",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2024-12-31",

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Valentione's Day (2025)/5251_I Promise You a Rose Garden.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Valentione's Day (2025)/5251_I Promise You a Rose Garden.json
@@ -2,7 +2,7 @@
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "Starr",
   "IsSeasonalQuest": true,
-  "SeasonalQuestExpiry": "2025-02-17T14:59:59Z",
+  "SeasonalQuestExpiry": "2025-02-17",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Valentione's Day (2025)/5251_I Promise You a Rose Garden.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Valentione's Day (2025)/5251_I Promise You a Rose Garden.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "Starr",
+  "IsSeasonalQuest": true,
+  "SeasonalQuestExpiry": "2025-02-17T14:59:59Z",
   "QuestSequence": [
     {
       "Sequence": 0,

--- a/QuestPaths/7.x - Dawntrail/Seasonal Events/Valentione's Day (2025)/5251_I Promise You a Rose Garden.json
+++ b/QuestPaths/7.x - Dawntrail/Seasonal Events/Valentione's Day (2025)/5251_I Promise You a Rose Garden.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$schema": "https://qstxiv.github.io/schema/quest-v2.json",
   "Author": "Starr",
   "IsSeasonalQuest": true,
   "SeasonalQuestExpiry": "2025-02-17",

--- a/QuestPaths/quest-v1.json
+++ b/QuestPaths/quest-v1.json
@@ -26,6 +26,15 @@
       "type": "boolean",
       "description": "If set to false, no priority quest (e.g. class quests) will be done while this is the currently active quest"
     },
+    "IsSeasonalQuest": {
+      "type": "boolean",
+      "description": "Set to true if this is an event quest (e.g. seasonal event)"
+    },
+    "SeasonalQuestExpiry": {
+      "description": "If this is an seasonal (event) quest, the date and time (in UTC) when this quest should no longer be available",
+      "format": "date-time",
+      "type": [ "string", "null" ]
+    },
     "Comment": {
       "type": "string"
     },
@@ -521,6 +530,33 @@
         "InteractionType"
       ],
       "allOf": [
+        {
+          "if": {
+            "properties": {
+              "IsSeasonalQuest": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "SeasonalQuestExpiry": {
+                "type": {
+                  "description": "If this is an seasonal (event) quest, the date and time (in UTC) when this quest should no longer be available",
+                  "format": "date-time",
+                  "type": [ "string", "null" ]
+                }
+              }
+            }
+          },
+          "else": {
+            "not": {
+              "required": [
+                "SeasonalQuestExpiry"
+              ]
+            }
+          }
+        },
         {
           "if": {
             "properties": {

--- a/QuestPaths/quest-v1.json
+++ b/QuestPaths/quest-v1.json
@@ -541,11 +541,9 @@
           "then": {
             "properties": {
               "SeasonalQuestExpiry": {
-                "type": {
-                  "description": "If this is an seasonal (event) quest, the date and time (in UTC) when this quest should no longer be available",
-                  "format": "date-time",
-                  "type": [ "string", "null" ]
-                }
+                "description": "If this is an seasonal (event) quest, the date and time (in UTC) when this quest should no longer be available",
+                "format": "date-time",
+                "type": [ "string", "null" ]
               }
             }
           },

--- a/QuestPaths/quest-v2.json
+++ b/QuestPaths/quest-v2.json
@@ -26,6 +26,15 @@
       "type": "boolean",
       "description": "If set to false, no priority quest (e.g. class quests) will be done while this is the currently active quest"
     },
+    "IsSeasonalQuest": {
+      "type": "boolean",
+      "description": "Set to true if this is an event quest (e.g. seasonal event)"
+    },
+    "SeasonalQuestExpiry": {
+      "description": "If this is an seasonal (event) quest, the date and time (in UTC) when this quest should no longer be available",
+      "format": "date-time",
+      "type": [ "string", "null" ]
+    },
     "Comment": {
       "type": "string"
     },
@@ -521,6 +530,31 @@
         "InteractionType"
       ],
       "allOf": [
+        {
+          "if": {
+            "properties": {
+              "IsSeasonalQuest": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "SeasonalQuestExpiry": {
+                "description": "If this is an seasonal (event) quest, the date and time (in UTC) when this quest should no longer be available",
+                "format": "date-time",
+                "type": [ "string", "null" ]
+              }
+            }
+          },
+          "else": {
+            "not": {
+              "required": [
+                "SeasonalQuestExpiry"
+              ]
+            }
+          }
+        },
         {
           "if": {
             "properties": {

--- a/Questionable/Configuration.cs
+++ b/Questionable/Configuration.cs
@@ -43,7 +43,7 @@ internal sealed class Configuration : IPluginConfiguration
         public bool ConfigureTextAdvance { get; set; } = true;
         public bool AutoStepRefreshEnabled { get; set; } = true;
         public int AutoStepRefreshDelaySeconds { get; set; } = 10;
-        public bool HideSeasonalEventsFromJournalProgress { get; set; } = false;
+        public bool HideSeasonalEventsFromJournalProgress { get; set; }
     }
 
     internal sealed class StopConfiguration

--- a/Questionable/Configuration.cs
+++ b/Questionable/Configuration.cs
@@ -43,6 +43,7 @@ internal sealed class Configuration : IPluginConfiguration
         public bool ConfigureTextAdvance { get; set; } = true;
         public bool AutoStepRefreshEnabled { get; set; } = true;
         public int AutoStepRefreshDelaySeconds { get; set; } = 10;
+        public bool HideSeasonalEventsFromJournalProgress { get; set; } = false;
     }
 
     internal sealed class StopConfiguration

--- a/Questionable/Controller/QuestRegistry.cs
+++ b/Questionable/Controller/QuestRegistry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -279,5 +279,9 @@ internal sealed class QuestRegistry
 
         dutyOptions = null;
         return false;
+    }
+    public IEnumerable<ElementId> GetAllQuestIds()
+    {
+        return _quests.Keys;
     }
 }

--- a/Questionable/Data/QuestData.cs
+++ b/Questionable/Data/QuestData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -66,44 +66,6 @@ internal sealed class QuestData
 
     public static ImmutableHashSet<QuestId> AetherCurrentQuests { get; } =
         AetherCurrentQuestsByTerritory.Values.SelectMany(x => x).ToImmutableHashSet();
-
-    public static readonly ImmutableDictionary<uint, ImmutableList<QuestId>> UnobtainableEventQuestsByEvent =
-        new Dictionary<uint, List<ushort>>
-        {
-            // Heavensturn
-            { 1, [ 1292, 1293, 1294, 1295, 1296, 252, 289, 290, 309, 287, 2217, 1549, 2425, 3014, 3176, 3738, 3751, 4023, 4024, 4588, 4589, 4679, 4680, 5186 ] },
-            // Valentione's Day
-            { 2, [ 1297, 1298, 1299, 1300, 1301, 512, 515, 523, 527, 547, 2218, 2219, 2220, 2419, 2420, 3082, 3083, 3205, 3206, 3752, 3753, 3754, 3755, 3756, 3757,
-                3758, 4465, 4466, 4467, 4654, 4808, 4809, 5251 ]
-            },
-            // Valentione's & Little Ladies' Day
-            { 3, [ 3996, 3997 ] },
-            // Little Ladies' Day
-            { 4, [ 1302, 1303, 1304, 1305, 1306, 1307, 499, 500, 501, 2221, 2222, 2223, 2399, 2400, 2401, 2406, 2407, 2408, 3084, 3085, 3208, 3209, 3850, 3851, 4471,
-                4472, 4720, 5237, 5238 ] },
-            // Little Ladies' & Hatching-tide
-            { 5, [ 4810, 4811 ] },
-            // Hatching-tide
-            { 6, [ 1414, 1415, 1416, 1417, 1418, 1419, 1420, 556, 557, 559, 2128, 2129, 2130, 2131, 2132, 2421, 2422, 2423, 3079, 3080, 3202, 3203, 3204, 3846, 3847,
-                4089, 4090, 4590, 4721, 4722, 5242, 5243 ] },
-            // Gold Saucer
-            { 7, [ 2133, 2135, 2424, 3133, 3134, 3207, 3963, 3964, 4054, 4055, 4056, 4584, 4727, 4728, 4814, 5322 ] },
-            // Moonfire Faire
-            { 8, [ 1534, 1535, 1536, 1537, 1538, 1539, 1540, 1541, 1542, 1543, 2124, 2125, 2126, 2127, 2136, 2137, 2138, 2139, 2140, 2956, 2957, 2958, 2959, 2960,
-                3135, 3136, 3137, 3663, 3664, 3665, 3666, 3667, 3966, 3967, 4082, 4083, 4540, 4541, 4723, 4724, 5182, 5183, 5321 ] },
-            // Rising
-            { 9, [ 1546, 2134, 2329, 2330, 2331, 2961, 3138, 3660, 3661, 3973, 3974, 4091, 4544, 4765, 4766, 5015, 5016, 5297, 5298 ] },
-            // All Saints' Wake
-            { 10, [ 1163, 1164, 1165, 1166, 1167, 1168, 1169, 1170, 1171, 1172, 1173, 1174, 236, 237, 238, 2149, 2150, 2151, 1548, 3011, 3012, 3013, 3169, 3170, 3171,
-                3172, 3668, 3669, 3670, 3995, 4520, 4655, 4656, 4657, 4785, 4786, 5184, 5185, 5375, 5376 ] },
-            // Starlight Celebration
-            { 11, [ 250, 251, 325, 338, 340, 247, 248, 249, 354, 2224, 2375, 2376, 2377, 2378, 3009, 3010, 3173, 3174, 3175, 3722, 3723, 3724, 4017, 4018, 4019, 4020,
-                4021, 4022, 4468, 4469, 4470, 4658, 4659, 4781, 4782, 4783, 5227, 5228, 5231 ] }
-        }
-        .ToImmutableDictionary(
-            x => x.Key,
-            x => x.Value.Select(y => new QuestId(y)).ToImmutableList()
-        );
 
     private static readonly IReadOnlyList<uint> TankRoleQuestChapters = [136, 154, 178];
     private static readonly IReadOnlyList<uint> HealerRoleQuestChapters = [137, 155, 179];
@@ -522,6 +484,4 @@ internal sealed class QuestData
         ];
         return startingClassQuests.SelectMany(x => x).Select(x => new QuestId(x)).ToList();
     }
-
-    public List<QuestId> GetUnobtainableEventQuests() => [.. UnobtainableEventQuestsByEvent.SelectMany(x => x.Value)];
 }

--- a/Questionable/Data/QuestData.cs
+++ b/Questionable/Data/QuestData.cs
@@ -67,6 +67,44 @@ internal sealed class QuestData
     public static ImmutableHashSet<QuestId> AetherCurrentQuests { get; } =
         AetherCurrentQuestsByTerritory.Values.SelectMany(x => x).ToImmutableHashSet();
 
+    public static readonly ImmutableDictionary<uint, ImmutableList<QuestId>> UnobtainableEventQuestsByEvent =
+        new Dictionary<uint, List<ushort>>
+        {
+            // Heavensturn
+            { 1, [ 1292, 1293, 1294, 1295, 1296, 252, 289, 290, 309, 287, 2217, 1549, 2425, 3014, 3176, 3738, 3751, 4023, 4024, 4588, 4589, 4679, 4680, 5186 ] },
+            // Valentione's Day
+            { 2, [ 1297, 1298, 1299, 1300, 1301, 512, 515, 523, 527, 547, 2218, 2219, 2220, 2419, 2420, 3082, 3083, 3205, 3206, 3752, 3753, 3754, 3755, 3756, 3757,
+                3758, 4465, 4466, 4467, 4654, 4808, 4809, 5251 ]
+            },
+            // Valentione's & Little Ladies' Day
+            { 3, [ 3996, 3997 ] },
+            // Little Ladies' Day
+            { 4, [ 1302, 1303, 1304, 1305, 1306, 1307, 499, 500, 501, 2221, 2222, 2223, 2399, 2400, 2401, 2406, 2407, 2408, 3084, 3085, 3208, 3209, 3850, 3851, 4471,
+                4472, 4720, 5237, 5238 ] },
+            // Little Ladies' & Hatching-tide
+            { 5, [ 4810, 4811 ] },
+            // Hatching-tide
+            { 6, [ 1414, 1415, 1416, 1417, 1418, 1419, 1420, 556, 557, 559, 2128, 2129, 2130, 2131, 2132, 2421, 2422, 2423, 3079, 3080, 3202, 3203, 3204, 3846, 3847,
+                4089, 4090, 4590, 4721, 4722, 5242, 5243 ] },
+            // Gold Saucer
+            { 7, [ 2133, 2135, 2424, 3133, 3134, 3207, 3963, 3964, 4054, 4055, 4056, 4584, 4727, 4728, 4814, 5322 ] },
+            // Moonfire Faire
+            { 8, [ 1534, 1535, 1536, 1537, 1538, 1539, 1540, 1541, 1542, 1543, 2124, 2125, 2126, 2127, 2136, 2137, 2138, 2139, 2140, 2956, 2957, 2958, 2959, 2960,
+                3135, 3136, 3137, 3663, 3664, 3665, 3666, 3667, 3966, 3967, 4082, 4083, 4540, 4541, 4723, 4724, 5182, 5183, 5321 ] },
+            // Rising
+            { 9, [ 1546, 2134, 2329, 2330, 2331, 2961, 3138, 3660, 3661, 3973, 3974, 4091, 4544, 4765, 4766, 5015, 5016, 5297, 5298 ] },
+            // All Saints' Wake
+            { 10, [ 1163, 1164, 1165, 1166, 1167, 1168, 1169, 1170, 1171, 1172, 1173, 1174, 236, 237, 238, 2149, 2150, 2151, 1548, 3011, 3012, 3013, 3169, 3170, 3171,
+                3172, 3668, 3669, 3670, 3995, 4520, 4655, 4656, 4657, 4785, 4786, 5184, 5185, 5375, 5376 ] },
+            // Starlight Celebration
+            { 11, [ 250, 251, 325, 338, 340, 247, 248, 249, 354, 2224, 2375, 2376, 2377, 2378, 3009, 3010, 3173, 3174, 3175, 3722, 3723, 3724, 4017, 4018, 4019, 4020,
+                4021, 4022, 4468, 4469, 4470, 4658, 4659, 4781, 4782, 4783, 5227, 5228, 5231 ] }
+        }
+        .ToImmutableDictionary(
+            x => x.Key,
+            x => x.Value.Select(y => new QuestId(y)).ToImmutableList()
+        );
+
     private static readonly IReadOnlyList<uint> TankRoleQuestChapters = [136, 154, 178];
     private static readonly IReadOnlyList<uint> HealerRoleQuestChapters = [137, 155, 179];
     private static readonly IReadOnlyList<uint> MeleeRoleQuestChapters = [138, 156, 180];
@@ -333,7 +371,6 @@ internal sealed class QuestData
     public List<IQuestInfo> GetAllByJournalGenre(uint journalGenre)
     {
         return _quests.Values
-            .Where(x => x is QuestInfo { IsSeasonalEvent: false } or not QuestInfo)
             .Where(x => x.JournalGenre == journalGenre)
             .OrderBy(x => x.SortKey)
             .ThenBy(x => x.QuestId)
@@ -485,4 +522,6 @@ internal sealed class QuestData
         ];
         return startingClassQuests.SelectMany(x => x).Select(x => new QuestId(x)).ToList();
     }
+
+    public List<QuestId> GetUnobtainableEventQuests() => [.. UnobtainableEventQuestsByEvent.SelectMany(x => x.Value)];
 }

--- a/Questionable/Data/QuestData.cs
+++ b/Questionable/Data/QuestData.cs
@@ -10,6 +10,7 @@ using Lumina.Excel.Sheets;
 using Questionable.Model;
 using Questionable.Model.Questing;
 using Quest = Lumina.Excel.Sheets.Quest;
+using Questionable.Windows.QuestComponents;
 
 namespace Questionable.Data;
 
@@ -490,7 +491,22 @@ internal sealed class QuestData
         if (_quests.TryGetValue(questId, out var info) && info is QuestInfo qi)
         {
             qi.IsSeasonalQuest = isSeasonal;
-            qi.SeasonalQuestExpiry = expiry;
+            if (expiry.HasValue)
+            {
+                DateTime raw = expiry.Value;
+                DateTime normalized;
+                // date-only (time 00:00:00) -> end of day at 14:59:59 UTC
+                if (raw.TimeOfDay == TimeSpan.Zero)
+                    normalized = EventInfoComponent.AtDailyReset(DateOnly.FromDateTime(raw));
+                else
+                    normalized = raw.Kind == DateTimeKind.Utc ? raw : raw.ToUniversalTime();
+
+                qi.SeasonalQuestExpiry = normalized;
+            }
+            else
+            {
+                qi.SeasonalQuestExpiry = null;
+            }
         }
     }
 }

--- a/Questionable/Data/QuestData.cs
+++ b/Questionable/Data/QuestData.cs
@@ -484,4 +484,13 @@ internal sealed class QuestData
         ];
         return startingClassQuests.SelectMany(x => x).Select(x => new QuestId(x)).ToList();
     }
+
+    public void ApplySeasonalOverride(ElementId questId, bool isSeasonal, DateTime? expiry)
+    {
+        if (_quests.TryGetValue(questId, out var info) && info is QuestInfo qi)
+        {
+            qi.IsSeasonalQuest = isSeasonal;
+            qi.SeasonalQuestExpiry = expiry;
+        }
+    }
 }

--- a/Questionable/Data/QuestData.cs
+++ b/Questionable/Data/QuestData.cs
@@ -143,8 +143,8 @@ internal sealed class QuestData
                     }
                 }));
 
-        quests.Add(new UnlockLinkQuestInfo(new UnlockLinkId(506), "Patch 7.2 Fantasia", 1052475));
-        quests.Add(new UnlockLinkQuestInfo(new UnlockLinkId(568), "Patch 7.3 Fantasia", 1052475));
+        quests.Add(new UnlockLinkQuestInfo(new UnlockLinkId(506), "Patch 7.2 Fantasia", 1052475, new DateTime(2025, 8, 5, 14, 59, 59, DateTimeKind.Utc)));
+        quests.Add(new UnlockLinkQuestInfo(new UnlockLinkId(568), "Patch 7.3 Fantasia", 1052475, new DateTime(2025, 12, 23, 14, 59, 59, DateTimeKind.Utc)));
 
         _quests = quests.ToDictionary(x => x.QuestId, x => x);
 

--- a/Questionable/Data/QuestData.cs
+++ b/Questionable/Data/QuestData.cs
@@ -143,8 +143,8 @@ internal sealed class QuestData
                     }
                 }));
 
-        quests.Add(new UnlockLinkQuestInfo(new UnlockLinkId(506), "Patch 7.2 Fantasia", 1052475, new DateTime(2025, 8, 5, 14, 59, 59, DateTimeKind.Utc)));
-        quests.Add(new UnlockLinkQuestInfo(new UnlockLinkId(568), "Patch 7.3 Fantasia", 1052475, new DateTime(2025, 12, 23, 14, 59, 59, DateTimeKind.Utc)));
+        quests.Add(new UnlockLinkQuestInfo(new UnlockLinkId(506), "Fantasia", 1052475, new DateTime(2025, 8, 5, 14, 59, 59, DateTimeKind.Utc), "Patch 7.2"));
+        quests.Add(new UnlockLinkQuestInfo(new UnlockLinkId(568), "Fantasia", 1052475, new DateTime(2025, 12, 23, 14, 59, 59, DateTimeKind.Utc), "Patch 7.3"));
 
         _quests = quests.ToDictionary(x => x.QuestId, x => x);
 

--- a/Questionable/Functions/QuestFunctions.cs
+++ b/Questionable/Functions/QuestFunctions.cs
@@ -721,6 +721,9 @@ internal sealed unsafe class QuestFunctions
                 return true;
         }
 
+        if (_questData.GetUnobtainableEventQuests().Contains(questId))
+            return true;
+
         if (_questData.GetLockedClassQuests().Contains(questId))
             return true;
 

--- a/Questionable/Functions/QuestFunctions.cs
+++ b/Questionable/Functions/QuestFunctions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -722,6 +722,9 @@ internal sealed unsafe class QuestFunctions
         }
 
         if (_questData.GetUnobtainableEventQuests().Contains(questId))
+            return true;
+
+        if (questInfo.IsSeasonalEvent && questInfo.SeasonalQuestExpiry is { } expiry && DateTime.UtcNow > expiry)
             return true;
 
         if (_questData.GetLockedClassQuests().Contains(questId))

--- a/Questionable/Functions/QuestFunctions.cs
+++ b/Questionable/Functions/QuestFunctions.cs
@@ -23,6 +23,7 @@ using Questionable.Model.Common;
 using Questionable.Model.Questing;
 using GrandCompany = FFXIVClientStructs.FFXIV.Client.UI.Agent.GrandCompany;
 using Quest = Questionable.Model.Quest;
+using Questionable.Windows.QuestComponents;
 
 namespace Questionable.Functions;
 
@@ -751,7 +752,12 @@ internal sealed unsafe class QuestFunctions
         // treat expiry alone as authoritative
         if (questInfo.SeasonalQuestExpiry is DateTime expiryValue)
         {
-            DateTime expiryUtc = expiryValue.Kind == DateTimeKind.Utc ? expiryValue : expiryValue.ToUniversalTime();
+            DateTime expiryUtc;
+            if (expiryValue.TimeOfDay == TimeSpan.Zero)
+                expiryUtc = EventInfoComponent.AtDailyReset(DateOnly.FromDateTime(expiryValue));
+            else
+                expiryUtc = expiryValue.Kind == DateTimeKind.Utc ? expiryValue : expiryValue.ToUniversalTime();
+
             if (DateTime.UtcNow > expiryUtc)
             {
                 if (_alreadyLoggedUnobtainableQuests.Add(questId.Value))

--- a/Questionable/Model/IQuestInfo.cs
+++ b/Questionable/Model/IQuestInfo.cs
@@ -13,6 +13,8 @@ internal interface IQuestInfo
     public string Name { get; }
     public uint IssuerDataId { get; }
     public bool IsRepeatable { get; }
+    public bool IsSeasonalQuest => false;
+    public DateTime? SeasonalQuestExpiry => null;
     public ImmutableList<PreviousQuestInfo> PreviousQuests { get; }
     public EQuestJoin PreviousQuestJoin { get; }
     public ushort Level { get; }

--- a/Questionable/Model/QuestInfo.cs
+++ b/Questionable/Model/QuestInfo.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Humanizer;
 using LLib.GameData;
 using Lumina.Excel.Sheets;
 using Questionable.Model.Questing;
@@ -13,7 +14,8 @@ namespace Questionable.Model;
 
 internal sealed class QuestInfo : IQuestInfo
 {
-    public QuestInfo(ExcelQuest quest, uint newGamePlusChapter, byte startingCity, JournalGenreOverrides journalGenreOverrides)
+    public QuestInfo(ExcelQuest quest, uint newGamePlusChapter, byte startingCity, JournalGenreOverrides journalGenreOverrides,
+        bool isSeasonalEventQuest = false, DateTime? seasonalQuestExpiry = null)
     {
         QuestId = QQuestId.FromRowId(quest.RowId);
 
@@ -75,6 +77,8 @@ internal sealed class QuestInfo : IQuestInfo
         AlliedSocietyRank = (int)quest.BeastReputationRank.RowId;
         ClassJobs = QuestInfoUtils.AsList(quest.ClassJobCategory0.ValueNullable!);
         IsSeasonalEvent = quest.Festival.RowId != 0;
+        IsSeasonalQuest = isSeasonalEventQuest;
+        SeasonalQuestExpiry = IsSeasonalQuest ? seasonalQuestExpiry : null;
         NewGamePlusChapter = newGamePlusChapter;
         StartingCity = startingCity;
         MoogleDeliveryLevel = (byte)quest.DeliveryQuest.RowId;
@@ -126,6 +130,8 @@ internal sealed class QuestInfo : IQuestInfo
     public bool IsMoogleDeliveryQuest => JournalGenre == 87;
     public IReadOnlyList<ItemReward> ItemRewards { get; }
     public EExpansionVersion Expansion { get; }
+    public DateTime? SeasonalQuestExpiry { get; }
+    public bool IsSeasonalQuest { get; }
 
     public void AddPreviousQuest(PreviousQuestInfo questId)
     {

--- a/Questionable/Model/QuestInfo.cs
+++ b/Questionable/Model/QuestInfo.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Humanizer;
 using LLib.GameData;
 using Lumina.Excel.Sheets;
 using Questionable.Model.Questing;
@@ -79,6 +78,7 @@ internal sealed class QuestInfo : IQuestInfo
         IsSeasonalEvent = quest.Festival.RowId != 0;
         IsSeasonalQuest = isSeasonalEventQuest;
         SeasonalQuestExpiry = IsSeasonalQuest ? seasonalQuestExpiry : null;
+        SeasonalQuestExpiry = seasonalQuestExpiry;
         NewGamePlusChapter = newGamePlusChapter;
         StartingCity = startingCity;
         MoogleDeliveryLevel = (byte)quest.DeliveryQuest.RowId;
@@ -130,8 +130,8 @@ internal sealed class QuestInfo : IQuestInfo
     public bool IsMoogleDeliveryQuest => JournalGenre == 87;
     public IReadOnlyList<ItemReward> ItemRewards { get; }
     public EExpansionVersion Expansion { get; }
-    public DateTime? SeasonalQuestExpiry { get; }
-    public bool IsSeasonalQuest { get; }
+    public DateTime? SeasonalQuestExpiry { get; internal set; }
+    public bool IsSeasonalQuest { get; internal set; }
 
     public void AddPreviousQuest(PreviousQuestInfo questId)
     {

--- a/Questionable/Model/UnlockLinkQuestInfo.cs
+++ b/Questionable/Model/UnlockLinkQuestInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using LLib.GameData;
@@ -7,17 +8,20 @@ namespace Questionable.Model;
 
 internal sealed class UnlockLinkQuestInfo : IQuestInfo
 {
-    public UnlockLinkQuestInfo(UnlockLinkId unlockLinkId, string name, uint issuerDataId)
+
+    public UnlockLinkQuestInfo(UnlockLinkId unlockLinkId, string name, uint issuerDataId, DateTime? expiryTime)
     {
         QuestId = unlockLinkId;
         Name = name;
         IssuerDataId = issuerDataId;
+        QuestExpiry = expiryTime;
     }
 
     public ElementId QuestId { get; }
     public string Name { get; }
     public uint IssuerDataId { get; }
     public bool IsRepeatable => false;
+    public DateTime? QuestExpiry { get; }
     public ImmutableList<PreviousQuestInfo> PreviousQuests => [];
     public EQuestJoin PreviousQuestJoin => EQuestJoin.All;
     public ushort Level => 1;

--- a/Questionable/Model/UnlockLinkQuestInfo.cs
+++ b/Questionable/Model/UnlockLinkQuestInfo.cs
@@ -9,12 +9,13 @@ namespace Questionable.Model;
 internal sealed class UnlockLinkQuestInfo : IQuestInfo
 {
 
-    public UnlockLinkQuestInfo(UnlockLinkId unlockLinkId, string name, uint issuerDataId, DateTime? expiryTime)
+    public UnlockLinkQuestInfo(UnlockLinkId unlockLinkId, string name, uint issuerDataId, DateTime? expiryTime, string? patch = null)
     {
         QuestId = unlockLinkId;
         Name = name;
         IssuerDataId = issuerDataId;
         QuestExpiry = expiryTime;
+        Patch = patch;
     }
 
     public ElementId QuestId { get; }
@@ -22,6 +23,7 @@ internal sealed class UnlockLinkQuestInfo : IQuestInfo
     public uint IssuerDataId { get; }
     public bool IsRepeatable => false;
     public DateTime? QuestExpiry { get; }
+    public string? Patch { get; }
     public ImmutableList<PreviousQuestInfo> PreviousQuests => [];
     public EQuestJoin PreviousQuestJoin => EQuestJoin.All;
     public ushort Level => 1;

--- a/Questionable/Windows/ConfigComponents/GeneralConfigComponent.cs
+++ b/Questionable/Windows/ConfigComponents/GeneralConfigComponent.cs
@@ -142,6 +142,13 @@ internal sealed class GeneralConfigComponent : ConfigComponent
                 Configuration.General.ShowIncompleteSeasonalEvents = showIncompleteSeasonalEvents;
                 Save();
             }
+
+            bool hideSeasonalFromJournal = Configuration.General.HideSeasonalEventsFromJournalProgress;
+            if (ImGui.Checkbox("Hide Seasonal Events from Journal Progress", ref hideSeasonalFromJournal))
+            {
+                Configuration.General.HideSeasonalEventsFromJournalProgress = hideSeasonalFromJournal;
+                Save();
+            }
         }
 
         ImGui.Separator();

--- a/Questionable/Windows/JournalComponents/QuestJournalComponent.cs
+++ b/Questionable/Windows/JournalComponents/QuestJournalComponent.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Interface;
+using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Plugin;
@@ -212,9 +212,6 @@ internal sealed class QuestJournalComponent
             _uiUtils.ChecklistItem(string.Empty, false);
 
         ImGui.TableNextColumn();
-
-        var (color, icon, text) = _uiUtils.GetQuestStyle(questInfo.QuestId);
-        _uiUtils.ChecklistItem(text, color, icon);
 
         bool isExpired = false;
         if (questInfo.SeasonalQuestExpiry is { } expiry)

--- a/Questionable/Windows/JournalComponents/QuestJournalComponent.cs
+++ b/Questionable/Windows/JournalComponents/QuestJournalComponent.cs
@@ -212,20 +212,25 @@ internal sealed class QuestJournalComponent
             _uiUtils.ChecklistItem(string.Empty, false);
 
         ImGui.TableNextColumn();
+
         var (color, icon, text) = _uiUtils.GetQuestStyle(questInfo.QuestId);
         _uiUtils.ChecklistItem(text, color, icon);
 
-        if (questInfo.IsSeasonalQuest && questInfo.SeasonalQuestExpiry is { } expiry)
+        bool isExpired = false;
+        if (questInfo.SeasonalQuestExpiry is { } expiry)
         {
-            if (DateTime.UtcNow < expiry)
-            {
-                var time = (expiry - DateTime.UtcNow).Humanize(precision: 1, culture: CultureInfo.InvariantCulture);
-                ImGui.TextColored(ImGuiColors.DalamudOrange, $"Seasonal Event ({time} left)");
-            }
-            else
-            {
-                ImGui.TextColored(ImGuiColors.DalamudRed, "Event expired");
-            }
+            DateTime expiryUtc = expiry.Kind == DateTimeKind.Utc ? expiry : expiry.ToUniversalTime();
+            if (DateTime.UtcNow > expiryUtc)
+                isExpired = true;
+        }
+
+        if (isExpired)
+        {
+            _uiUtils.ChecklistItem("Unavailable", ImGuiColors.DalamudGrey, FontAwesomeIcon.Minus);
+        }
+        else
+        {
+            _uiUtils.ChecklistItem("Available", ImGuiColors.DalamudYellow, FontAwesomeIcon.Running);
         }
     }
 

--- a/Questionable/Windows/JournalComponents/QuestJournalComponent.cs
+++ b/Questionable/Windows/JournalComponents/QuestJournalComponent.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Dalamud.Bindings.ImGui;
+using Humanizer;
 
 namespace Questionable.Windows.JournalComponents;
 
@@ -61,7 +62,7 @@ internal sealed class QuestJournalComponent
             ImGui.BulletText("'Supported' lists quests that Questionable can do for you");
             ImGui.BulletText("'Completed' lists quests your current character has completed.");
             ImGui.BulletText(
-                "Not all quests can be completed even if they're listed as available, e.g. starting city quest chains.");
+                "Not all quests can be completed even if they're listed as available, e.g. starting city quest chains or past seasonal events.");
 
             ImGui.Spacing();
             ImGui.Separator();
@@ -213,6 +214,19 @@ internal sealed class QuestJournalComponent
         ImGui.TableNextColumn();
         var (color, icon, text) = _uiUtils.GetQuestStyle(questInfo.QuestId);
         _uiUtils.ChecklistItem(text, color, icon);
+
+        if (questInfo.IsSeasonalQuest && questInfo.SeasonalQuestExpiry is { } expiry)
+        {
+            if (DateTime.UtcNow < expiry)
+            {
+                var time = (expiry - DateTime.UtcNow).Humanize(precision: 1, culture: CultureInfo.InvariantCulture);
+                ImGui.TextColored(ImGuiColors.DalamudOrange, $"Seasonal Event ({time} left)");
+            }
+            else
+            {
+                ImGui.TextColored(ImGuiColors.DalamudRed, "Event expired");
+            }
+        }
     }
 
     private static void DrawCount(int count, int total)

--- a/Questionable/Windows/JournalComponents/QuestJournalComponent.cs
+++ b/Questionable/Windows/JournalComponents/QuestJournalComponent.cs
@@ -13,15 +13,15 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Dalamud.Bindings.ImGui;
-using Humanizer;
+using Microsoft.Extensions.Logging;
 
 namespace Questionable.Windows.JournalComponents;
 
 internal sealed class QuestJournalComponent
 {
-    private readonly Dictionary<JournalData.Genre, JournalCounts> _genreCounts = [];
-    private readonly Dictionary<JournalData.Category, JournalCounts> _categoryCounts = [];
-    private readonly Dictionary<JournalData.Section, JournalCounts> _sectionCounts = [];
+    private readonly Dictionary<JournalData.Genre, JournalCounts> _genreCounts = new();
+    private readonly Dictionary<JournalData.Category, JournalCounts> _categoryCounts = new();
+    private readonly Dictionary<JournalData.Section, JournalCounts> _sectionCounts = new();
 
     private readonly JournalData _journalData;
     private readonly QuestRegistry _questRegistry;
@@ -31,12 +31,16 @@ internal sealed class QuestJournalComponent
     private readonly IDalamudPluginInterface _pluginInterface;
     private readonly QuestJournalUtils _questJournalUtils;
     private readonly QuestValidator _questValidator;
+    private readonly Configuration _configuration;
+    private readonly ILogger<QuestJournalComponent> _logger;
 
-    private List<FilteredSection> _filteredSections = [];
+    private List<FilteredSection> _filteredSections = new();
+    private bool _lastHideSeasonalGlobally;
 
     public QuestJournalComponent(JournalData journalData, QuestRegistry questRegistry, QuestFunctions questFunctions,
         UiUtils uiUtils, QuestTooltipComponent questTooltipComponent, IDalamudPluginInterface pluginInterface,
-        QuestJournalUtils questJournalUtils, QuestValidator questValidator)
+        QuestJournalUtils questJournalUtils, QuestValidator questValidator, Configuration configuration,
+        ILogger<QuestJournalComponent> logger)
     {
         _journalData = journalData;
         _questRegistry = questRegistry;
@@ -46,6 +50,9 @@ internal sealed class QuestJournalComponent
         _pluginInterface = pluginInterface;
         _questJournalUtils = questJournalUtils;
         _questValidator = questValidator;
+        _configuration = configuration;
+        _logger = logger;
+        _lastHideSeasonalGlobally = _configuration.General.HideSeasonalEventsFromJournalProgress;
     }
 
     internal FilterConfiguration Filter { get; } = new();
@@ -55,6 +62,14 @@ internal sealed class QuestJournalComponent
         using var tab = ImRaii.TabItem("Quests");
         if (!tab)
             return;
+
+        var currentHide = _configuration.General.HideSeasonalEventsFromJournalProgress;
+        if (currentHide != _lastHideSeasonalGlobally)
+        {
+            _lastHideSeasonalGlobally = currentHide;
+            _logger.LogDebug("Configuration change detected: HideSeasonalEventsFromJournalProgress={Hide} - refreshing journal", currentHide);
+            UpdateFilter();
+        }
 
         if (ImGui.CollapsingHeader("Explanation", ImGuiTreeNodeFlags.DefaultOpen))
         {
@@ -223,7 +238,7 @@ internal sealed class QuestJournalComponent
 
         if (isExpired)
         {
-            _uiUtils.ChecklistItem("Unavailable", ImGuiColors.DalamudGrey, FontAwesomeIcon.Minus);
+            _uiUtils.ChecklistItem("Unobtainable", ImGuiColors.DalamudGrey, FontAwesomeIcon.Minus);
         }
         else
         {
@@ -267,37 +282,39 @@ internal sealed class QuestJournalComponent
         if (IsCategorySectionGenreMatch(filter, section.Name))
         {
             filteredCategories = section.Categories
-                .Select(x => FilterCategory(x, filter.WithoutName()));
+                .Select(x => FilterCategory(x, filter.WithoutName(), section));
         }
         else
         {
             filteredCategories = section.Categories
-                .Select(category => FilterCategory(category, filter));
+                .Select(category => FilterCategory(category, filter, section));
         }
 
         return new FilteredSection(section, filteredCategories.Where(x => x.Genres.Count > 0).ToList());
     }
 
-    private FilteredCategory FilterCategory(JournalData.Category category, FilterConfiguration filter)
+    private FilteredCategory FilterCategory(JournalData.Category category, FilterConfiguration filter, JournalData.Section? parentSection = null)
     {
         IEnumerable<FilteredGenre> filteredGenres;
         if (IsCategorySectionGenreMatch(filter, category.Name))
         {
             filteredGenres = category.Genres
-                .Select(x => FilterGenre(x, filter.WithoutName()));
+                .Select(x => FilterGenre(x, filter.WithoutName(), parentSection));
         }
         else
         {
             filteredGenres = category.Genres
-                .Select(genre => FilterGenre(genre, filter));
+                .Select(genre => FilterGenre(genre, filter, parentSection));
         }
 
         return new FilteredCategory(category, filteredGenres.Where(x => x.Quests.Count > 0).ToList());
     }
 
-    private FilteredGenre FilterGenre(JournalData.Genre genre, FilterConfiguration filter)
+    private FilteredGenre FilterGenre(JournalData.Genre genre, FilterConfiguration filter, JournalData.Section? parentSection = null)
     {
         IEnumerable<IQuestInfo> filteredQuests;
+        bool hideSeasonalGlobally = _configuration.General.HideSeasonalEventsFromJournalProgress;
+
         if (IsCategorySectionGenreMatch(filter, genre.Name))
         {
             filteredQuests = genre.Quests
@@ -309,6 +326,9 @@ internal sealed class QuestJournalComponent
                 .Where(x => IsQuestMatch(filter, x));
         }
 
+        if (hideSeasonalGlobally)
+            filteredQuests = filteredQuests.Where(q => !IsSeasonal(q));
+
         return new FilteredGenre(genre, filteredQuests.ToList());
     }
 
@@ -318,24 +338,28 @@ internal sealed class QuestJournalComponent
         _categoryCounts.Clear();
         _sectionCounts.Clear();
 
+        bool hideSeasonalGlobally = _configuration.General.HideSeasonalEventsFromJournalProgress;
+        _logger.LogInformation("Refreshing journal counts. HideSeasonalEventsFromJournalProgress={Hide}", hideSeasonalGlobally);
+
         foreach (var genre in _journalData.Genres)
         {
-            int available = genre.Quests.Count(x =>
+            var relevantQuests = hideSeasonalGlobally
+                ? genre.Quests.Where(q => !IsSeasonal(q)).ToList()
+                : genre.Quests.ToList();
+
+            int available = relevantQuests.Count(x =>
                 _questRegistry.TryGetQuest(x.QuestId, out var quest) &&
                 !quest.Root.Disabled &&
                 !_questFunctions.IsQuestRemoved(x.QuestId));
-            int total = genre.Quests.Count(x => !_questFunctions.IsQuestRemoved(x.QuestId));
-            int obtainable = genre.Quests.Count(x => !_questFunctions.IsQuestUnobtainable(x.QuestId));
-            int completed = genre.Quests.Count(x => _questFunctions.IsQuestComplete(x.QuestId));
+            int total = relevantQuests.Count(x => !_questFunctions.IsQuestRemoved(x.QuestId));
+            int obtainable = relevantQuests.Count(x => !_questFunctions.IsQuestUnobtainable(x.QuestId));
+            int completed = relevantQuests.Count(x => _questFunctions.IsQuestComplete(x.QuestId));
             _genreCounts[genre] = new(available, total, obtainable, completed);
         }
 
         foreach (var category in _journalData.Categories)
         {
-            var counts = _genreCounts
-                .Where(x => category.Genres.Contains(x.Key))
-                .Select(x => x.Value)
-                .ToList();
+            var counts = _genre_counts_or_default(category);
             int available = counts.Sum(x => x.Available);
             int total = counts.Sum(x => x.Total);
             int obtainable = counts.Sum(x => x.Obtainable);
@@ -355,6 +379,19 @@ internal sealed class QuestJournalComponent
             int completed = counts.Sum(x => x.Completed);
             _sectionCounts[section] = new(available, total, obtainable, completed);
         }
+
+        var grandTotal = _sectionCounts.Values.Sum(x => x.Total);
+        _logger.LogDebug("RefreshCounts complete. Sections={Sections}, Categories={Categories}, Genres={Genres}, TotalQuests={Total}",
+            _sectionCounts.Count, _categoryCounts.Count, _genreCounts.Count, grandTotal);
+    }
+
+    // Helper added inline to keep style consistent and avoid repeating LINQ in RefreshCounts
+    private List<JournalCounts> _genre_counts_or_default(JournalData.Category category)
+    {
+        return _genreCounts
+            .Where(x => category.Genres.Contains(x.Key))
+            .Select(x => x.Value)
+            .ToList();
     }
 
     internal void ClearCounts(int type, int code)
@@ -381,6 +418,9 @@ internal sealed class QuestJournalComponent
             !(questInfo.Name.Contains(filter.SearchText, StringComparison.CurrentCultureIgnoreCase) || questInfo.QuestId.ToString() == filter.SearchText))
             return false;
 
+        // Note: seasonal hiding is only performed for the "Other Quests" section previously.
+        // We now perform global hiding only when the configuration requests it, so do not filter here.
+
         if (filter.AvailableOnly && !_questFunctions.IsReadyToAcceptQuest(questInfo.QuestId))
             return false;
 
@@ -389,6 +429,15 @@ internal sealed class QuestJournalComponent
             return false;
 
         return true;
+    }
+
+    private static bool IsSeasonal(IQuestInfo q)
+    {
+        if (q == null) return false;
+        if (q.IsSeasonalQuest) return true;
+        if (q.SeasonalQuestExpiry is not null) return true;
+        if (q is UnlockLinkQuestInfo uli && uli.QuestExpiry is not null) return true;
+        return false;
     }
 
     private sealed record FilteredSection(JournalData.Section Section, List<FilteredCategory> Categories);

--- a/Questionable/Windows/QuestComponents/EventInfoComponent.cs
+++ b/Questionable/Windows/QuestComponents/EventInfoComponent.cs
@@ -2,9 +2,6 @@ using Dalamud.Bindings.ImGui;
 using Dalamud.Interface;
 using Dalamud.Interface.Components;
 using Dalamud.Interface.Utility.Raii;
-using Dalamud.Logging;
-using Humanizer;
-using Humanizer.Localisation;
 using Microsoft.Extensions.Logging;
 using Questionable.Controller;
 using Questionable.Data;
@@ -14,7 +11,6 @@ using Questionable.Model.Questing;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Linq;
 
 namespace Questionable.Windows.QuestComponents;
@@ -119,11 +115,11 @@ internal sealed class EventInfoComponent
 
         if (eventQuest.EndsAtUtc != DateTime.MaxValue)
         {
-            string time = (eventQuest.EndsAtUtc - DateTime.UtcNow).Humanize(
-                precision: 1,
-                culture: CultureInfo.InvariantCulture,
-                minUnit: TimeUnit.Minute,
-                maxUnit: TimeUnit.Day);
+            var remaining = eventQuest.EndsAtUtc - DateTime.UtcNow;
+            if (remaining < TimeSpan.Zero)
+                remaining = TimeSpan.Zero;
+
+            string time = FormatRemainingTime(remaining);
             ImGui.Text($"{displayName} ({time})");
         }
         else

--- a/Questionable/Windows/QuestComponents/EventInfoComponent.cs
+++ b/Questionable/Windows/QuestComponents/EventInfoComponent.cs
@@ -44,12 +44,6 @@ internal sealed class EventInfoComponent
         _configuration = configuration;
     }
 
-    [SuppressMessage("ReSharper", "UnusedMember.Local")]
-    private static DateTime AtDailyReset(DateOnly date)
-    {
-        return new DateTime(date, new TimeOnly(14, 59), DateTimeKind.Utc);
-    }
-
     public bool ShouldDraw => _configuration.General.ShowIncompleteSeasonalEvents && GetActiveSeasonalQuests().Any();
 
     public void Draw()
@@ -123,19 +117,11 @@ internal sealed class EventInfoComponent
         }
     }
 
-    private bool IsIncomplete(EventQuest eventQuest)
-    {
-        if (eventQuest.EndsAtUtc <= DateTime.UtcNow)
-            return false;
-
-        return eventQuest.QuestIds.Any(ShouldShowQuest);
-    }
-
     public IEnumerable<ElementId> GetCurrentlyActiveEventQuests()
     {
-        return _eventQuests
-            .Where(x => x.EndsAtUtc >= DateTime.UtcNow)
-            .SelectMany(x => x.QuestIds)
+        return GetActiveSeasonalQuests()
+            .Where(q => q.SeasonalQuestExpiry is { } expiry && expiry >= DateTime.UtcNow)
+            .Select(q => q.QuestId)
             .Where(ShouldShowQuest);
     }
 

--- a/Questionable/Windows/QuestComponents/EventInfoComponent.cs
+++ b/Questionable/Windows/QuestComponents/EventInfoComponent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -19,13 +19,6 @@ namespace Questionable.Windows.QuestComponents;
 
 internal sealed class EventInfoComponent
 {
-    [SuppressMessage("ReSharper", "CollectionNeverUpdated.Local")]
-    private readonly List<EventQuest> _eventQuests =
-    [
-        new EventQuest("Limited Time Items", [new UnlockLinkId(568)], DateTime.MaxValue),
-        new EventQuest("The Rising 2025", [new QuestId(5297), new QuestId(5298)], AtDailyReset(new DateOnly(2025, 9, 11))) // 11 September 2025 at 14:59 (GMT)
-    ];
-
     private readonly QuestData _questData;
     private readonly QuestRegistry _questRegistry;
     private readonly QuestFunctions _questFunctions;


### PR DESCRIPTION
@Cryotechnic, please comment below if you're okay with your code being PR'd here

original description:

When an event happens in the game, it must be added manually to the panel. This feature moves that functionality to the JSON schema, with 2 new properties: `IsSeasonalQuest` and `SeasonalQuestExpiry`. `SeasonalQuestExpiry` depends on `IsSeasonalQuest` being `true`, else you will get a "JSON Validation failed" error. All events will be displayed in the main Questionable window, in the same way as they were previously. Once the event has concluded, it will be automatically hidden from view and can be found in the Journal Progress window.

Furthermore, an option was added to the "General" section: "Hide Seasonal Events from Journal Progress". This lets the user hide quests designated as events from the Journal Progress window. The only limitation of this feature is that it doesn't hide event quests that haven't been generated. An option would be to simply generate the files and add the necessary event metadata, but that would bloat the file size for little return. I'm open to any other ideas, including hiding the category altogether, but I haven't managed to implement that functionality, hence I settled for the next best option which is the feature in its current iteration.
