### PR TITLE
Release v6.6.0.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         id: is-testing
         run: |
           BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          if [ "$BRANCH" = "main" ]; then
+          if [ "$BRANCH" = "new-main" ]; then
             echo "testing=false" >> $GITHUB_OUTPUT
           else
             echo "testing=true" >> $GITHUB_OUTPUT

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup Condition="$(MSBuildProjectName) != 'GatheringPathRenderer'">
-        <Version>6.6.0.9</Version>
+        <Version>6.6.0.10</Version>
     </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup Condition="$(MSBuildProjectName) != 'GatheringPathRenderer'">
-        <Version>6.5.0.8</Version>
+        <Version>6.6.0.9</Version>
     </PropertyGroup>
 </Project>

--- a/QuestPaths/2.x - A Realm Reborn/Allied Societies/Amalj'aa/Dailies/1222_A Shell to Scry On.json
+++ b/QuestPaths/2.x - A Realm Reborn/Allied Societies/Amalj'aa/Dailies/1222_A Shell to Scry On.json
@@ -13,7 +13,22 @@
             "Z": -357.3816
           },
           "TerritoryId": 146,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Southern Thanalan - Little Ala Mhigo",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 98.924194,
+                  "Y": 15.29447,
+                  "Z": -349.4469
+                },
+                "TerritoryId": 146,
+                "MaximumDistance": 500
+              }
+            }
+          }
         }
       ]
     },
@@ -68,7 +83,21 @@
           },
           "TerritoryId": 146,
           "InteractionType": "CompleteQuest",
-          "Fly": true
+          "AetheryteShortcut": "Southern Thanalan - Little Ala Mhigo",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 98.924194,
+                  "Y": 15.29447,
+                  "Z": -349.4469
+                },
+                "TerritoryId": 146,
+                "MaximumDistance": 500
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/2.x - A Realm Reborn/Allied Societies/Amalj'aa/Dailies/1223_Borderline Slaughter.json
+++ b/QuestPaths/2.x - A Realm Reborn/Allied Societies/Amalj'aa/Dailies/1223_Borderline Slaughter.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "$": "Checked by alydev 20250916",
   "Author": "plogon_enjoyer",
   "QuestSequence": [
     {

--- a/QuestPaths/2.x - A Realm Reborn/Allied Societies/Amalj'aa/Dailies/1223_Borderline Slaughter.json
+++ b/QuestPaths/2.x - A Realm Reborn/Allied Societies/Amalj'aa/Dailies/1223_Borderline Slaughter.json
@@ -14,7 +14,22 @@
             "Z": -357.3816
           },
           "TerritoryId": 146,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Southern Thanalan - Little Ala Mhigo",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 98.924194,
+                  "Y": 15.29447,
+                  "Z": -349.4469
+                },
+                "TerritoryId": 146,
+                "MaximumDistance": 500
+              }
+            }
+          }
         }
       ]
     },
@@ -56,7 +71,21 @@
           },
           "TerritoryId": 146,
           "InteractionType": "CompleteQuest",
