### PR TITLE
Fix race condition when interacting with NPCs after combat

### DIFF
--- a/Questionable/Controller/Steps/Interactions/Interact.cs
+++ b/Questionable/Controller/Steps/Interactions/Interact.cs
@@ -278,6 +278,14 @@ internal static class Interact
 
         public override bool ShouldInterruptOnDamage() => true;
 
+        public override bool WasInterrupted()
+        {
+            if (condition[ConditionFlag.InCombat])
+                return true;
+
+            return base.WasInterrupted();
+        }
+
         private enum EInteractionState
         {
             None,


### PR DESCRIPTION
 `Interact.cs`: Added combat check in `DoInteract.WasInterrupted()`