### PR TITLE
2639: Added dismount on last sequence step

### DIFF
--- a/QuestPaths/4.x - Stormblood/Aether Currents/The Fringes/2639_Magiteknical Failure.json
+++ b/QuestPaths/4.x - Stormblood/Aether Currents/The Fringes/2639_Magiteknical Failure.json
@@ -80,6 +80,15 @@
       "Sequence": 255,
       "Steps": [
         {
+          "Position": {
+            "X": -653.0099,
+            "Y": 129.91537,
+            "Z": -510.67374
+          },
+          "TerritoryId": 612,
+          "InteractionType": "WalkTo"
+        },
+        {
           "DataId": 1019517,
           "Position": {
             "X": -653.0099,
@@ -87,6 +96,7 @@
             "Z": -510.67374
           },
           "TerritoryId": 612,
+          "Mount": false,
           "InteractionType": "CompleteQuest",
           "AetheryteShortcut": "Fringes - Castrum Oriens"
         }

--- a/QuestPaths/4.x - Stormblood/Aether Currents/The Fringes/2639_Magiteknical Failure.json
+++ b/QuestPaths/4.x - Stormblood/Aether Currents/The Fringes/2639_Magiteknical Failure.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
-  "Author": "JerryWester",
+  "Author": ["JerryWester", "Oblituarius"],
   "QuestSequence": [
     {
       "Sequence": 0,


### PR DESCRIPTION
On ending sequence, there was only a step0 with a `CompleteQuest` interaction.
I've added a new step0 and moved the previous one to step1.
Now we should:
- WalkTo position (remains Mounted)
- Dismount at position (`"Mount": false`)
- CompleteQuest
This should hopefully prevent from being unable to interact with the NPC while still mounted on the Magitek Armor.
Added myself as contributor to the path file.