### PR TITLE
Add Il Mheg Side Quests

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup Condition="$(MSBuildProjectName) != 'GatheringPathRenderer'">
-        <Version>6.7.12.0</Version>
+        <Version>6.7.13.0</Version>
     </PropertyGroup>
 </Project>

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3392_What's in a Name.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3392_What's in a Name.json
@@ -1,41 +1,35 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
-  "Author": "Clockwise Starr",
+  "Author": "alydev",
   "QuestSequence": [
     {
       "Sequence": 0,
       "Steps": [
         {
-          "DataId": 1030838,
+          "DataId": 1028051,
           "Position": {
-            "X": -285.90833,
-            "Y": 40.324036,
-            "Z": 444.41882
+            "X": -283.16174,
+            "Y": 68.296906,
+            "Z": 533.8368
           },
           "TerritoryId": 816,
           "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
           "Fly": true,
           "AetheryteShortcut": "Il Mheg - Lydha Lran",
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "NearPosition": {
                 "Position": {
-                  "X": -285.90833,
-                  "Y": 40.324036,
-                  "Z": 444.41882
+                  "X": -283.16174,
+                  "Y": 68.296906,
+                  "Z": 533.8368
                 },
                 "TerritoryId": 816,
                 "MaximumDistance": 200
               }
             }
-          },
-          "DialogueChoices": [
-            {
-              "Type": "List",
-              "Prompt": "TEXT_LUCKZC103_03406_Q1_000_000",
-              "Answer": "TEXT_LUCKZC103_03406_A1_000_000"
-            }
-          ]
+          }
         }
       ]
     },
@@ -43,15 +37,34 @@
       "Sequence": 1,
       "Steps": [
         {
-          "DataId": 2010370,
+          "DataId": 1028053,
           "Position": {
-            "X": -268.17737,
-            "Y": 31.876099,
-            "Z": 344.04517
+            "X": -241.41296,
+            "Y": 49.837833,
+            "Z": 587.4874
           },
           "TerritoryId": 816,
           "InteractionType": "Interact",
-          "Fly": true,
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "High": 4
+            }
+          ]
+        },
+        {
+          "DataId": 1028054,
+          "Position": {
+            "X": -304.82953,
+            "Y": 70.86284,
+            "Z": 574.9751
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
           "CompletionQuestVariablesFlags": [
             null,
             null,
@@ -64,15 +77,14 @@
           ]
         },
         {
-          "DataId": 2010368,
+          "DataId": 1028052,
           "Position": {
-            "X": -356.8628,
-            "Y": 46.64673,
-            "Z": 419.39417
+            "X": -381.09412,
+            "Y": 58.71793,
+            "Z": 554.2534
           },
           "TerritoryId": 816,
           "InteractionType": "Interact",
-          "Fly": true,
           "CompletionQuestVariablesFlags": [
             null,
             null,
@@ -80,35 +92,9 @@
             null,
             null,
             {
-              "High": 8
+              "High": 1
             }
           ]
-        },
-        {
-          "DataId": 2010369,
-          "Position": {
-            "X": -397.87903,
-            "Y": 51.773804,
-            "Z": 383.505
-          },
-          "TerritoryId": 816,
-          "InteractionType": "Interact"
-        }
-      ]
-    },
-    {
-      "Sequence": 2,
-      "Steps": [
-        {
-          "DataId": 1030845,
-          "Position": {
-            "X": -320.14954,
-            "Y": 20.880749,
-            "Z": 298.45117
-          },
-          "TerritoryId": 816,
-          "InteractionType": "Interact",
-          "Fly": true
         }
       ]
     },
@@ -116,30 +102,42 @@
       "Sequence": 255,
       "Steps": [
         {
-          "DataId": 1030838,
+          "DataId": 1028051,
           "Position": {
-            "X": -285.90833,
-            "Y": 40.324036,
-            "Z": 444.41882
+            "X": -283.16174,
+            "Y": 68.296906,
+            "Z": 533.8368
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
           "Fly": true,
           "AetheryteShortcut": "Il Mheg - Lydha Lran",
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "NearPosition": {
                 "Position": {
-                  "X": -285.90833,
-                  "Y": 40.324036,
-                  "Z": 444.41882
+                  "X": -283.16174,
+                  "Y": 68.296906,
+                  "Z": 533.8368
                 },
                 "TerritoryId": 816,
                 "MaximumDistance": 200
               }
             }
           },
-          "NextQuestId": 3407
+          "DialogueChoices": [
+            {
+              "Prompt": "TEXT_LUCKZC009_03392_Q1_000_000",
+              "Answer": "TEXT_LUCKZC009_03392_A1_000_001",
+              "Type": "List"
+            },
+            {
+              "Prompt": "TEXT_LUCKZC009_03392_Q2_000_000",
+              "Answer": "TEXT_LUCKZC009_03392_A2_000_001",
+              "Type": "List"
+            }
+          ]
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3393_A Hairy Request.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3393_A Hairy Request.json
@@ -1,35 +1,42 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
-  "Author": "Clockwise Starr",
+  "Author": "alydev",
   "QuestSequence": [
     {
       "Sequence": 0,
       "Steps": [
         {
-          "DataId": 1031025,
+          "DataId": 1031347,
           "Position": {
-            "X": -79.75891,
-            "Y": 37.968338,
-            "Z": -531.8532
+            "X": -340.81024,
+            "Y": 74.42241,
+            "Z": 557.3052
           },
           "TerritoryId": 816,
           "InteractionType": "AcceptQuest",
           "StopDistance": 0.25,
           "Fly": true,
-          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "NearPosition": {
                 "Position": {
-                  "X": -79.75891,
-                  "Y": 37.968338,
-                  "Z": -531.8532
+                  "X": -340.81024,
+                  "Y": 74.42241,
+                  "Z": 557.3052
                 },
                 "TerritoryId": 816,
                 "MaximumDistance": 200
               }
             }
-          }
+          },
+          "DialogueChoices": [
+            {
+              "Prompt": "TEXT_LUCKZC010_03393_Q1_000_000",
+              "Answer": "TEXT_LUCKZC010_03393_A1_000_001",
+              "Type": "List"
+            }
+          ]
         }
       ]
     },
@@ -37,16 +44,18 @@
       "Sequence": 1,
       "Steps": [
         {
-          "DataId": 1027695,
           "Position": {
-            "X": 441.64185,
-            "Y": 89.80711,
-            "Z": -653.43713
+            "X": -448.4794,
+            "Y": 81.68824,
+            "Z": 674.1933
           },
           "TerritoryId": 816,
-          "AetheryteShortcut": "Il Mheg - Wolekdorf",
-          "InteractionType": "Interact",
-          "Fly": true
+          "InteractionType": "Combat",
+          "Fly": true,
+          "EnemySpawnType": "OverworldEnemies",
+          "KillEnemyDataIds": [
+            10266
+          ]
         }
       ]
     },
