### PR TITLE
7,4 msq fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
 Fixes applied for quest sheet check (most things back to normal again)
+
 - Tiny change to Starlight quest -Kiarra
 - Add 3200 A Lone Wolf No More (Stormblood ex mount quest) -Kiarra
+- Fix 7.4 MSQ quests -Gezah
+

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup Condition="$(MSBuildProjectName) != 'GatheringPathRenderer'">
-        <Version>14.200.7.0</Version>
+        <Version>14.200.8.0</Version>
     </PropertyGroup>
 </Project>

--- a/QuestPaths/7.x - Dawntrail/MSQ/J-7.4/5426_With the Winds.json
+++ b/QuestPaths/7.x - Dawntrail/MSQ/J-7.4/5426_With the Winds.json
@@ -37,7 +37,7 @@
           "TargetTerritoryId": 1207,
           "AetheryteShortcut": "Solution Nine",
           "AethernetShortcut": [
-            "[Solution Nine] Resolution",
+            "[Solution Nine] Aetheryte Plaza",
             "[Solution Nine] Neon Stein"
           ],
           "SkipConditions": {
@@ -90,7 +90,7 @@
       "Sequence": 3,
       "Steps": [
         {
-          "DataId": 1056119,
+          "DataId": 2014993,
           "Position": {
             "X": 129.9068,
             "Y": -16.56085,

--- a/QuestPaths/7.x - Dawntrail/MSQ/J-7.4/5428_Beyond the Mountains.json
+++ b/QuestPaths/7.x - Dawntrail/MSQ/J-7.4/5428_Beyond the Mountains.json
@@ -60,8 +60,23 @@
         }
       ]
     },
-    {
+	{
       "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 1056149,
+          "Position": {
+            "X": 274.6471,
+            "Y": -115.97899,
+            "Z": -460.83777
+          },
+          "TerritoryId": 1332,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 5,
       "Steps": [
         {
           "Position": {

--- a/QuestPaths/7.x - Dawntrail/MSQ/J-7.4/5431_In Her Heart.json
+++ b/QuestPaths/7.x - Dawntrail/MSQ/J-7.4/5431_In Her Heart.json
@@ -66,7 +66,7 @@
       "Sequence": 4,
       "Steps": [
         {
-          "DataId": 1056167,
+          "DataId": 1056267,
           "Position": {
             "X": 325.18494,
             "Y": -117.5,

--- a/QuestPaths/7.x - Dawntrail/MSQ/J-7.4/5433_Where We Call Home.json
+++ b/QuestPaths/7.x - Dawntrail/MSQ/J-7.4/5433_Where We Call Home.json
@@ -29,7 +29,15 @@
           },
           "TerritoryId": 1332,
           "InteractionType": "Interact",
-          "TargetTerritoryId": 1338
+          "TargetTerritoryId": 1338,
+		  "DialogueChoices":
+			[
+			{
+				"Prompt": "TEXT_KINGMJ108_05433_SYSTEM_000_032",
+				"Type": "YesNo",
+				"Yes": true
+			}
+			]
         }
       ]
     },
@@ -49,6 +57,38 @@
         }
       ]
     },
-    {"Sequence":255}
+	{
+      "Sequence": 4
+    },
+	{
+      "Sequence": 5,
+      "Steps": [
+        {
+          "DataId": 1056268,
+          "Position": {
+            "X": 264.7898,
+            "Y": -115,
+            "Z": -630.7317
+          },
+          "TerritoryId": 1332,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1056175,
+          "Position": {
+            "X": 280.59814,
+            "Y": -115.97899,
+            "Z": -422.78174
+          },
+          "TerritoryId": 1332,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
   ]
 }

--- a/QuestPaths/7.x - Dawntrail/MSQ/J-7.4/5434_Into the Mist.json
+++ b/QuestPaths/7.x - Dawntrail/MSQ/J-7.4/5434_Into the Mist.json
@@ -1,9 +1,86 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "alydev",
-  "Disabled": true,
-  "Comment": "WIP",
   "QuestSequence": [
-
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1056175,
+          "Position": {
+            "X": 280.59814,
+            "Y": -115.97899,
+            "Z": -422.78174
+          },
+          "TerritoryId": 1332,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1056179,
+          "Position": {
+            "X": 281.17798,
+            "Y": -115,
+            "Z": -643.061
+          },
+          "TerritoryId": 1332,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+	{
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2014998,
+          "Position": {
+            "X": 281.0471,
+            "Y": -98,
+            "Z": -277.821
+          },
+          "TerritoryId": 1332,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+	{
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1056190,
+          "Position": {
+            "X": -1.8158569,
+            "Y": 53.200012,
+            "Z": 768.24585
+          },
+          "TerritoryId": 1192,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1056199,
+          "Position": {
+            "X": 17.31897,
+            "Y": 38.80659,
+            "Z": -410.5135
+          },
+          "TerritoryId": 1186,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Solution Nine",
+          "AethernetShortcut": [
+            "[Solution Nine] Aetheryte Plaza",
+            "[Solution Nine] Resolution"
+          ]
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Following Quests edited:
5426 - Fixed not using the athernet on Solution Nine in sequence 1 resulting of running into a wall and not interacting with the waiting point in Tuliyolal in sequence 3
5428 - Fixed use item being in sequence 4 instead of 5
5431 - Fixed wrong DataID in sequence 4
5433 - Fixed not entering Bentini Depot in sequence 1 and fixed to turn in the quest in sequence 255. Added sequence 5, but only set it to interact with the NPC that starts the Solo Duty, not actually starting the Solo Duty
5434 - Added QuestPath