-          "Fly": true
+          "AetheryteShortcut": "Southern Thanalan - Little Ala Mhigo",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 98.924194,
+                  "Y": 15.29447,
+                  "Z": -349.4469
+                },
+                "TerritoryId": 146,
+                "MaximumDistance": 500
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/2.x - A Realm Reborn/Allied Societies/Amalj'aa/Dailies/1233_Thinning the Ranks.json
+++ b/QuestPaths/2.x - A Realm Reborn/Allied Societies/Amalj'aa/Dailies/1233_Thinning the Ranks.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Comment": "Unsupported: complex combat complications. Skip/Step if stuck",
+  "$": "Checked by alydev 20250916",
+  "Author": "alydev",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1005551,
+          "Position": {
+            "X": 98.924194,
+            "Y": 15.29447,
+            "Z": -349.4469
+          },
+          "TerritoryId": 146,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Southern Thanalan - Little Ala Mhigo",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 98.924194,
+                  "Y": 15.29447,
+                  "Z": -349.4469
+                },
+                "TerritoryId": 146,
+                "MaximumDistance": 500
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -91.21763,
+            "Y": 45.81123,
+            "Z": 176.64693
+          },
+          "TerritoryId": 146,
+          "InteractionType": "Combat",
+          "ComplexCombatData": [
+            {
+              "DataId": 739,
+              "NameId": 2297,
+              "MinimumKillCount": 2
+            },
+            {
+              "DataId": 741,
+              "NameId": 249,
+              "MinimumKillCount": 2
+            }
+          ],
+          "EnemySpawnType": "OverworldEnemies",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1005551,
+          "Position": {
+            "X": 98.924194,
+            "Y": 15.29447,
+            "Z": -349.4469
+          },
+          "TerritoryId": 146,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Southern Thanalan - Little Ala Mhigo",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 98.924194,
+                  "Y": 15.29447,
+                  "Z": -349.4469
+                },
+                "TerritoryId": 146,
+                "MaximumDistance": 500
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Allied Societies/Amalj'aa/Dailies/1243_Unholier than Thou.json
+++ b/QuestPaths/2.x - A Realm Reborn/Allied Societies/Amalj'aa/Dailies/1243_Unholier than Thou.json
@@ -1,83 +1,235 @@
 {
-    "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
-    "Author": "skiaz",
-    "QuestSequence": [
-      {
-        "Sequence": 0,
-        "Steps": [
-          {
-            "DataId": 1005552,
-            "Position": {
-                "X": 85.618286,
-                "Y": 15.28719,
-                "Z": -355.70312
-            },
-            "TerritoryId": 146,
-            "InteractionType": "AcceptQuest",
-            "Fly": true
-          }
-        ]
-      },
-      {
-        "Sequence": 1,
-        "Comment": "Probably better to make here single steps for each enemy, since they are spread across a larger area",
-        "Steps": [
-          {
-            "Position": {
-                "X": 103.1051,
-                "Y": 15.034634,
-                "Z": 20.46234
-            },
-            "TerritoryId": 146,
-            "InteractionType": "Combat",
-            "ComplexCombatData": [
-              {
-                "DataId": 742,
-                "NameId": 1840,
-                "MinimumKillCount": 3
-              }
-            ],
-            "EnemySpawnType": "OverworldEnemies",
-            "Fly": true
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Comment": "Unsupported: complex combat complications. Skip/Step if stuck",
+  "Author": "alydev",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1005552,
+          "Position": {
+            "X": 85.618286,
+            "Y": 15.28719,
+            "Z": -355.70312
           },
-          {
-            "DataId": 740,
-            "Position": {
-                "X": 103.1051,
-                "Y": 15.034634,
-                "Z": 20.46234
-            },
-            "TerritoryId": 146,
-            "InteractionType": "Combat",
-            "ComplexCombatData": [
-              {
-                "DataId": 740,
-                "NameId": 1839,
-                "MinimumKillCount": 3
+          "TerritoryId": 146,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Southern Thanalan - Little Ala Mhigo",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 85.618286,
+                  "Y": 15.28719,
+                  "Z": -355.70312
+                },
+                "TerritoryId": 146,
+                "MaximumDistance": 300
               }
-            ],
-            "EnemySpawnType": "OverworldEnemies",
-            "Fly": true
+            }
           }
-        ]
-      },
-      {
-        "Sequence": 255,
-        "Steps": [
-          {
-            "DataId": 1005552,
-            "Position": {
-                "X": 85.618286,
-                "Y": 15.28719,
-                "Z": -355.70312
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 116.05795,
+            "Y": 15.937954,
+            "Z": 10.586162
+          },
+          "TerritoryId": 146,
+          "InteractionType": "Combat",
+          "CompletionQuestVariablesFlags": [
+            null,
+            {
+              "High": 1,
+              "Low": 1
             },
-            "TerritoryId": 146,
-            "InteractionType": "CompleteQuest",
-            "AetheryteShortcut": "Southern Thanalan - Little Ala Mhigo",
-            "Fly": true
+            null,
+            null,
+            null,
+            null
+          ],
+          "ComplexCombatData": [
+            {
+              "DataId": 740,
+              "NameId": 1839,
+              "MinimumKillCount": 1,
+              "CompletionQuestVariablesFlags": [
+                null,
+                {
+                  "Low": 1
+                },
+                null,
+                null,
+                null,
+                null
+              ]
+            },
+            {
+              "DataId": 742,
+              "NameId": 1840,
+              "MinimumKillCount": 1,
+              "CompletionQuestVariablesFlags": [
+                null,
+                {
+                  "High": 1
+                },
+                null,
+                null,
+                null,
+                null
+              ]
+            }
+          ],
+          "EnemySpawnType": "OverworldEnemies",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 240.30867,
+            "Y": 8.018455,
+            "Z": -21.842773
+          },
+          "TerritoryId": 146,
+          "InteractionType": "Combat",
+          "CompletionQuestVariablesFlags": [
+            null,
+            {
+              "Low": 2
+            },
+            null,
+            null,
+            null,
+            null
+          ],
+          "ComplexCombatData": [
+            {
+              "DataId": 740,
+              "NameId": 1839,
+              "MinimumKillCount": 1,
+              "CompletionQuestVariablesFlags": [
+                null,
+                {
+                  "Low": 2
+                },
+                null,
+                null,
+                null,
+                null
+              ]
+            }
+          ],
+          "EnemySpawnType": "OverworldEnemies",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 349.61588,
+            "Y": 9.234073,
+            "Z": -39.244358
+          },
+          "TerritoryId": 146,
+          "InteractionType": "Combat",
+          "CompletionQuestVariablesFlags": [
+            {
+              "High": 1
+            },
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
+          "ComplexCombatData": [
+            {
+              "DataId": 740,
+              "NameId": 1839,
+              "MinimumKillCount": 1,
+              "CompletionQuestVariablesFlags": [
+                null,
+                {
+                  "Low": 3
+                },
+                null,
+                null,
+                null,
+                null
+              ]
+            },
+            {
+              "DataId": 742,
+              "NameId": 1840,
+              "MinimumKillCount": 1,
+              "CompletionQuestVariablesFlags": [
+                null,
+                {
+                  "High": 2
+                },
+                null,
+                null,
+                null,
+                null
+              ]
+            }
+          ],
+          "EnemySpawnType": "OverworldEnemies",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 407.0323,
+            "Y": 12.405342,
+            "Z": -132.22331
+          },
+          "TerritoryId": 146,
+          "InteractionType": "Combat",
+          "ComplexCombatData": [
+            {
+              "DataId": 742,
+              "NameId": 1840,
+              "MinimumKillCount": 1
+            }
+          ],
+          "EnemySpawnType": "OverworldEnemies",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1005552,
+          "Position": {
+            "X": 85.618286,
+            "Y": 15.28719,
+            "Z": -355.70312
+          },
+          "TerritoryId": 146,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Southern Thanalan - Little Ala Mhigo",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 85.618286,
+                  "Y": 15.28719,
+                  "Z": -355.70312
+                },
+                "TerritoryId": 146,
+                "MaximumDistance": 300
+              }
+            }
           }
