### PR TITLE
Update quest parameters for Urqopacha side quests

### DIFF
--- a/QuestPaths/7.x - Dawntrail/Side Quests/Urqopacha/5056_Sparks of Joy.json
+++ b/QuestPaths/7.x - Dawntrail/Side Quests/Urqopacha/5056_Sparks of Joy.json
@@ -15,6 +15,21 @@
           "StopDistance": 5,
           "TerritoryId": 1187,
           "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Urqopacha - Worlar's Echo",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "TerritoryId": 1187,
+                "Position": {
+                  "X": 425.07043,
+                  "Y": 118.935005,
+                  "Z": 606.13403
+                },
+                "MaximumDistance": 50
+              }
+            }
+          },
           "DialogueChoices": [
             {
               "Type": "List",

--- a/QuestPaths/7.x - Dawntrail/Side Quests/Urqopacha/5057_A Giant's Footsteps.json
+++ b/QuestPaths/7.x - Dawntrail/Side Quests/Urqopacha/5057_A Giant's Footsteps.json
@@ -53,7 +53,8 @@
           },
           "TerritoryId": 1187,
           "InteractionType": "WaitForNpcAtPosition",
-          "NpcWaitDistance": 6,
+          "NpcWaitDistance": 8,
+          "StopDistance": 1,
           "Mount": false,
           "Sprint": false
         },
@@ -66,7 +67,8 @@
           },
           "TerritoryId": 1187,
           "InteractionType": "WaitForNpcAtPosition",
-          "NpcWaitDistance": 6,
+          "NpcWaitDistance": 8,
+          "StopDistance": 1,
           "Mount": false,
           "Sprint": false
         },
@@ -79,7 +81,8 @@
           },
           "TerritoryId": 1187,
           "InteractionType": "WaitForNpcAtPosition",
-          "NpcWaitDistance": 6,
+          "NpcWaitDistance": 8,
+          "StopDistance": 1,
           "Mount": false,
           "Sprint": false
         },
@@ -122,7 +125,8 @@
           },
           "TerritoryId": 1187,
           "InteractionType": "WaitForNpcAtPosition",
-          "NpcWaitDistance": 6.5,
+          "NpcWaitDistance": 8,
+          "StopDistance": 1,
           "Mount": false,
           "Sprint": false
         },
@@ -135,7 +139,8 @@
           },
           "TerritoryId": 1187,
           "InteractionType": "WaitForNpcAtPosition",
-          "NpcWaitDistance": 6.5,
+          "NpcWaitDistance": 8,
+          "StopDistance": 1,
           "Mount": false,
           "Sprint": false
         },


### PR DESCRIPTION
Added flying and aetheryte shortcut options to 'Sparks of Joy' quest, including skip conditions based on player position. Adjusted NPC wait distances and stop distances for multiple steps in 'A Giant's Footsteps' quest to improve quest flow and accuracy.