### PR TITLE
[hotfix] Added condition to CheckAutoRefreshCondition for IsNavmeshReady and the various WaitAtEnd tasks

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup Condition="$(MSBuildProjectName) != 'GatheringPathRenderer'">
-        <Version>6.5.0.2</Version>
+        <Version>6.5.0.4</Version>
     </PropertyGroup>
 </Project>

--- a/Questionable/Controller/QuestController.cs
+++ b/Questionable/Controller/QuestController.cs
@@ -313,6 +313,8 @@ internal sealed class QuestController : MiniTaskController<QuestController>
             _gameFunctions.IsOccupied() ||
             _movementController.IsPathfinding ||
             _movementController.IsPathRunning ||
+            !_movementController.IsNavmeshReady ||
+            (_taskQueue.CurrentTaskExecutor?.CurrentTask.GetType().Namespace == typeof(WaitAtEnd).Namespace) ||
             DateTime.Now < _safeAnimationEnd)
         {
             _lastProgressUpdate = DateTime.Now;


### PR DESCRIPTION
should fix issues with several quests where the autorefresh condition didn't account for deliberate Wait interactionsteps or navmesh loading on territory transitions