@@ -54,11 +63,27 @@
       "Sequence": 2,
       "Steps": [
         {
-          "DataId": 1031026,
+          "DataId": 1031347,
           "Position": {
-            "X": 354.69592,
-            "Y": 87.448784,
-            "Z": -711.7876
+            "X": -340.81024,
+            "Y": 74.42241,
+            "Z": 557.3052
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1027657,
+          "Position": {
+            "X": -246.63159,
+            "Y": 50.84181,
+            "Z": 583.7948
           },
           "TerritoryId": 816,
           "InteractionType": "Interact",
@@ -70,31 +95,30 @@
       "Sequence": 255,
       "Steps": [
         {
-          "DataId": 1031025,
+          "DataId": 1031347,
           "Position": {
-            "X": -79.75891,
-            "Y": 37.968338,
-            "Z": -531.8532
+            "X": -340.81024,
+            "Y": 74.42241,
+            "Z": 557.3052
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
           "StopDistance": 0.25,
           "Fly": true,
-          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "NearPosition": {
                 "Position": {
-                  "X": -79.75891,
-                  "Y": 37.968338,
-                  "Z": -531.8532
+                  "X": -340.81024,
+                  "Y": 74.42241,
+                  "Z": 557.3052
                 },
                 "TerritoryId": 816,
                 "MaximumDistance": 200
               }
             }
-          },
-          "NextQuestId": 3429
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3394_Flowers of Fury.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3394_Flowers of Fury.json
@@ -1,41 +1,35 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
-  "Author": "Clockwise Starr",
+  "Author": "alydev",
   "QuestSequence": [
     {
       "Sequence": 0,
       "Steps": [
         {
-          "DataId": 1030838,
+          "DataId": 1030619,
           "Position": {
-            "X": -285.90833,
-            "Y": 40.324036,
-            "Z": 444.41882
+            "X": -326.77197,
+            "Y": 68.13059,
+            "Z": 582.0248
           },
           "TerritoryId": 816,
           "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
           "Fly": true,
           "AetheryteShortcut": "Il Mheg - Lydha Lran",
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "NearPosition": {
                 "Position": {
-                  "X": -285.90833,
-                  "Y": 40.324036,
-                  "Z": 444.41882
+                  "X": -326.77197,
+                  "Y": 68.13059,
+                  "Z": 582.0248
                 },
                 "TerritoryId": 816,
                 "MaximumDistance": 200
               }
             }
-          },
-          "DialogueChoices": [
-            {
-              "Type": "List",
-              "Prompt": "TEXT_LUCKZC103_03406_Q1_000_000",
-              "Answer": "TEXT_LUCKZC103_03406_A1_000_000"
-            }
-          ]
+          }
         }
       ]
     },
@@ -43,15 +37,19 @@
       "Sequence": 1,
       "Steps": [
         {
-          "DataId": 2010370,
+          "DataId": 1030621,
           "Position": {
-            "X": -268.17737,
-            "Y": 31.876099,
-            "Z": 344.04517
+            "X": -428.67175,
+            "Y": 122.715324,
+            "Z": 728.5725
           },
           "TerritoryId": 816,
-          "InteractionType": "Interact",
           "Fly": true,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterInteraction",
+          "KillEnemyDataIds": [
+            11111
+          ],
           "CompletionQuestVariablesFlags": [
             null,
             null,
@@ -59,40 +57,24 @@
             null,
             null,
             {
-              "High": 2
+              "High": 4
             }
           ]
         },
         {
-          "DataId": 2010368,
+          "DataId": 1030620,
           "Position": {
-            "X": -356.8628,
-            "Y": 46.64673,
-            "Z": 419.39417
+            "X": -679.6826,
+            "Y": 132.20087,
+            "Z": 626.00134
           },
           "TerritoryId": 816,
-          "InteractionType": "Interact",
           "Fly": true,
-          "CompletionQuestVariablesFlags": [
-            null,
-            null,
-            null,
-            null,
-            null,
-            {
-              "High": 8
-            }
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterInteraction",
+          "KillEnemyDataIds": [
+            11110
           ]
-        },
-        {
-          "DataId": 2010369,
-          "Position": {
-            "X": -397.87903,
-            "Y": 51.773804,
-            "Z": 383.505
-          },
-          "TerritoryId": 816,
-          "InteractionType": "Interact"
         }
       ]
     },
@@ -100,11 +82,11 @@
       "Sequence": 2,
       "Steps": [
         {
-          "DataId": 1030845,
+          "DataId": 1030651,
           "Position": {
-            "X": -320.14954,
-            "Y": 20.880749,
-            "Z": 298.45117
+            "X": -562.0966,
+            "Y": 88.35041,
+            "Z": 601.5564
           },
           "TerritoryId": 816,
           "InteractionType": "Interact",
@@ -116,30 +98,30 @@
       "Sequence": 255,
       "Steps": [
         {
-          "DataId": 1030838,
+          "DataId": 1030619,
           "Position": {
-            "X": -285.90833,
-            "Y": 40.324036,
-            "Z": 444.41882
+            "X": -326.77197,
+            "Y": 68.13059,
+            "Z": 582.0248
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
           "Fly": true,
           "AetheryteShortcut": "Il Mheg - Lydha Lran",
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "NearPosition": {
                 "Position": {
-                  "X": -285.90833,
-                  "Y": 40.324036,
-                  "Z": 444.41882
+                  "X": -326.77197,
+                  "Y": 68.13059,
+                  "Z": 582.0248
                 },
                 "TerritoryId": 816,
                 "MaximumDistance": 200
               }
             }
-          },
-          "NextQuestId": 3407
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3396_When Beavers Cry.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3396_When Beavers Cry.json
@@ -1,29 +1,29 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
-  "Author": "Clockwise Starr",
+  "Author": "alydev",
   "QuestSequence": [
     {
       "Sequence": 0,
       "Steps": [
         {
-          "DataId": 1031025,
+          "DataId": 1030266,
           "Position": {
-            "X": -79.75891,
-            "Y": 37.968338,
-            "Z": -531.8532
+            "X": -367.66614,
+            "Y": 66.863594,
+            "Z": 557.1526
           },
           "TerritoryId": 816,
           "InteractionType": "AcceptQuest",
           "StopDistance": 0.25,
           "Fly": true,
-          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "NearPosition": {
                 "Position": {
-                  "X": -79.75891,
-                  "Y": 37.968338,
-                  "Z": -531.8532
+                  "X": -367.66614,
+                  "Y": 66.863594,
+                  "Z": 557.1526
                 },
                 "TerritoryId": 816,
                 "MaximumDistance": 200
@@ -37,14 +37,13 @@
       "Sequence": 1,
       "Steps": [
         {
-          "DataId": 1027695,
+          "DataId": 1030268,
           "Position": {
-            "X": 441.64185,
-            "Y": 89.80711,
-            "Z": -653.43713
+            "X": -225.05536,
+            "Y": 45.947155,
+            "Z": 576.8978
           },
           "TerritoryId": 816,
-          "AetheryteShortcut": "Il Mheg - Wolekdorf",
           "InteractionType": "Interact",
           "Fly": true
         }
@@ -54,11 +53,27 @@
       "Sequence": 2,
       "Steps": [
         {
-          "DataId": 1031026,
+          "DataId": 1030261,
           "Position": {
-            "X": 354.69592,
-            "Y": 87.448784,
-            "Z": -711.7876
+            "X": -40.512756,
+            "Y": 24.160252,
+            "Z": 741.0239
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1030268,
+          "Position": {
+            "X": -225.05536,
+            "Y": 45.947155,
+            "Z": 576.8978
           },
           "TerritoryId": 816,
           "InteractionType": "Interact",
@@ -70,31 +85,30 @@
       "Sequence": 255,
       "Steps": [
         {
-          "DataId": 1031025,
+          "DataId": 1030266,
           "Position": {
-            "X": -79.75891,
-            "Y": 37.968338,
-            "Z": -531.8532
+            "X": -367.66614,
+            "Y": 66.863594,
+            "Z": 557.1526
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
           "StopDistance": 0.25,
           "Fly": true,
-          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "NearPosition": {
                 "Position": {
-                  "X": -79.75891,
-                  "Y": 37.968338,
-                  "Z": -531.8532
+                  "X": -367.66614,
+                  "Y": 66.863594,
+                  "Z": 557.1526
                 },
                 "TerritoryId": 816,
                 "MaximumDistance": 200
               }
             }
-          },
-          "NextQuestId": 3429
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3397_And Then There Were None.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3397_And Then There Were None.json
@@ -1,41 +1,35 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
-  "Author": "Clockwise Starr",
+  "Author": "alydev",
   "QuestSequence": [
     {
       "Sequence": 0,
       "Steps": [
         {
-          "DataId": 1030838,
+          "DataId": 1030266,
           "Position": {
-            "X": -285.90833,
-            "Y": 40.324036,
-            "Z": 444.41882
+            "X": -367.66614,
+            "Y": 66.863594,
+            "Z": 557.1526
           },
           "TerritoryId": 816,
           "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
           "Fly": true,
           "AetheryteShortcut": "Il Mheg - Lydha Lran",
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "NearPosition": {
                 "Position": {
-                  "X": -285.90833,
-                  "Y": 40.324036,
-                  "Z": 444.41882
+                  "X": -367.66614,
+                  "Y": 66.863594,
+                  "Z": 557.1526
                 },
                 "TerritoryId": 816,
                 "MaximumDistance": 200
               }
             }
-          },
-          "DialogueChoices": [
-            {
-              "Type": "List",
-              "Prompt": "TEXT_LUCKZC103_03406_Q1_000_000",
-              "Answer": "TEXT_LUCKZC103_03406_A1_000_000"
-            }
-          ]
+          }
         }
       ]
     },
@@ -43,13 +37,14 @@
       "Sequence": 1,
       "Steps": [
         {
-          "DataId": 2010370,
+          "DataId": 1030263,
           "Position": {
-            "X": -268.17737,
-            "Y": 31.876099,
-            "Z": 344.04517
+            "X": -42.815117,
+            "Y": 24.277075,
+            "Z": 742.348
           },
           "TerritoryId": 816,
+          "StopDistance": 1,
           "InteractionType": "Interact",
           "Fly": true,
           "CompletionQuestVariablesFlags": [
@@ -59,40 +54,21 @@
             null,
             null,
             {
-              "High": 2
+              "High": 4
             }
           ]
         },
         {
-          "DataId": 2010368,
+          "DataId": 1030261,
           "Position": {
-            "X": -356.8628,
-            "Y": 46.64673,
-            "Z": 419.39417
+            "X": -40.512756,
+            "Y": 24.160252,
+            "Z": 741.0239
           },
           "TerritoryId": 816,
+          "StopDistance": 3,
           "InteractionType": "Interact",
-          "Fly": true,
-          "CompletionQuestVariablesFlags": [
-            null,
-            null,
-            null,
-            null,
-            null,
-            {
-              "High": 8
-            }
-          ]
-        },
-        {
-          "DataId": 2010369,
-          "Position": {
-            "X": -397.87903,
-            "Y": 51.773804,
-            "Z": 383.505
-          },
-          "TerritoryId": 816,
-          "InteractionType": "Interact"
+          "Fly": true
         }
       ]
     },
@@ -100,15 +76,33 @@
       "Sequence": 2,
       "Steps": [
         {
-          "DataId": 1030845,
+          "DataId": 1030270,
           "Position": {
-            "X": -320.14954,
-            "Y": 20.880749,
-            "Z": 298.45117
+            "X": -266.37683,
+            "Y": 50.977943,
+            "Z": 582.69617
           },
           "TerritoryId": 816,
-          "InteractionType": "Interact",
-          "Fly": true
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 2010722,
+          "Position": {
+            "X": -42.313293,
+            "Y": 24.246582,
+            "Z": 742.2445
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Say",
+          "Fly": true,
+          "ChatMessage": {
+            "Key": "TEXT_LUCKZC014_03397_SYSTEM_000_024"
+          }
         }
       ]
     },
@@ -116,30 +110,30 @@
       "Sequence": 255,
       "Steps": [
         {
-          "DataId": 1030838,
+          "DataId": 1030269,
           "Position": {
-            "X": -285.90833,
-            "Y": 40.324036,
-            "Z": 444.41882
+            "X": -364.065,
+            "Y": 67.968376,
+            "Z": 561.24194
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
           "Fly": true,
           "AetheryteShortcut": "Il Mheg - Lydha Lran",
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "NearPosition": {
                 "Position": {
-                  "X": -285.90833,
-                  "Y": 40.324036,
-                  "Z": 444.41882
+                  "X": -364.065,
+                  "Y": 67.968376,
+                  "Z": 561.24194
                 },
                 "TerritoryId": 816,
                 "MaximumDistance": 200
               }
             }
-          },
-          "NextQuestId": 3407
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3399_Bewitched Books.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3399_Bewitched Books.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1030618,
+          "Position": {
+            "X": -613.39746,
+            "Y": 36.54754,
+            "Z": -215.41168
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1031477,
+          "Position": {
+            "X": -626.9475,
+            "Y": 35.86156,
+            "Z": -217.18164
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "DialogueChoices": [
+            {
+              "Prompt": "TEXT_LUCKZC016_03399_Q1_000_000",
+              "Type": "YesNo",
+              "Yes": false
+            }
+          ]
+        },
+        {
+          "DataId": 1031479,
+          "Position": {
+            "X": -652.1249,
+            "Y": 37.361507,
+            "Z": -229.23633
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "DialogueChoices": [
+            {
+              "Prompt": "TEXT_LUCKZC016_03399_Q3_000_000",
+              "Type": "YesNo",
+              "Yes": false
+            }
+          ]
+        },
+        {
+          "DataId": 1031478,
+          "Position": {
+            "X": -630.15186,
+            "Y": 35.86156,
+            "Z": -245.0752
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "DialogueChoices": [
+            {
+              "Prompt": "TEXT_LUCKZC016_03399_Q2_000_000",
+              "Type": "YesNo",
+              "Yes": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1030618,
+          "Position": {
+            "X": -613.39746,
+            "Y": 36.54754,
+            "Z": -215.41168
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3399_Bewitched Books.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3399_Bewitched Books.json
@@ -13,7 +13,23 @@
             "Z": -215.41168
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -613.39746,
+                  "Y": 36.54754,
+                  "Z": -215.41168
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 500
+              }
+            }
+          }
         }
       ]
     },
@@ -84,7 +100,23 @@
             "Z": -215.41168
           },
           "TerritoryId": 816,
-          "InteractionType": "CompleteQuest"
+          "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -613.39746,
+                  "Y": 36.54754,
+                  "Z": -215.41168
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 500
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3400_Revolting Refreshments.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3400_Revolting Refreshments.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1029882,
+          "Position": {
+            "X": -613.8552,
+            "Y": 36.972534,
+            "Z": -242.78632
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1030415,
+          "Position": {
+            "X": -816.495,
+            "Y": 24.887575,
+            "Z": -155.19952
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1029882,
+          "Position": {
+            "X": -613.8552,
+            "Y": 36.972534,
+            "Z": -242.78632
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": false
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 2010101,
+          "Position": {
+            "X": -649.95807,
+            "Y": 38.223755,
+            "Z": -245.83813
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 1029882,
+          "Position": {
+            "X": -613.8552,
+            "Y": 36.972534,
+            "Z": -242.78632
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1030416,
+          "Position": {
+            "X": -606.0121,
+            "Y": 31.647814,
+            "Z": -181.90283
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3400_Revolting Refreshments.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3400_Revolting Refreshments.json
@@ -13,7 +13,23 @@
             "Z": -242.78632
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -613.8552,
+                  "Y": 36.972534,
+                  "Z": -242.78632
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 500
+              }
+            }
+          }
         }
       ]
     },
@@ -90,7 +106,23 @@
             "Z": -181.90283
           },
           "TerritoryId": 816,
-          "InteractionType": "CompleteQuest"
+          "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -606.0121,
+                  "Y": 31.647814,
+                  "Z": -181.90283
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 500
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3401_An Artist's Tale.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3401_An Artist's Tale.json
@@ -13,7 +13,23 @@
             "Z": 433.21887
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -278.8587,
+                  "Y": 32.170254,
+                  "Z": 433.21887
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -30,7 +46,17 @@
           "InteractionType": "None",
           "StopDistance": 0.25,
           "Land": true,
-          "Fly": true
+          "Fly": true,
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "High": 8
+            }
+          ]
         },
         {
           "Position": {
@@ -58,8 +84,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
           "AetheryteShortcut": "Il Mheg - Lydha Lran",
-          "Fly": true
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -278.8587,
+                  "Y": 32.170254,
+                  "Z": 433.21887
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3401_An Artist's Tale.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3401_An Artist's Tale.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1030418,
+          "Position": {
+            "X": -278.8587,
+            "Y": 32.170254,
+            "Z": 433.21887
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -301.52243,
+            "Y": 0.4953022,
+            "Z": 160.67256
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "StopDistance": 0.25,
+          "Land": true,
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -707.16205,
+            "Y": 39.079216,
+            "Z": 149.52554
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "StopDistance": 0.25,
+          "Land": true,
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1030418,
+          "Position": {
+            "X": -278.8587,
+            "Y": 32.170254,
+            "Z": 433.21887
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3402_Counting Pixies.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3402_Counting Pixies.json
@@ -1,29 +1,28 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
-  "Author": "Clockwise Starr",
+  "Author": "alydev",
   "QuestSequence": [
     {
       "Sequence": 0,
       "Steps": [
         {
-          "DataId": 1031025,
+          "DataId": 1030262,
           "Position": {
-            "X": -79.75891,
-            "Y": 37.968338,
-            "Z": -531.8532
+            "X": -350.60657,
+            "Y": 45.053513,
+            "Z": 408.83496
           },
           "TerritoryId": 816,
           "InteractionType": "AcceptQuest",
-          "StopDistance": 0.25,
           "Fly": true,
-          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "NearPosition": {
                 "Position": {
-                  "X": -79.75891,
-                  "Y": 37.968338,
-                  "Z": -531.8532
+                  "X": -350.60657,
+                  "Y": 45.053513,
+                  "Z": 408.83496
                 },
                 "TerritoryId": 816,
                 "MaximumDistance": 200
@@ -37,14 +36,13 @@
       "Sequence": 1,
       "Steps": [
         {
-          "DataId": 1027695,
+          "DataId": 1030271,
           "Position": {
-            "X": 441.64185,
-            "Y": 89.80711,
-            "Z": -653.43713
+            "X": -549.82837,
+            "Y": 48.51715,
+            "Z": 201.31226
           },
           "TerritoryId": 816,
-          "AetheryteShortcut": "Il Mheg - Wolekdorf",
           "InteractionType": "Interact",
           "Fly": true
         }
@@ -54,15 +52,37 @@
       "Sequence": 2,
       "Steps": [
         {
-          "DataId": 1031026,
+          "DataId": 2010157,
           "Position": {
-            "X": 354.69592,
-            "Y": 87.448784,
-            "Z": -711.7876
+            "X": -546.53235,
+            "Y": 48.386353,
+            "Z": 202.56348
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Snipe",
+          "Comment": "Three pixies visible, plus one\nup here, answer is four"
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1030271,
+          "Position": {
+            "X": -549.82837,
+            "Y": 48.51715,
+            "Z": 201.31226
           },
           "TerritoryId": 816,
           "InteractionType": "Interact",
-          "Fly": true
+          "DialogueChoices": [
+            {
+              "Prompt": "TEXT_LUCKZC019_03402_Q1_000_000",
+              "Answer": "TEXT_LUCKZC019_03402_A1_000_003",
+              "Type": "List"
+            }
+          ]
         }
       ]
     },
@@ -70,31 +90,29 @@
       "Sequence": 255,
       "Steps": [
         {
-          "DataId": 1031025,
+          "DataId": 1030262,
           "Position": {
-            "X": -79.75891,
-            "Y": 37.968338,
-            "Z": -531.8532
+            "X": -350.60657,
+            "Y": 45.053513,
+            "Z": 408.83496
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
-          "StopDistance": 0.25,
           "Fly": true,
-          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "NearPosition": {
                 "Position": {
-                  "X": -79.75891,
-                  "Y": 37.968338,
-                  "Z": -531.8532
+                  "X": -350.60657,
+                  "Y": 45.053513,
+                  "Z": 408.83496
                 },
                 "TerritoryId": 816,
                 "MaximumDistance": 200
               }
             }
-          },
-          "NextQuestId": 3429
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3403_A Rosy Problem.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3403_A Rosy Problem.json
@@ -1,29 +1,28 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
-  "Author": "Clockwise Starr",
+  "Author": "alydev",
   "QuestSequence": [
     {
       "Sequence": 0,
       "Steps": [
         {
-          "DataId": 1031204,
+          "DataId": 1027657,
           "Position": {
-            "X": 481.95605,
-            "Y": 90.43779,
-            "Z": -656.09216
+            "X": -246.63159,
+            "Y": 50.84181,
+            "Z": 583.7948
           },
           "TerritoryId": 816,
           "InteractionType": "AcceptQuest",
-          "StopDistance": 0.25,
           "Fly": true,
-          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "NearPosition": {
                 "Position": {
-                  "X": 481.95605,
-                  "Y": 90.43779,
-                  "Z": -656.09216
+                  "X": -246.63159,
+                  "Y": 50.84181,
+                  "Z": 583.7948
                 },
                 "TerritoryId": 816,
                 "MaximumDistance": 200
@@ -38,17 +37,34 @@
       "Steps": [
         {
           "Position": {
-            "X": 488.49036,
-            "Y": 79.56046,
-            "Z": -578.25543
+            "X": -95.62203,
+            "Y": 23.378927,
+            "Z": 543.38715
           },
           "TerritoryId": 816,
           "InteractionType": "Combat",
+          "Fly": true,
           "EnemySpawnType": "OverworldEnemies",
-          "KillEnemyDataIds": [
-            10261
-          ],
-          "Fly": true
+          "ComplexCombatData": [
+            {
+              "DataId": 10262,
+              "MinimumKillCount": 2,
+              "CompletionQuestVariablesFlags": [
+                null,
+                {
+                  "High": 2
+                },
+                null,
+                null,
+                null,
+                null
+              ]
+            },
+            {
+              "DataId": 11162,
+              "MinimumKillCount": 1
+            }
+          ]
         }
       ]
     },
@@ -56,24 +72,23 @@
       "Sequence": 255,
       "Steps": [
         {
-          "DataId": 1031204,
+          "DataId": 1027657,
           "Position": {
-            "X": 481.95605,
-            "Y": 90.43779,
-            "Z": -656.09216
+            "X": -246.63159,
+            "Y": 50.84181,
+            "Z": 583.7948
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
-          "StopDistance": 0.25,
           "Fly": true,
-          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "NearPosition": {
                 "Position": {
-                  "X": 481.95605,
-                  "Y": 90.43779,
-                  "Z": -656.09216
+                  "X": -246.63159,
+                  "Y": 50.84181,
+                  "Z": 583.7948
                 },
                 "TerritoryId": 816,
                 "MaximumDistance": 200

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3405_Painting for Praise.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3405_Painting for Praise.json
@@ -14,6 +14,21 @@
           },
           "TerritoryId": 816,
           "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -285.90833,
+                  "Y": 40.324036,
+                  "Z": 444.41882
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          },
           "DialogueChoices": [
             {
               "Type": "List",
@@ -37,7 +52,9 @@
           "TerritoryId": 816,
           "InteractionType": "Combat",
           "EnemySpawnType": "AfterInteraction",
-          "KillEnemyDataIds": [11155],
+          "KillEnemyDataIds": [
+            11155
+          ],
           "Fly": true
         },
         {
@@ -50,7 +67,9 @@
           "TerritoryId": 816,
           "InteractionType": "Combat",
           "EnemySpawnType": "AfterInteraction",
-          "KillEnemyDataIds": [11155],
+          "KillEnemyDataIds": [
+            11155
+          ],
           "Fly": true
         },
         {
@@ -128,6 +147,21 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -285.90833,
+                  "Y": 40.324036,
+                  "Z": 444.41882
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          },
           "NextQuestId": 3406
         }
       ]

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3405_Painting for Praise.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3405_Painting for Praise.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1030838,
+          "Position": {
+            "X": -285.90833,
+            "Y": 40.324036,
+            "Z": 444.41882
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZC102_03405_Q1_000_000",
+              "Answer": "TEXT_LUCKZC102_03405_A1_000_000"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2010365,
+          "Position": {
+            "X": -168.9632,
+            "Y": 27.450928,
+            "Z": 473.10596
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterInteraction",
+          "KillEnemyDataIds": [11155],
+          "Fly": true
+        },
+        {
+          "DataId": 2010366,
+          "Position": {
+            "X": -94.010864,
+            "Y": 19.516235,
+            "Z": 473.1975
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterInteraction",
+          "KillEnemyDataIds": [11155],
+          "Fly": true
+        },
+        {
+          "DataId": 2010367,
+          "Position": {
+            "X": -99.38208,
+            "Y": 18.051392,
+            "Z": 440.26855
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1030838,
+          "Position": {
+            "X": -285.90833,
+            "Y": 40.324036,
+            "Z": 444.41882
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "$": "Stop distance to avoid sacks on ground",
+          "StopDistance": 1.0,
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1030844,
+          "Position": {
+            "X": -696.7727,
+            "Y": 38.733704,
+            "Z": -28.366577
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 1030838,
+          "Position": {
+            "X": -285.90833,
+            "Y": 40.324036,
+            "Z": 444.41882
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1030838,
+          "Position": {
+            "X": -285.90833,
+            "Y": 40.324036,
+            "Z": 444.41882
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "NextQuestId": 3406
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3406_Gifts to Gladden.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3406_Gifts to Gladden.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1030838,
+          "Position": {
+            "X": -285.90833,
+            "Y": 40.324036,
+            "Z": 444.41882
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZC103_03406_Q1_000_000",
+              "Answer": "TEXT_LUCKZC103_03406_A1_000_000"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2010370,
+          "Position": {
+            "X": -268.17737,
+            "Y": 31.876099,
+            "Z": 344.04517
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 2010368,
+          "Position": {
+            "X": -356.8628,
+            "Y": 46.64673,
+            "Z": 419.39417
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 2010369,
+          "Position": {
+            "X": -397.87903,
+            "Y": 51.773804,
+            "Z": 383.505
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1030845,
+          "Position": {
+            "X": -320.14954,
+            "Y": 20.880749,
+            "Z": 298.45117
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1030838,
+          "Position": {
+            "X": -285.90833,
+            "Y": 40.324036,
+            "Z": 444.41882
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "NextQuestId": 3407,
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3407_The Dependable Darling.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3407_The Dependable Darling.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1030838,
+          "Position": {
+            "X": -285.90833,
+            "Y": 40.324036,
+            "Z": 444.41882
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZC104_03407_Q1_000_000",
+              "Answer": "TEXT_LUCKZC104_03407_A1_000_000"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1030721,
+          "Position": {
+            "X": -626.2455,
+            "Y": 52.029984,
+            "Z": 368.73413
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": -909.4109,
+            "Y": 35.300686,
+            "Z": 300.0915
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [11109],
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1030846,
+          "Position": {
+            "X": -910.94836,
+            "Y": 35.31905,
+            "Z": 301.16724
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1030838,
+          "Position": {
+            "X": -285.90833,
+            "Y": 40.324036,
+            "Z": 444.41882
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3407_The Dependable Darling.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3407_The Dependable Darling.json
@@ -14,6 +14,21 @@
           },
           "TerritoryId": 816,
           "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -285.90833,
+                  "Y": 40.324036,
+                  "Z": 444.41882
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          },
           "DialogueChoices": [
             {
               "Type": "List",
@@ -84,8 +99,21 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "Fly": true,
           "AetheryteShortcut": "Il Mheg - Lydha Lran",
-          "Fly": true
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -285.90833,
+                  "Y": 40.324036,
+                  "Z": 444.41882
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3408_Scents of Security.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3408_Scents of Security.json
@@ -1,29 +1,28 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
-  "Author": "Clockwise Starr",
+  "Author": "alydev",
   "QuestSequence": [
     {
       "Sequence": 0,
       "Steps": [
         {
-          "DataId": 1030700,
+          "DataId": 1027670,
           "Position": {
-            "X": 4.5929565,
-            "Y": 105.69799,
-            "Z": -849.45447
+            "X": 32.028687,
+            "Y": 101.900696,
+            "Z": -857.87744
           },
           "TerritoryId": 816,
           "InteractionType": "AcceptQuest",
-          "StopDistance": 0.25,
           "Fly": true,
           "AetheryteShortcut": "Il Mheg - Pla Enni",
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "NearPosition": {
                 "Position": {
-                  "X": 4.5929565,
-                  "Y": 105.69799,
-                  "Z": -849.45447
+                  "X": 32.028687,
+                  "Y": 101.900696,
+                  "Z": -857.87744
                 },
                 "TerritoryId": 816,
                 "MaximumDistance": 200
@@ -38,56 +37,63 @@
       "Steps": [
         {
           "Position": {
-            "X": -198.09572,
-            "Y": 92.04302,
-            "Z": -770.4763
+            "X": 32.028687,
+            "Y": 101.900696,
+            "Z": -857.87744
           },
           "TerritoryId": 816,
-          "InteractionType": "None",
-          "Fly": true
+          "InteractionType": "UseItem",
+          "ItemId": 2002608,
+          "$": "Starts with 0 16 0 0 0 0, using item sets to 0 0 0 0 0 0",
+          "CompletionQuestVariablesFlags": [
+            null,
+            {
+              "High": 0,
+              "Mode": "Exact"
+            },
+            null,
+            null,
+            null,
+            null
+          ]
         },
         {
+          "DataId": 1030272,
           "Position": {
-            "X": -146.5222,
-            "Y": 81.52178,
-            "Z": -725.06104
-          },
-          "TerritoryId": 816,
-          "InteractionType": "None",
-          "Fly": true
-        },
-        {
-          "Position": {
-            "X": -133.10895,
-            "Y": 64.91831,
-            "Z": -671.84753
-          },
-          "TerritoryId": 816,
-          "InteractionType": "None",
-          "DisableNavmesh": true,
-          "Fly": true
-        },
-        {
-          "DataId": 1030276,
-          "Position": {
-            "X": -468.68085,
-            "Y": 75.95398,
-            "Z": -376.3943
+            "X": -247.33356,
+            "Y": 54.021065,
+            "Z": -508.9342
           },
           "TerritoryId": 816,
           "InteractionType": "Interact",
-          "Fly": true
-        },
+          "Fly": true,
+          "RequiredQuestVariables": [
+            null,
+            [
+              {
+                "High": 0
+              }
+            ],
+            null,
+            null,
+            null,
+            null
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
         {
-          "DataId": 1030277,
+          "DataId": 1030272,
           "Position": {
-            "X": -544.4877,
-            "Y": 72.54534,
-            "Z": -407.0039
+            "X": -247.33356,
+            "Y": 54.021065,
+            "Z": -508.9342
           },
           "TerritoryId": 816,
-          "InteractionType": "Interact",
-          "Fly": true
+          "InteractionType": "Interact"
         }
       ]
     },
@@ -95,24 +101,23 @@
       "Sequence": 255,
       "Steps": [
         {
-          "DataId": 1030700,
+          "DataId": 1027670,
           "Position": {
-            "X": 4.5929565,
-            "Y": 105.69799,
-            "Z": -849.45447
+            "X": 32.028687,
+            "Y": 101.900696,
+            "Z": -857.87744
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
-          "StopDistance": 0.25,
           "Fly": true,
           "AetheryteShortcut": "Il Mheg - Pla Enni",
           "SkipConditions": {
             "AetheryteShortcutIf": {
               "NearPosition": {
                 "Position": {
-                  "X": 4.5929565,
-                  "Y": 105.69799,
-                  "Z": -849.45447
+                  "X": 32.028687,
+                  "Y": 101.900696,
+                  "Z": -857.87744
                 },
                 "TerritoryId": 816,
                 "MaximumDistance": 200

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3409_A Lawful Trade.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3409_A Lawful Trade.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1028044,
+          "Position": {
+            "X": 69.7489,
+            "Y": 110.69292,
+            "Z": -883.69574
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1028052,
+          "Position": {
+            "X": -381.09412,
+            "Y": 58.71793,
+            "Z": 554.2534
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "Fly": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZD002_03409_Q1_000_000",
+              "Answer": "TEXT_LUCKZD002_03409_A1_000_002"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2010189,
+          "Position": {
+            "X": -426.7796,
+            "Y": 36.484253,
+            "Z": 331.80737
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 2010186,
+          "Position": {
+            "X": -411.00177,
+            "Y": 18.600708,
+            "Z": 209.18591
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 2010185,
+          "Position": {
+            "X": -428.4276,
+            "Y": 21.164185,
+            "Z": 207.20227
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        },
+        {
+          "DataId": 2010184,
+          "Position": {
+            "X": -450.6142,
+            "Y": 12.924377,
+            "Z": 27.725586
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 2010187,
+          "Position": {
+            "X": -468.46722,
+            "Y": 15.6710205,
+            "Z": 8.743347
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        },
+        {
+          "DataId": 2010188,
+          "Position": {
+            "X": -460.19684,
+            "Y": 7.370056,
+            "Z": -21.896729
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1028044,
+          "Position": {
+            "X": 69.7489,
+            "Y": 110.69292,
+            "Z": -883.69574
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "StopDistance": 0.25,
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3409_A Lawful Trade.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3409_A Lawful Trade.json
@@ -8,12 +8,28 @@
         {
           "DataId": 1028044,
           "Position": {
-            "X": 69.7489,
-            "Y": 110.69292,
-            "Z": -883.69574
+            "X": 71.46892,
+            "Y": 110.75986,
+            "Z": -882.7626
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "StopDistance": 1,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 69.7489,
+                  "Y": 110.69292,
+                  "Z": -883.69574
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -115,15 +131,28 @@
         {
           "DataId": 1028044,
           "Position": {
-            "X": 69.7489,
-            "Y": 110.69292,
-            "Z": -883.69574
+            "X": 71.46892,
+            "Y": 110.75986,
+            "Z": -882.7626
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "StopDistance": 1,
+          "Fly": true,
           "AetheryteShortcut": "Il Mheg - Pla Enni",
-          "StopDistance": 0.25,
-          "Fly": true
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 71.46892,
+                  "Y": 110.75986,
+                  "Z": -882.7626
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3410_The Mushroom Menace.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3410_The Mushroom Menace.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1030698,
+          "Position": {
+            "X": -224.84174,
+            "Y": 79.61796,
+            "Z": -786.3432
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -143.63945,
+            "Y": 74.80255,
+            "Z": -710.7938
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -130.4393,
+            "Y": 66.68743,
+            "Z": -666.78925
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "DisableNavmesh": true,
+          "Fly": true
+        },
+        {
+          "DataId": 2010102,
+          "Position": {
+            "X": 3.7078857,
+            "Y": 26.993164,
+            "Z": -507.4083
+          },
+          "TerritoryId": 816,
+          "StopDistance": 0.5,
+          "InteractionType": "UseItem",
+          "ItemId": 2002655,
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2010216,
+          "Position": {
+            "X": -6.1189575,
+            "Y": 29.251465,
+            "Z": -512.047
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterInteraction",
+          "KillEnemyDataIds": [11112]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "Position": {
+            "X": -130.83179,
+            "Y": 67.79039,
+            "Z": -679.27563
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -150.98509,
+            "Y": 70.57293,
+            "Z": -718.194
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "DisableNavmesh": true,
+          "Fly": true
+        },
+        {
+          "DataId": 1030698,
+          "Position": {
+            "X": -224.84174,
+            "Y": 79.61796,
+            "Z": -786.3432
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3410_The Mushroom Menace.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3410_The Mushroom Menace.json
@@ -13,7 +13,22 @@
             "Z": -786.3432
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -224.84174,
+                  "Y": 79.61796,
+                  "Z": -786.3432
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 350
+              }
+            }
+          }
         }
       ]
     },
@@ -69,34 +84,15 @@
           "TerritoryId": 816,
           "InteractionType": "Combat",
           "EnemySpawnType": "AfterInteraction",
-          "KillEnemyDataIds": [11112]
+          "KillEnemyDataIds": [
+            11112
+          ]
         }
       ]
     },
     {
       "Sequence": 255,
       "Steps": [
-        {
-          "Position": {
-            "X": -130.83179,
-            "Y": 67.79039,
-            "Z": -679.27563
-          },
-          "TerritoryId": 816,
-          "InteractionType": "None",
-          "Fly": true
-        },
-        {
-          "Position": {
-            "X": -150.98509,
-            "Y": 70.57293,
-            "Z": -718.194
-          },
-          "TerritoryId": 816,
-          "InteractionType": "None",
-          "DisableNavmesh": true,
-          "Fly": true
-        },
         {
           "DataId": 1030698,
           "Position": {
@@ -105,7 +101,22 @@
             "Z": -786.3432
           },
           "TerritoryId": 816,
-          "InteractionType": "CompleteQuest"
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -224.84174,
+                  "Y": 79.61796,
+                  "Z": -786.3432
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 300
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3411_Growing Pla Enni.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3411_Growing Pla Enni.json
@@ -8,12 +8,28 @@
         {
           "DataId": 1027673,
           "Position": {
-            "X": -106.06549,
+            "X": -106.43583,
             "Y": 108.39998,
-            "Z": -841.7639
+            "Z": -840.68567
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -106.43583,
+                  "Y": 108.39998,
+                  "Z": -840.68567
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -22,15 +38,53 @@
       "Steps": [
         {
           "Position": {
-            "X": -639.1647,
-            "Y": 128.91765,
-            "Z": 621.7844
+            "X": -354.8902,
+            "Y": 47.989246,
+            "Z": 495.83212
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "Fly": true,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -354.8902,
+                  "Y": 47.989246,
+                  "Z": 495.83212
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
+        },
+        {
+          "Position": {
+            "X": -725.7799,
+            "Y": 93.38933,
+            "Z": 569.39484
           },
           "TerritoryId": 816,
           "InteractionType": "Combat",
           "EnemySpawnType": "OverworldEnemies",
-          "KillEnemyDataIds": [10266],
-          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            {
+              "High": 1
+            },
+            null,
+            null
+          ],
+          "ComplexCombatData": [
+            {
+              "DataId": 10266,
+              "MinimumKillCount": 1
+            }
+          ],
           "Fly": true
         },
         {
@@ -42,20 +96,50 @@
           "TerritoryId": 816,
           "InteractionType": "Combat",
           "EnemySpawnType": "OverworldEnemies",
-          "KillEnemyDataIds": [10269],
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            {
+              "Low": 1
+            },
+            null,
+            null,
+            null
+          ],
+          "ComplexCombatData": [
+            {
+              "DataId": 10269,
+              "MinimumKillCount": 1
+            }
+          ],
           "Fly": true
         },
         {
           "DataId": 10252,
           "Position": {
-            "X": -18.120531,
-            "Y": 57.509007,
-            "Z": -125.96332
+            "X": -119.04461,
+            "Y": 97.54629,
+            "Z": -173.52538
           },
           "TerritoryId": 816,
           "InteractionType": "Combat",
           "EnemySpawnType": "OverworldEnemies",
-          "KillEnemyDataIds": [10252],
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            {
+              "High": 1
+            },
+            null,
+            null,
+            null
+          ],
+          "ComplexCombatData": [
+            {
+              "DataId": 10252,
+              "MinimumKillCount": 1
+            }
+          ],
           "Fly": true
         }
       ]
@@ -66,15 +150,28 @@
         {
           "DataId": 1027673,
           "Position": {
-            "X": -106.06549,
+            "X": -106.43583,
             "Y": 108.39998,
-            "Z": -841.7639
+            "Z": -840.68567
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
           "StopDistance": 0.25,
+          "Fly": true,
           "AetheryteShortcut": "Il Mheg - Pla Enni",
-          "Fly": true
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -106.43583,
+                  "Y": 108.39998,
+                  "Z": -840.68567
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3411_Growing Pla Enni.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3411_Growing Pla Enni.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027673,
+          "Position": {
+            "X": -106.06549,
+            "Y": 108.39998,
+            "Z": -841.7639
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -639.1647,
+            "Y": 128.91765,
+            "Z": 621.7844
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "KillEnemyDataIds": [10266],
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -150.93805,
+            "Y": 13.96408,
+            "Z": 376.68124
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "KillEnemyDataIds": [10269],
+          "Fly": true
+        },
+        {
+          "DataId": 10252,
+          "Position": {
+            "X": -18.120531,
+            "Y": 57.509007,
+            "Z": -125.96332
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "KillEnemyDataIds": [10252],
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027673,
+          "Position": {
+            "X": -106.06549,
+            "Y": 108.39998,
+            "Z": -841.7639
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3412_Much Ado About Giving.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3412_Much Ado About Giving.json
@@ -13,7 +13,22 @@
             "Z": -875.5169
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -58.091125,
+                  "Y": 104.18485,
+                  "Z": -875.5169
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -69,7 +84,21 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
-          "Fly": true
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -58.091125,
+                  "Y": 104.18485,
+                  "Z": -875.5169
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3412_Much Ado About Giving.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3412_Much Ado About Giving.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1030273,
+          "Position": {
+            "X": -58.091125,
+            "Y": 104.18485,
+            "Z": -875.5169
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1027673,
+          "Position": {
+            "X": -106.06549,
+            "Y": 108.39998,
+            "Z": -841.7639
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "StopDistance": 0.25,
+          "Fly": true
+        },
+        {
+          "DataId": 1027670,
+          "Position": {
+            "X": 32.028687,
+            "Y": 101.900696,
+            "Z": -857.87744
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 1028044,
+          "Position": {
+            "X": 69.7489,
+            "Y": 110.69292,
+            "Z": -883.69574
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "StopDistance": 0.25,
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1030273,
+          "Position": {
+            "X": -58.091125,
+            "Y": 104.18485,
+            "Z": -875.5169
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3413_Help My Porxie.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3413_Help My Porxie.json
@@ -8,12 +8,28 @@
         {
           "DataId": 1030274,
           "Position": {
-            "X": -46.12805,
-            "Y": 110.93045,
-            "Z": -851.92645
+            "X": -45.759922,
+            "Y": 110.93033,
+            "Z": -850.55524
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -45.759922,
+                  "Y": 110.93033,
+                  "Z": -850.55524
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -60,15 +76,28 @@
         {
           "DataId": 1030274,
           "Position": {
-            "X": -46.12805,
-            "Y": 110.93045,
-            "Z": -851.92645
+            "X": -45.759922,
+            "Y": 110.93033,
+            "Z": -850.55524
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
           "StopDistance": 0.25,
+          "Fly": true,
           "AetheryteShortcut": "Il Mheg - Pla Enni",
-          "Fly": true
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -45.759922,
+                  "Y": 110.93033,
+                  "Z": -850.55524
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3413_Help My Porxie.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3413_Help My Porxie.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1030274,
+          "Position": {
+            "X": -46.12805,
+            "Y": 110.93045,
+            "Z": -851.92645
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2010192,
+          "Position": {
+            "X": 63.645386,
+            "Y": 0.1373291,
+            "Z": -276.17303
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "Fly": true
+        },
+        {
+          "DataId": 2010190,
+          "Position": {
+            "X": 63.553833,
+            "Y": -0.16790771,
+            "Z": -289.4179
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        },
+        {
+          "DataId": 2010191,
+          "Position": {
+            "X": 48.53894,
+            "Y": -0.35101318,
+            "Z": -283.61945
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1030274,
+          "Position": {
+            "X": -46.12805,
+            "Y": 110.93045,
+            "Z": -851.92645
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3414_One Good Trick Deserves Another.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3414_One Good Trick Deserves Another.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1030700,
+          "Position": {
+            "X": 4.5929565,
+            "Y": 105.69799,
+            "Z": -849.45447
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -198.09572,
+            "Y": 92.04302,
+            "Z": -770.4763
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -146.5222,
+            "Y": 81.52178,
+            "Z": -725.06104
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -133.10895,
+            "Y": 64.91831,
+            "Z": -671.84753
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "DisableNavmesh": true,
+          "Fly": true
+        },
+        {
+          "DataId": 1030276,
+          "Position": {
+            "X": -468.68085,
+            "Y": 75.95398,
+            "Z": -376.3943
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 1030277,
+          "Position": {
+            "X": -544.4877,
+            "Y": 72.54534,
+            "Z": -407.0039
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1030700,
+          "Position": {
+            "X": 4.5929565,
+            "Y": 105.69799,
+            "Z": -849.45447
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3415_A Leafman and a Hero.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3415_A Leafman and a Hero.json
@@ -13,7 +13,23 @@
             "Z": -889.82983
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -15.610046,
+                  "Y": 106.46049,
+                  "Z": -889.82983
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -66,8 +82,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
           "AetheryteShortcut": "Il Mheg - Pla Enni",
-          "Fly": true
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -15.610046,
+                  "Y": 106.46049,
+                  "Z": -889.82983
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3415_A Leafman and a Hero.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3415_A Leafman and a Hero.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1030699,
+          "Position": {
+            "X": -15.610046,
+            "Y": 106.46049,
+            "Z": -889.82983
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 11.219196,
+            "Y": 136.42273,
+            "Z": -828.22034
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 47.042942,
+            "Y": 152.99881,
+            "Z": -757.84467
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "DataId": 2010193,
+          "Position": {
+            "X": -166.09448,
+            "Y": 2.3345947,
+            "Z": -220.17242
+          },
+          "TerritoryId": 816,
+          "InteractionType": "UseItem",
+          "ItemId": 2002646,
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1030699,
+          "Position": {
+            "X": -15.610046,
+            "Y": 106.46049,
+            "Z": -889.82983
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3416_Magic Is Love, Magic Is Life.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3416_Magic Is Love, Magic Is Life.json
@@ -8,12 +8,28 @@
         {
           "DataId": 1027673,
           "Position": {
-            "X": -106.06549,
+            "X": -106.43583,
             "Y": 108.39998,
-            "Z": -841.7639
+            "Z": -840.68567
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -106.43583,
+                  "Y": 108.39998,
+                  "Z": -840.68567
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -60,7 +76,22 @@
           "TerritoryId": 816,
           "InteractionType": "Combat",
           "EnemySpawnType": "OverworldEnemies",
-          "KillEnemyDataIds": [10255],
+          "CompletionQuestVariablesFlags": [
+            null,
+            {
+              "Low": 1
+            },
+            null,
+            null,
+            null,
+            null
+          ],
+          "ComplexCombatData": [
+            {
+              "DataId": 10255,
+              "MinimumKillCount": 1
+            }
+          ],
           "Fly": true
         },
         {
@@ -120,14 +151,28 @@
         {
           "DataId": 1027673,
           "Position": {
-            "X": -106.06549,
+            "X": -106.43583,
             "Y": 108.39998,
-            "Z": -841.7639
+            "Z": -840.68567
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
           "StopDistance": 0.25,
-          "Fly": true
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -106.43583,
+                  "Y": 108.39998,
+                  "Z": -840.68567
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3416_Magic Is Love, Magic Is Life.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3416_Magic Is Love, Magic Is Life.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027673,
+          "Position": {
+            "X": -106.06549,
+            "Y": 108.39998,
+            "Z": -841.7639
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -208.01585,
+            "Y": 93.95745,
+            "Z": -798.679
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -147.16849,
+            "Y": 82.71202,
+            "Z": -735.21466
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -133.04337,
+            "Y": 65.32452,
+            "Z": -668.47845
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "DisableNavmesh": true,
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -111.79012,
+            "Y": 56.679848,
+            "Z": -665.1558
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "KillEnemyDataIds": [10255],
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -48.470287,
+            "Y": 47.403774,
+            "Z": -602.753
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "KillEnemyDataIds": [10265],
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": -130.71318,
+            "Y": 65.82463,
+            "Z": -680.729
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -151.2964,
+            "Y": 67.730545,
+            "Z": -714.6202
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "DisableNavmesh": true,
+          "Fly": true
+        },
+        {
+          "DataId": 1030701,
+          "Position": {
+            "X": -183.94751,
+            "Y": 80.33522,
+            "Z": -745.449
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027673,
+          "Position": {
+            "X": -106.06549,
+            "Y": 108.39998,
+            "Z": -841.7639
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3417_Are You Being Served.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3417_Are You Being Served.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1030702,
+          "Position": {
+            "X": -1.8158569,
+            "Y": 100.46835,
+            "Z": -889.34155
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1028044,
+          "Position": {
+            "X": 69.7489,
+            "Y": 110.69292,
+            "Z": -883.69574
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "StopDistance": 0.25,
+          "Fly": true
+        },
+        {
+          "DataId": 1027671,
+          "Position": {
+            "X": -33.12738,
+            "Y": 105.68533,
+            "Z": -879.9115
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 1027673,
+          "Position": {
+            "X": -106.06549,
+            "Y": 108.39998,
+            "Z": -841.7639
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "StopDistance": 0.25,
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1030702,
+          "Position": {
+            "X": -1.8158569,
+            "Y": 100.46835,
+            "Z": -889.34155
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "Position": {
+            "X": -306.4134,
+            "Y": 67.26528,
+            "Z": 653.3375
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "KillEnemyDataIds": [10246],
+          "CombatItemUse": {
+            "Condition": "Health%",
+            "Value": 49,
+            "ItemId": 2002661
+          },
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1030702,
+          "Position": {
+            "X": -1.8158569,
+            "Y": 100.46835,
+            "Z": -889.34155
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3417_Are You Being Served.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3417_Are You Being Served.json
@@ -13,7 +13,23 @@
             "Z": -889.34155
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -1.8158569,
+                  "Y": 100.46835,
+                  "Z": -889.34155
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -77,22 +93,39 @@
       "Sequence": 3,
       "Steps": [
         {
+          "DataId": 10246,
           "Position": {
             "X": -306.4134,
             "Y": 67.26528,
             "Z": 653.3375
           },
           "TerritoryId": 816,
-          "InteractionType": "Combat",
-          "EnemySpawnType": "OverworldEnemies",
-          "KillEnemyDataIds": [10246],
+          "$": "Leveled players kill mob too quickly for CombatItemUse.Condition to trigger",
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Comment": "Manual: Bring echevore to <49% health, then use sack",
+          "KillEnemyDataIds": [
+            10246
+          ],
           "CombatItemUse": {
             "Condition": "Health%",
             "Value": 49,
             "ItemId": 2002661
           },
           "AetheryteShortcut": "Il Mheg - Lydha Lran",
-          "Fly": true
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -306.4134,
+                  "Y": 67.26528,
+                  "Z": 653.3375
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -108,8 +141,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
           "AetheryteShortcut": "Il Mheg - Pla Enni",
-          "Fly": true
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -1.8158569,
+                  "Y": 100.46835,
+                  "Z": -889.34155
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3418_A Stranger Fuath.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3418_A Stranger Fuath.json
@@ -13,7 +13,23 @@
             "Z": -838.49854
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -101.51831,
+                  "Y": 101.86012,
+                  "Z": -838.49854
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -36,7 +52,6 @@
               "Answer": "TEXT_LUCKZD011_03418_A1_000_002"
             }
           ],
-          "AetheryteShortcut": "Il Mheg - Wolekdorf",
           "Fly": true
         }
       ]
@@ -53,7 +68,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
-          "AetheryteShortcut": "Il Mheg - Pla Enni"
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -101.51831,
+                  "Y": 101.86012,
+                  "Z": -838.49854
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3418_A Stranger Fuath.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3418_A Stranger Fuath.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027672,
+          "Position": {
+            "X": -101.51831,
+            "Y": 101.86012,
+            "Z": -838.49854
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1031498,
+          "Position": {
+            "X": 64.34729,
+            "Y": 11.202045,
+            "Z": -543.75525
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZD011_03418_Q1_000_000",
+              "Answer": "TEXT_LUCKZD011_03418_A1_000_002"
+            }
+          ],
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027672,
+          "Position": {
+            "X": -101.51831,
+            "Y": 101.86012,
+            "Z": -838.49854
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Pla Enni"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3419_Pushy for Patronage.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3419_Pushy for Patronage.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027692,
+          "Position": {
+            "X": 382.1317,
+            "Y": 86.5506,
+            "Z": -617.0901
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1027670,
+          "Position": {
+            "X": 32.028687,
+            "Y": 101.900696,
+            "Z": -857.87744
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": 81.892,
+            "Y": 108.524185,
+            "Z": -831.4639
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 113.36558,
+            "Y": 96.24501,
+            "Z": -756.37885
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "DisableNavmesh": true,
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 174.2612,
+            "Y": 89.864105,
+            "Z": -732.0094
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "DisableNavmesh": true,
+          "Fly": true
+        },
+        {
+          "DataId": 2010695,
+          "Position": {
+            "X": 131.7616,
+            "Y": 71.488525,
+            "Z": -662.3179
+          },
+          "TerritoryId": 816,
+          "StopDistance": 0.25,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 2010694,
+          "Position": {
+            "X": 103.89868,
+            "Y": 49.393433,
+            "Z": -630.33496
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 2010697,
+          "Position": {
+            "X": 137.4989,
+            "Y": 21.683044,
+            "Z": -551.68994
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 2010696,
+          "Position": {
+            "X": 108.20166,
+            "Y": 15.487854,
+            "Z": -540.1542
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1027670,
+          "Position": {
+            "X": 32.028687,
+            "Y": 101.900696,
+            "Z": -857.87744
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027692,
+          "Position": {
+            "X": 382.1317,
+            "Y": 86.5506,
+            "Z": -617.0901
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3419_Pushy for Patronage.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3419_Pushy for Patronage.json
@@ -13,7 +13,23 @@
             "Z": -617.0901
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 382.1317,
+                  "Y": 86.5506,
+                  "Z": -617.0901
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -144,8 +160,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
           "AetheryteShortcut": "Il Mheg - Wolekdorf",
-          "Fly": true
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 382.1317,
+                  "Y": 86.5506,
+                  "Z": -617.0901
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3420_In His Mistress's Memory.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3420_In His Mistress's Memory.json
@@ -13,7 +13,23 @@
             "Z": -715.41925
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 364.27856,
+                  "Y": 87.001114,
+                  "Z": -715.41925
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -52,7 +68,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
           "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 364.27856,
+                  "Y": 87.001114,
+                  "Z": -715.41925
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          },
           "NextQuestId": 3425
         }
       ]

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3420_In His Mistress's Memory.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3420_In His Mistress's Memory.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027693,
+          "Position": {
+            "X": 364.27856,
+            "Y": 87.001114,
+            "Z": -715.41925
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2010699,
+          "Position": {
+            "X": 55.22229,
+            "Y": 0.015197754,
+            "Z": -282.36823
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_LUCKZD013_03420_SYSTEM_110_010",
+              "Yes": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027693,
+          "Position": {
+            "X": 364.27856,
+            "Y": 87.001114,
+            "Z": -715.41925
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "NextQuestId": 3425
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3421_Lurkers in the Lake.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3421_Lurkers in the Lake.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1031499,
+          "Position": {
+            "X": 394.00305,
+            "Y": 88.98844,
+            "Z": -634.4854
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2010701,
+          "Position": {
+            "X": 237.99487,
+            "Y": 25.986084,
+            "Z": -473.13654
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterInteraction",
+          "KillEnemyDataIds": [11172, 11172],
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1031506,
+          "Position": {
+            "X": 229.60242,
+            "Y": 24.333113,
+            "Z": -458.97614
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031499,
+          "Position": {
+            "X": 394.00305,
+            "Y": 88.98844,
+            "Z": -634.4854
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3421_Lurkers in the Lake.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3421_Lurkers in the Lake.json
@@ -13,7 +13,23 @@
             "Z": -634.4854
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 394.00305,
+                  "Y": 88.98844,
+                  "Z": -634.4854
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -30,7 +46,10 @@
           "TerritoryId": 816,
           "InteractionType": "Combat",
           "EnemySpawnType": "AfterInteraction",
-          "KillEnemyDataIds": [11172, 11172],
+          "KillEnemyDataIds": [
+            11172,
+            11172
+          ],
           "Fly": true
         }
       ]
@@ -62,8 +81,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
           "AetheryteShortcut": "Il Mheg - Wolekdorf",
-          "Fly": true
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 394.00305,
+                  "Y": 88.98844,
+                  "Z": -634.4854
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3422_A Tale of a Tail.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3422_A Tale of a Tail.json
@@ -13,7 +13,23 @@
             "Z": -742.5193
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 457.87744,
+                  "Y": 89.41441,
+                  "Z": -742.5193
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -28,7 +44,9 @@
           },
           "TerritoryId": 816,
           "InteractionType": "Combat",
-          "KillEnemyDataIds": [10254],
+          "KillEnemyDataIds": [
+            10254
+          ],
           "EnemySpawnType": "OverworldEnemies",
           "Fly": true
         }
@@ -46,8 +64,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
           "AetheryteShortcut": "Il Mheg - Wolekdorf",
-          "Fly": true
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 457.87744,
+                  "Y": 89.41441,
+                  "Z": -742.5193
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3422_A Tale of a Tail.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3422_A Tale of a Tail.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027694,
+          "Position": {
+            "X": 457.87744,
+            "Y": 89.41441,
+            "Z": -742.5193
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 555.16394,
+            "Y": 93.2426,
+            "Z": -457.1445
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Combat",
+          "KillEnemyDataIds": [10254],
+          "EnemySpawnType": "OverworldEnemies",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027694,
+          "Position": {
+            "X": 457.87744,
+            "Y": 89.41441,
+            "Z": -742.5193
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3423_Not All Pixies.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3423_Not All Pixies.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1031203,
+          "Position": {
+            "X": 490.2876,
+            "Y": 90.00257,
+            "Z": -700.64856
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "$": "Avoid Phooka combat",
+          "Position": {
+            "X": -69.011116,
+            "Y": 95.166016,
+            "Z": -159.66423
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "DataId": 1031507,
+          "Position": {
+            "X": -52.0791,
+            "Y": 87.9948,
+            "Z": -180.31586
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1027671,
+          "Position": {
+            "X": -33.12738,
+            "Y": 105.68533,
+            "Z": -879.9115
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "Position": {
+            "X": -175.66415,
+            "Y": 102.020195,
+            "Z": -833.0812
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -183.17235,
+            "Y": 94.52451,
+            "Z": -753.12067
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -142.48228,
+            "Y": 74.786835,
+            "Z": -707.13934
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -129.47108,
+            "Y": 66.06374,
+            "Z": -666.76575
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "DisableNavmesh": true,
+          "Fly": true
+        },
+        {
+          "$": "Avoid Phooka combat",
+          "Position": {
+            "X": -69.011116,
+            "Y": 95.166016,
+            "Z": -159.66423
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "DataId": 1031507,
+          "Position": {
+            "X": -52.0791,
+            "Y": 87.9948,
+            "Z": -180.31586
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031203,
+          "Position": {
+            "X": 490.2876,
+            "Y": 90.00257,
+            "Z": -700.64856
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3423_Not All Pixies.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3423_Not All Pixies.json
@@ -13,7 +13,23 @@
             "Z": -700.64856
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 490.2876,
+                  "Y": 90.00257,
+                  "Z": -700.64856
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -141,8 +157,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
           "AetheryteShortcut": "Il Mheg - Wolekdorf",
-          "Fly": true
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 490.2876,
+                  "Y": 90.00257,
+                  "Z": -700.64856
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3424_A Gift in Advance.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3424_A Gift in Advance.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1031204,
+          "Position": {
+            "X": 481.95605,
+            "Y": 90.43779,
+            "Z": -656.09216
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 488.49036,
+            "Y": 79.56046,
+            "Z": -578.25543
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "KillEnemyDataIds": [10261],
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031204,
+          "Position": {
+            "X": 481.95605,
+            "Y": 90.43779,
+            "Z": -656.09216
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3425_In His Mistress's Name.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3425_In His Mistress's Name.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027656,
+          "Position": {
+            "X": -291.61517,
+            "Y": 40.324036,
+            "Z": 456.65674
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1027693,
+          "Position": {
+            "X": 364.27856,
+            "Y": 87.001114,
+            "Z": -715.41925
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Il Mheg - Wolekdorf"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027656,
+          "Position": {
+            "X": -291.61517,
+            "Y": 40.324036,
+            "Z": 456.65674
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3425_In His Mistress's Name.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3425_In His Mistress's Name.json
@@ -13,7 +13,23 @@
             "Z": 456.65674
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -291.61517,
+                  "Y": 40.324036,
+                  "Z": 456.65674
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -45,8 +61,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
           "AetheryteShortcut": "Il Mheg - Lydha Lran",
-          "Fly": true
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -291.61517,
+                  "Y": 40.324036,
+                  "Z": 456.65674
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3426_Hide and Seek.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3426_Hide and Seek.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1031521,
+          "Position": {
+            "X": -419.30273,
+            "Y": 60.306217,
+            "Z": 498.16125
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1031522,
+          "Position": {
+            "X": 676.2949,
+            "Y": 186.37202,
+            "Z": 323.5066
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "$": "Make pathfinding a bit easier",
+          "Position": {
+            "X": 543.39996,
+            "Y": 189.17812,
+            "Z": 136.01952
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 495.16104,
+            "Y": 152.8019,
+            "Z": 61.648518
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 499.35895,
+            "Y": 147.40627,
+            "Z": 58.37402
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Land": true
+        },
+        {
+          "DataId": 1031526,
+          "Position": {
+            "X": 536.1256,
+            "Y": 149.64941,
+            "Z": 13.565186
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Say",
+          "ChatMessage": 
+          {
+            "Key": "TEXT_LUCKZD019_03426_SYSTEM_100_020"
+          },
+          "DisableNavmesh": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "Position": {
+            "X": 493.37753,
+            "Y": 150.0216,
+            "Z": 60.386654
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "DataId": 1031522,
+          "Position": {
+            "X": 676.2949,
+            "Y": 186.37202,
+            "Z": 323.5066
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031521,
+          "Position": {
+            "X": -419.30273,
+            "Y": 60.306217,
+            "Z": 498.16125
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "$": "Pathing from aetheryte would sometimes give error with default stop distance",
+          "StopDistance": 1.0,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Lydha Lran"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3426_Hide and Seek.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3426_Hide and Seek.json
@@ -13,7 +13,23 @@
             "Z": 498.16125
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -419.30273,
+                  "Y": 60.306217,
+                  "Z": 498.16125
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -21,6 +37,7 @@
       "Sequence": 1,
       "Steps": [
         {
+          "$": "Wolekdorf is slightly closer, but not worth TP",
           "DataId": 1031522,
           "Position": {
             "X": 676.2949,
@@ -76,8 +93,7 @@
           },
           "TerritoryId": 816,
           "InteractionType": "Say",
-          "ChatMessage": 
-          {
+          "ChatMessage": {
             "Key": "TEXT_LUCKZD019_03426_SYSTEM_100_020"
           },
           "DisableNavmesh": true
@@ -122,10 +138,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
-          "$": "Pathing from aetheryte would sometimes give error with default stop distance",
-          "StopDistance": 1.0,
+          "StopDistance": 0.25,
           "Fly": true,
-          "AetheryteShortcut": "Il Mheg - Lydha Lran"
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -419.30273,
+                  "Y": 60.306217,
+                  "Z": 498.16125
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3428_A Costly Meal.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3428_A Costly Meal.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1031025,
+          "Position": {
+            "X": -79.75891,
+            "Y": 37.968338,
+            "Z": -531.8532
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1027695,
+          "Position": {
+            "X": 441.64185,
+            "Y": 89.80711,
+            "Z": -653.43713
+          },
+          "TerritoryId": 816,
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1031026,
+          "Position": {
+            "X": 354.69592,
+            "Y": 87.448784,
+            "Z": -711.7876
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031025,
+          "Position": {
+            "X": -79.75891,
+            "Y": 37.968338,
+            "Z": -531.8532
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "NextQuestId": 3429,
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3429_By Way of Reparation.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3429_By Way of Reparation.json
@@ -13,7 +13,23 @@
             "Z": -531.8532
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -79.75891,
+                  "Y": 37.968338,
+                  "Z": -531.8532
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -78,7 +94,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
           "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 37.76599,
+                  "Y": 53.890167,
+                  "Z": -649.2866
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          },
           "NextQuestId": 3430
         }
       ]

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3429_By Way of Reparation.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3429_By Way of Reparation.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1031025,
+          "Position": {
+            "X": -79.75891,
+            "Y": 37.968338,
+            "Z": -531.8532
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1027695,
+          "Position": {
+            "X": 441.64185,
+            "Y": 89.80711,
+            "Z": -653.43713
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1031028,
+          "Position": {
+            "X": 435.04993,
+            "Y": 89.67002,
+            "Z": -654.2916
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 2010484,
+          "Position": {
+            "X": 204.91333,
+            "Y": 73.502686,
+            "Z": -756.466
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1030716,
+          "Position": {
+            "X": 37.76599,
+            "Y": 53.890167,
+            "Z": -649.2866
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "NextQuestId": 3430
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3430_The Key Ingredient.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3430_The Key Ingredient.json
@@ -13,7 +13,23 @@
             "Z": -649.2866
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Pla Enni",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 37.76599,
+                  "Y": 53.890167,
+                  "Z": -649.2866
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -84,8 +100,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
-          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "StopDistance": 0.25,
           "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 440.26855,
+                  "Y": 90.109146,
+                  "Z": -651.2093
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          },
           "NextQuestId": 3431
         }
       ]

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3430_The Key Ingredient.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3430_The Key Ingredient.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1030716,
+          "Position": {
+            "X": 37.76599,
+            "Y": 53.890167,
+            "Z": -649.2866
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1031030,
+          "Position": {
+            "X": -390.82935,
+            "Y": 54.333584,
+            "Z": 434.92773
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1031087,
+          "Position": {
+            "X": -345.0523,
+            "Y": 27.132893,
+            "Z": 341.90894
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1031087,
+          "Position": {
+            "X": -345.0523,
+            "Y": 27.132893,
+            "Z": 341.90894
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZD104_03430_Q1_000_000",
+              "Answer": "TEXT_LUCKZD104_03430_A2_000_000"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031027,
+          "Position": {
+            "X": 440.26855,
+            "Y": 90.109146,
+            "Z": -651.2093
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "Fly": true,
+          "NextQuestId": 3431
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3431_A New Favorite.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3431_A New Favorite.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027695,
+          "Position": {
+            "X": 441.64185,
+            "Y": 89.80711,
+            "Z": -653.43713
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZD201_03431_Q1_000_000",
+              "Answer": "TEXT_LUCKZD201_03431_A1_000_000"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1031287,
+          "Position": {
+            "X": 378.71362,
+            "Y": 87.640625,
+            "Z": -643.4272
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1031288,
+          "Position": {
+            "X": -242.02338,
+            "Y": 22.781544,
+            "Z": 401.87683
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "Land": true,
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1031290,
+          "Position": {
+            "X": -508.17123,
+            "Y": 69.79544,
+            "Z": 520.2562
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 1031290,
+          "Position": {
+            "X": -508.17123,
+            "Y": 69.79544,
+            "Z": 520.2562
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 5,
+      "Steps": [
+        {
+          "DataId": 2010639,
+          "Position": {
+            "X": -625.57416,
+            "Y": 49.362915,
+            "Z": 345.3269
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        },
+        {
+          "DataId": 2010640,
+          "Position": {
+            "X": -427.02374,
+            "Y": 21.530457,
+            "Z": 216.6322
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 6,
+      "Steps": [
+        {
+          "$": "Ideally, we could remove the transparent effect to fly in this step. I'm not sure if that's currently possible",
+          "DataId": 1031290,
+          "Position": {
+            "X": -508.17123,
+            "Y": 69.79544,
+            "Z": 520.2562
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 7,
+      "Steps": [
+        {
+          "Position": {
+            "X": -777.891,
+            "Y": 47.54754,
+            "Z": 163.27303
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [ 11161, 11161, 11161 ],
+          "Land": true,
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 8,
+      "Steps": [
+        {
+          "DataId": 1031297,
+          "Position": {
+            "X": -777.4319,
+            "Y": 47.349903,
+            "Z": 165.78918
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027695,
+          "Position": {
+            "X": 441.64185,
+            "Y": 89.80711,
+            "Z": -653.43713
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3431_A New Favorite.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3431_A New Favorite.json
@@ -14,6 +14,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 441.64185,
+                  "Y": 89.80711,
+                  "Z": -653.43713
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          },
           "DialogueChoices": [
             {
               "Type": "List",
@@ -127,7 +143,8 @@
             "Z": 520.2562
           },
           "TerritoryId": 816,
-          "InteractionType": "Interact"
+          "InteractionType": "Interact",
+          "Fly": true
         }
       ]
     },
@@ -143,7 +160,9 @@
           "TerritoryId": 816,
           "InteractionType": "Combat",
           "EnemySpawnType": "AutoOnEnterArea",
-          "KillEnemyDataIds": [ 11161, 11161, 11161 ],
+          "KillEnemyDataIds": [
+            11161
+          ],
           "Land": true,
           "Fly": true
         }
@@ -176,8 +195,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
           "AetheryteShortcut": "Il Mheg - Wolekdorf",
-          "Fly": true
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 441.64185,
+                  "Y": 89.80711,
+                  "Z": -653.43713
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3432_Duplicity in the Depths.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3432_Duplicity in the Depths.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1031179,
+          "Position": {
+            "X": 353.84143,
+            "Y": 86.52623,
+            "Z": -691.2795
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2010715,
+          "Position": {
+            "X": -84.00098,
+            "Y": -86.56445,
+            "Z": -55.86328
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031179,
+          "Position": {
+            "X": 353.84143,
+            "Y": 86.52623,
+            "Z": -691.2795
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Wolekdorf"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3432_Duplicity in the Depths.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3432_Duplicity in the Depths.json
@@ -13,13 +13,39 @@
             "Z": -691.2795
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 353.84143,
+                  "Y": 86.52623,
+                  "Z": -691.2795
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
     {
       "Sequence": 1,
       "Steps": [
+        {
+          "Position": {
+            "X": -65.72714,
+            "Y": 1.4000998,
+            "Z": -38.895847
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "Fly": true
+        },
         {
           "DataId": 2010715,
           "Position": {
@@ -29,6 +55,8 @@
           },
           "TerritoryId": 816,
           "InteractionType": "Interact",
+          "StopDistance": 0.25,
+          "DisableNavmesh": true,
           "Fly": true
         }
       ]
@@ -45,7 +73,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
-          "AetheryteShortcut": "Il Mheg - Wolekdorf"
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 353.84143,
+                  "Y": 86.52623,
+                  "Z": -691.2795
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3433_Marks of the Monarch.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3433_Marks of the Monarch.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1031500,
+          "Position": {
+            "X": 366.90308,
+            "Y": 86.37964,
+            "Z": -753.2616
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2010717,
+          "Position": {
+            "X": 264.8507,
+            "Y": 27.725586,
+            "Z": -41.947144
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Emote",
+          "Emote": "lookout",
+          "Fly": true
+        },
+        {
+          "DataId": 2010716,
+          "Position": {
+            "X": 671.2595,
+            "Y": 107.07251,
+            "Z": -900.8774
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Emote",
+          "Emote": "lookout",
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031500,
+          "Position": {
+            "X": 366.90308,
+            "Y": 86.37964,
+            "Z": -753.2616
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "Fly": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZD203_03433_Q1_000_020",
+              "Answer": "TEXT_LUCKZD203_03433_A1_000_021"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3433_Marks of the Monarch.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3433_Marks of the Monarch.json
@@ -13,7 +13,23 @@
             "Z": -753.2616
           },
           "TerritoryId": 816,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 366.90308,
+                  "Y": 86.37964,
+                  "Z": -753.2616
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     },
@@ -59,8 +75,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
-          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "StopDistance": 0.25,
           "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 366.90308,
+                  "Y": 86.37964,
+                  "Z": -753.2616
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          },
           "DialogueChoices": [
             {
               "Type": "List",

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3434_An Eggshell a Day.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3434_An Eggshell a Day.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Clockwise Starr",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027691,
+          "Position": {
+            "X": 416.80017,
+            "Y": 87.947784,
+            "Z": -751.09485
+          },
+          "TerritoryId": 816,
+          "InteractionType": "AcceptQuest",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZD204_03434_Q1_000_020",
+              "Answer": "TEXT_LUCKZD204_03434_A1_000_022"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "$": "Attempt to avoid Garden Crocota combat",
+          "Position": {
+            "X": 602.7202,
+            "Y": 123.73922,
+            "Z": -860.4524
+          },
+          "TerritoryId": 816,
+          "InteractionType": "None",
+          "StopDistance": 0.25,
+          "Land": true,
+          "Fly": true
+        },
+        {
+          "DataId": 2010721,
+          "Position": {
+            "X": 600.4271,
+            "Y": 111.283936,
+            "Z": -857.8469
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        },
+        {
+          "DataId": 2010718,
+          "Position": {
+            "X": 620.2639,
+            "Y": 109.147705,
+            "Z": -871.1223
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 2010719,
+          "Position": {
+            "X": 642.75574,
+            "Y": 109.941284,
+            "Z": -827.4815
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 2010720,
+          "Position": {
+            "X": 625.4824,
+            "Y": 109.69714,
+            "Z": -824.9485
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027691,
+          "Position": {
+            "X": 416.80017,
+            "Y": 87.947784,
+            "Z": -751.09485
+          },
+          "TerritoryId": 816,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3434_An Eggshell a Day.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/Il Mheg/3434_An Eggshell a Day.json
@@ -14,6 +14,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "AcceptQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
+          "AetheryteShortcut": "Il Mheg - Wolekdorf",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 416.80017,
+                  "Y": 87.947784,
+                  "Z": -751.09485
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          },
           "DialogueChoices": [
             {
               "Type": "List",
@@ -48,7 +64,17 @@
             "Z": -857.8469
           },
           "TerritoryId": 816,
-          "InteractionType": "Interact"
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "High": 1
+            }
+          ]
         },
         {
           "DataId": 2010718,
@@ -59,6 +85,16 @@
           },
           "TerritoryId": 816,
           "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "High": 8
+            }
+          ],
           "Fly": true
         },
         {
@@ -70,6 +106,16 @@
           },
           "TerritoryId": 816,
           "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "High": 4
+            }
+          ],
           "Fly": true
         },
         {
@@ -80,7 +126,17 @@
             "Z": -824.9485
           },
           "TerritoryId": 816,
-          "InteractionType": "Interact"
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "High": 2
+            }
+          ]
         }
       ]
     },
@@ -96,8 +152,22 @@
           },
           "TerritoryId": 816,
           "InteractionType": "CompleteQuest",
+          "StopDistance": 0.25,
+          "Fly": true,
           "AetheryteShortcut": "Il Mheg - Wolekdorf",
-          "Fly": true
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 416.80017,
+                  "Y": 87.947784,
+                  "Z": -751.09485
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 200
+              }
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
Adds 31 sidequests from Il Mheg.

I have already completed 7 of the quests, so I couldn't create the paths myself.

For the quest "3408_Scents of Security" it seems like the CW flags go from "0 16 0 0 0 0 -> 0 0 0 0 0 0" when you use the quest item, but I can't get the "CompletionQuestVariablesFlags" to work with this.
I've been trying:
"CompletionQuestVariablesFlags": [
  null,
  0,
  null,
  null,
  null,
  null
]

Which won't even load the questpath. I admit I don't really know how the flags work. 
If I just put all null values, it will load the quest path successfully and the quest will try to use the item a second time with an error, and then it will continue to completion, so maybe I can just do that. 

I haven't included quest 3408 in the pull request because of the issues. Let me know if I should add the null version that technically works.