-        ]
-      }
-    ]
-  }
-  
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Allied Societies/Sylphs/Dailies/1257_Deck the Hut.json
+++ b/QuestPaths/2.x - A Realm Reborn/Allied Societies/Sylphs/Dailies/1257_Deck the Hut.json
@@ -121,6 +121,25 @@
           "ItemId": 2001117
         },
         {
+          "Position": {
+            "X": -233.39812,
+            "Y": 3.5426886,
+            "Z": 285.5684
+          },
+          "TerritoryId": 152,
+          "InteractionType": "WalkTo"
+        },
+        {
+          "Position": {
+            "X": -228.49472,
+            "Y": 3.5543644,
+            "Z": 284.51855
+          },
+          "TerritoryId": 152,
+          "InteractionType": "WalkTo",
+          "DisableNavmesh": true
+        },
+        {
           "DataId": 2003156,
           "Position": {
             "X": -227.19159,
@@ -129,6 +148,7 @@
           },
           "TerritoryId": 152,
           "InteractionType": "UseItem",
+          "DisableNavmesh": true,
           "ItemId": 2001117
         }
       ]
@@ -137,6 +157,26 @@
       "Sequence": 2,
       "Steps": [
         {
+          "Position": {
+            "X": -228.49472,
+            "Y": 3.5543644,
+            "Z": 284.51855
+          },
+          "TerritoryId": 152,
+          "InteractionType": "WalkTo",
+          "DisableNavmesh": true
+        },
+        {
+          "Position": {
+            "X": -233.39812,
+            "Y": 3.5426886,
+            "Z": 285.5684
+          },
+          "TerritoryId": 152,
+          "InteractionType": "WalkTo",
+          "DisableNavmesh": true
+        },
+        {
           "DataId": 1000540,
           "Position": {
             "X": -238.17816,
@@ -144,7 +184,8 @@
             "Z": 283.71094
           },
           "TerritoryId": 152,
-          "InteractionType": "Interact"
+          "InteractionType": "Interact",
+          "DisableNavmesh": true
         }
       ]
     },

