### PR TITLE
QoL changes to 141 and 568

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,2 @@
-- Add missing Sightseeing logs Shb(3604) EW(4174) by Kiarra
-- 194 Unicorn power CNJ specific quest by Kiarra
-- Fix angle on gathering node by alydev
-- Add recovery to some tribe quests by alydev
+- 141: Add support for HQ item delivery by Oblituarius
+- 568: Accept 253 is now automatic by Oblituarius

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup Condition="$(MSBuildProjectName) != 'GatheringPathRenderer'">
-        <Version>6.28.37.0</Version>
+        <Version>6.28.38.0</Version>
     </PropertyGroup>
 </Project>

--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/CRP/141_A Carpenter in Need.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/CRP/141_A Carpenter in Need.json
@@ -66,6 +66,7 @@
           },
           "TerritoryId": 132,
           "InteractionType": "Interact",
+          "AllowHighQuality": true,
           "AethernetShortcut": [
             "[Gridania] Aetheryte Plaza",
             "[Gridania] Archers' Guild"
@@ -93,6 +94,7 @@
           },
           "TerritoryId": 133,
           "InteractionType": "Interact",
+          "AllowHighQuality": true,
           "AethernetShortcut": [
             "[Gridania] Archers' Guild",
             "[Gridania] Lancers' Guild"

--- a/QuestPaths/2.x - A Realm Reborn/MSQ-1/Ul'dah/568_GLA_Close to Home.json
+++ b/QuestPaths/2.x - A Realm Reborn/MSQ-1/Ul'dah/568_GLA_Close to Home.json
@@ -165,8 +165,14 @@
           "TerritoryId": 131,
           "InteractionType": "AcceptQuest",
           "PickUpQuestId": 253,
-          "Comment": "Manual interaction required on 'yes'",
-          "$": "No clue why this requires manual. Tried copying DialogueChoices from 253, got a NPE. -aly"
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "ExcelSheet": "quest/001/ClsGla001_00177",
+              "Prompt": 50,
+              "Yes": true
+            }
+          ]
         },
         {
           "DataId": 1001353,


### PR DESCRIPTION
- 141: Add support for HQ item delivery:
  - Allowing HQ item delivery just in case.
- 568: Accept 253 is now automatic:
  - No longer need manual interaction on this quest thanks to the new raw sheet support.