### PR TITLE
Pathing fix for 522

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/MSQ-2/C6-Mor Dhona/522_The Black Wolf's Ultimatum.json
+++ b/QuestPaths/2.x - A Realm Reborn/MSQ-2/C6-Mor Dhona/522_The Black Wolf's Ultimatum.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
-  "Author": "JerryWester",
+  "Author": [
+    "JerryWester",
+    "Kiarra"
+  ],
   "QuestSequence": [
     {
       "Sequence": 0,
@@ -21,6 +24,16 @@
     {
       "Sequence": 1,
       "Steps": [
+        {
+          "Position": {
+            "X": -139.75781,
+            "Y": -3.288031,
+            "Z": -175.0319
+          },
+          "TerritoryId": 130,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Ul'dah"
+        },
         {
           "DataId": 1001821,
           "Position": {


### PR DESCRIPTION
Add step to walk to the Ul'dah Aetheryte to make it teleport out of the airship mini zone it otherwise gets stuck trying to walk into the void.