--- a/QuestPaths/2.x - A Realm Reborn/MSQ-1/Gridania/3855_A Soldier's Breakfast.json
+++ b/QuestPaths/2.x - A Realm Reborn/MSQ-1/Gridania/3855_A Soldier's Breakfast.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
-  "Author": "liza",
+  "Author": "liza,alydev",
   "QuestSequence": [
     {
       "Sequence": 0,
@@ -19,55 +19,8 @@
     },
     {
       "Sequence": 1,
+      "Comment": "Avoid AOEs/turn on VBM if you have it",
       "Steps": [
-        {
-          "Position": {
-            "X": 459.86548,
-            "Y": 17.983778,
-            "Z": -76.51779
-          },
-          "StopDistance": 1,
-          "TerritoryId": 148,
-          "InteractionType": "Combat",
-          "EnemySpawnType": "FinishCombatIfAny",
-          "KillEnemyDataIds": []
-        },
-        {
-          "Position": {
-            "X": 486.40424,
-            "Y": 24.968294,
-            "Z": -88.684456
-          },
-          "StopDistance": 1,
-          "TerritoryId": 148,
-          "InteractionType": "Combat",
-          "EnemySpawnType": "FinishCombatIfAny",
-          "KillEnemyDataIds": []
-        },
-        {
-          "Position": {
-            "X": 485.05884,
-            "Y": 30.642492,
-            "Z": -59.45244
-          },
-          "StopDistance": 1,
-          "TerritoryId": 148,
-          "InteractionType": "Combat",
-          "EnemySpawnType": "FinishCombatIfAny",
-          "KillEnemyDataIds": []
-        },
-        {
-          "Position": {
-            "X": 480.88794,
-            "Y": 30.746826,
-            "Z": -49.729187
-          },
-          "StopDistance": 1,
-          "TerritoryId": 148,
-          "InteractionType": "Combat",
-          "EnemySpawnType": "FinishCombatIfAny",
-          "KillEnemyDataIds": []
-        },
         {
           "DataId": 2000010,
           "Position": {
@@ -88,9 +41,9 @@
         },
         {
           "Position": {
-            "X": 480.88794,
-            "Y": 30.746826,
-            "Z": -49.729187
+            "X": 434.71976,
+            "Y": 8.614418,
+            "Z": -87.96375
           },
           "TerritoryId": 148,
           "InteractionType": "Combat",

--- a/QuestPaths/2.x - A Realm Reborn/MSQ-1/Gridania/387_Salvaging the Scene.json
+++ b/QuestPaths/2.x - A Realm Reborn/MSQ-1/Gridania/387_Salvaging the Scene.json
@@ -30,8 +30,12 @@
           "TerritoryId": 148,
           "InteractionType": "Combat",
           "EnemySpawnType": "AutoOnEnterArea",
-          "KillEnemyDataIds": [
-            26
+          "ComplexCombatData": [
+            {
+              "DataId": 26,
+              "NameId": 592,
+              "IgnoreQuestMarker": true
+            }
           ]
         },
         {

--- a/QuestPaths/4.x - Stormblood/MSQ/B-4.1/2962_Arenvald's Adventure.json
+++ b/QuestPaths/4.x - Stormblood/MSQ/B-4.1/2962_Arenvald's Adventure.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
-  "Author": "JerryWester",
+  "Author": "JerryWester,alydev",
   "QuestSequence": [
     {
       "Sequence": 0,
@@ -15,6 +15,10 @@
           "TerritoryId": 635,
           "InteractionType": "AcceptQuest",
           "AetheryteShortcut": "Rhalgr's Reach",
+          "AethernetShortcut": [
+            "[Rhalgr's Reach] Aetheryte Plaza",
+            "[Rhalgr's Reach] Northeastern Rhalgr's Reach"
+          ],
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "InSameTerritory": true

--- a/QuestPaths/4.x - Stormblood/MSQ/B-4.1/2969_A Sultana's Resolve.json
+++ b/QuestPaths/4.x - Stormblood/MSQ/B-4.1/2969_A Sultana's Resolve.json
@@ -15,6 +15,10 @@
           "TerritoryId": 144,
           "InteractionType": "AcceptQuest",
           "AetheryteShortcut": "Gold Saucer",
+          "AethernetShortcut": [
+            "[Gold Saucer] Aetheryte Plaza",
+            "[Gold Saucer] Wonder Square West"
+          ],
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "InSameTerritory": true

--- a/Questionable/Configuration.cs
+++ b/Questionable/Configuration.cs
@@ -96,6 +96,7 @@ internal sealed class Configuration : IPluginConfiguration
         public bool SkipARealmRebornHardModePrimals { get; set; }
         public bool SkipCrystalTowerRaids { get; set; }
         public bool PreventQuestCompletion { get; set; }
+        public bool ShowWindowOnStart { get; set; }
     }
 
     internal enum ECombatModule

--- a/Questionable/DalamudInitializer.cs
+++ b/Questionable/DalamudInitializer.cs
@@ -74,6 +74,8 @@ internal sealed class DalamudInitializer : IDisposable
         _toastGui.Toast += OnToast;
         _toastGui.ErrorToast += OnErrorToast;
         _toastGui.QuestToast += OnQuestToast;
+        if (_configuration.Advanced.ShowWindowOnStart)
+            ToggleQuestWindow();
     }
 
     private void FrameworkUpdate(IFramework framework)

--- a/Questionable/Questionable.json
+++ b/Questionable/Questionable.json
@@ -1,12 +1,12 @@
 ﻿{
   "Name": "Questionable",
-  "Author": "Liza Carvelli",
+  "Author": "liza, qstxiv, & various contributors",
   "Punchline": "A tiny quest helper plugin.",
   "Description": "A tiny little quest helper plugin, which does quests for you automatically where possible. Uses navmesh to automatically walk to all quest waypoints, and tries to automatically complete all steps along the way (excluding dungeons, single player duties and combat).\n\nNot all quests are supported, check the discord or git repository for an up-to-date list.\n\nRequired Plugins: vnavmesh, TextAdvance, Lifestream",
   "Tags": [
     "quests",
     "msq"
   ],
-  "RepoUrl": "https://github.com/qstxiv/Questionable",
+  "RepoUrl": "https://github.com/PunishXIV/Questionable",
   "IconUrl": "https://qstxiv.github.io/icons/Questionable.png"
 }

--- a/Questionable/Windows/ConfigComponents/DebugConfigComponent.cs
+++ b/Questionable/Windows/ConfigComponents/DebugConfigComponent.cs
@@ -129,6 +129,16 @@ internal sealed class DebugConfigComponent : ConfigComponent
 
             ImGui.SameLine();
             ImGuiComponents.HelpMarker("When enabled, Questionable will not attempt to turn-in and complete quests. This will do everything automatically except the final turn-in step.");
+
+            bool showWindowOnStart = Configuration.Advanced.ShowWindowOnStart;
+            if (ImGui.Checkbox("Show window on start", ref showWindowOnStart))
+            {
+                Configuration.Advanced.ShowWindowOnStart = showWindowOnStart;
+                Save();
+            }
+
+            ImGui.SameLine();
+            ImGuiComponents.HelpMarker("When enabled, Questionable's progress window will show when the plugin is loaded.");
         }
     }
 }

--- a/Questionable/Windows/ConfigComponents/PluginConfigComponent.cs
+++ b/Questionable/Windows/ConfigComponents/PluginConfigComponent.cs
@@ -193,11 +193,11 @@ internal sealed class PluginConfigComponent : ConfigComponent
                 }
 
                 allRequiredInstalled &= DrawCombatPlugin(Configuration.ECombatModule.BossMod, checklistPadding);
+                allRequiredInstalled &= DrawCombatPlugin(Configuration.ECombatModule.WrathCombo, checklistPadding);
             }
-            ImGui.Text("The following rotation/combat plugins are provided for compatibility and testing purposes:");
+            ImGui.Text("The following rotation/combat plugin(s) are provided for compatibility and testing purposes:");
             using (ImRaii.PushIndent())
             {
-                allRequiredInstalled &= DrawCombatPlugin(Configuration.ECombatModule.WrathCombo, checklistPadding);
                 allRequiredInstalled &=
                     DrawCombatPlugin(Configuration.ECombatModule.RotationSolverReborn, checklistPadding);
             }

--- a/Questionable/Windows/ConfigComponents/PluginConfigComponent.cs
+++ b/Questionable/Windows/ConfigComponents/PluginConfigComponent.cs
@@ -179,11 +179,11 @@ internal sealed class PluginConfigComponent : ConfigComponent
         ImGui.Separator();
         ImGui.Spacing();
 
-        ImGui.Text("Questionable supports multiple rotation/combat plugins, please pick the one\nyou want to use:");
+        ImGui.Text("Questionable recommends Boss Mod (VBM) for rotation/combat automation.");
 
-        using (ImRaii.PushIndent())
+        using (ImRaii.Disabled(_combatController.IsRunning))
         {
-            using (ImRaii.Disabled(_combatController.IsRunning))
+            using (ImRaii.PushIndent())
             {
                 if (ImGui.RadioButton("No rotation/combat plugin (combat must be done manually)",
                         _configuration.General.CombatModule == Configuration.ECombatModule.None))
@@ -193,6 +193,10 @@ internal sealed class PluginConfigComponent : ConfigComponent
                 }
 
                 allRequiredInstalled &= DrawCombatPlugin(Configuration.ECombatModule.BossMod, checklistPadding);
+            }
+            ImGui.Text("The following rotation/combat plugins are provided for compatibility and testing purposes:");
+            using (ImRaii.PushIndent())
+            {
                 allRequiredInstalled &= DrawCombatPlugin(Configuration.ECombatModule.WrathCombo, checklistPadding);
                 allRequiredInstalled &=
                     DrawCombatPlugin(Configuration.ECombatModule.RotationSolverReborn, checklistPadding);


### PR DESCRIPTION
### Changelog

- tribes 1222,1223,1257 fixes (a766402a) by alydev
- workflow Correct branch name again (5ad1940c) by alydev
- Rotation plugin list order update: move Wrath above the separator (f865b7d8) by alydev
- Add note recommending VBM over other rotation plogon (98a0cc24) by alydev
- New feature: Show Questionable window on start (9ba583e0) by alydev
- grd 387 additional info on combat (c88c871e) by alydev
- grd 3855 simplify route, avoid KO (ac81b121) by alydev
- Post stb: 2962,2969 add shortcuts (124cab70) by alydev
- Tested amaljaa quests 1223,1233,1243 (4402ebb8) by alydev
- Fix plugin metadata (381b55b4) by alydev