### PR TITLE
AAC Heavyweight M1-M4 Raid Quests

### DIFF
--- a/QuestPaths/7.x - Dawntrail/Raid Quests/5436_The Breathtaker.json
+++ b/QuestPaths/7.x - Dawntrail/Raid Quests/5436_The Breathtaker.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Akechi",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1053745,
+          "Position": {
+            "X": 1.6326294,
+            "Y": -2.9191749E-12,
+            "Z": -12.466675
+          },
+          "StopDistance": 5,
+          "TerritoryId": 1224,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "TerritoryId": 1224,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": false,
+            "ContentFinderConditionId": 1068
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1053792,
+          "Position": {
+            "X": 1.9683228,
+            "Y": -2.3974921E-12,
+            "Z": -11.12384
+          },
+          "StopDistance": 5,
+          "TerritoryId": 1224,
+          "InteractionType": "CompleteQuest",
+          "NextQuestId": 5437
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/7.x - Dawntrail/Raid Quests/5437_Daring Devils.json
+++ b/QuestPaths/7.x - Dawntrail/Raid Quests/5437_Daring Devils.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Akechi",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1053792,
+          "Position": {
+            "X": 1.9683228,
+            "Y": -2.3974921E-12,
+            "Z": -11.12384
+          },
+          "StopDistance": 5,
+          "TerritoryId": 1224,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2013722,
+          "Position": {
+            "X": -0.07635498,
+            "Y": 1.0527954,
+            "Z": 8.102478
+          },
+          "TerritoryId": 1224,
+          "InteractionType": "Interact",
+          "TargetTerritoryId": 1186
+        },
+        {
+          "DataId": 1056304,
+          "Position": {
+            "X": 491.32507,
+            "Y": 59.55,
+            "Z": 128.09949
+          },
+          "TerritoryId": 1186,
+          "InteractionType": "Interact",
+          "AethernetShortcut": [
+            "[Solution Nine] The Arcadion",
+            "[Solution Nine] True Vue"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2013725,
+          "Position": {
+            "X": 4.0740967,
+            "Y": 0.8086548,
+            "Z": 10.574402
+          },
+          "TerritoryId": 1223,
+          "InteractionType": "Interact",
+          "TargetTerritoryId": 1186,
+          "SkipConditions": {
+            "StepIf": {
+              "NotInTerritory": [
+                1223
+              ]
+            }
+          }
+        },
+        {
+          "DataId": 1049793,
+          "Position": {
+            "X": 364.3396,
+            "Y": 60.125,
+            "Z": 357.1068
+          },
+          "TerritoryId": 1186,
+          "InteractionType": "Interact",
+          "AethernetShortcut": [
+            "[Solution Nine] True Vue",
+            "[Solution Nine] The Arcadion"
+          ],
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": null,
+              "Yes": true
+            }
+          ]
+        },
+        {
+          "DataId": 1053745,
+          "Position": {
+            "X": 1.6326294,
+            "Y": -2.9191749E-12,
+            "Z": -12.466675
+          },
+          "TerritoryId": 1224,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "TerritoryId": 1224,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": false,
+            "ContentFinderConditionId": 1070
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1053792,
+          "Position": {
+            "X": 1.9683228,
+            "Y": -2.3974921E-12,
+            "Z": -11.12384
+          },
+          "StopDistance": 5,
+          "TerritoryId": 1224,
+          "InteractionType": "CompleteQuest",
+          "NextQuestId": 5438
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/7.x - Dawntrail/Raid Quests/5438_Challenger and Champion.json
+++ b/QuestPaths/7.x - Dawntrail/Raid Quests/5438_Challenger and Champion.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Akechi",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1053792,
+          "Position": {
+            "X": 1.9683228,
+            "Y": -2.3974921E-12,
+            "Z": -11.12384
+          },
+          "StopDistance": 5,
+          "TerritoryId": 1224,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1056307,
+          "Position": {
+            "X": 4.257263,
+            "Y": 0,
+            "Z": -6.4851074
+          },
+          "TerritoryId": 1344,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2015047,
+          "Position": {
+            "X": 4.0749,
+            "Y": 0.81,
+            "Z": 10.5759
+          },
+          "TerritoryId": 1344,
+          "InteractionType": "Interact",
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": null,
+              "Yes": true
+            }
+          ]
+        },
+        {
+          "DataId": 1056308,
+          "Position": {
+            "X": 491.1726,
+            "Y": 59.549995,
+            "Z": 123.91846
+          },
+          "TerritoryId": 1186,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1056310,
+          "Position": {
+            "X": 391.4701,
+            "Y": 60,
+            "Z": 75.42529
+          },
+          "TerritoryId": 1186,
+          "InteractionType": "Interact"
+        },
+        {
+          "DataId": 1056311,
+          "Position": {
+            "X": 379.99524,
+            "Y": 50.749996,
+            "Z": 172.0149
+          },
+          "TerritoryId": 1186,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [ null, null, null, null, null, 64 ]
+        },
+        {
+          "DataId": 1056312,
+          "Position": {
+            "X": 340.81018,
+            "Y": 50.75,
+            "Z": 278.43127
+          },
+          "TerritoryId": 1186,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [ null, null, null, null, null, 16 ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1049787,
+          "Position": {
+            "X": 364.3396,
+            "Y": 60.125,
+            "Z": 357.1068
+          },
+          "TerritoryId": 1186,
+          "InteractionType": "CompleteQuest",
+          "NextQuestId": 5439
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/7.x - Dawntrail/Raid Quests/5439_Iron Fist.json
+++ b/QuestPaths/7.x - Dawntrail/Raid Quests/5439_Iron Fist.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Akechi",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1053745,
+          "Position": {
+            "X": 1.6326294,
+            "Y": -2.9191749E-12,
+            "Z": -12.466675
+          },
+          "StopDistance": 5,
+          "TerritoryId": 1224,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "TerritoryId": 1224,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": false,
+            "ContentFinderConditionId": 1072
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1053792,
+          "Position": {
+            "X": 1.9683228,
+            "Y": -2.3974921E-12,
+            "Z": -11.12384
+          },
+          "TerritoryId": 1224,
+          "InteractionType": "CompleteQuest",
+          "NextQuestId": 5440
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/7.x - Dawntrail/Raid Quests/5440_Glory Incarnate.json
+++ b/QuestPaths/7.x - Dawntrail/Raid Quests/5440_Glory Incarnate.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Akechi",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1053792,
+          "Position": {
+            "X": 1.9683228,
+            "Y": -2.3974921E-12,
+            "Z": -11.12384
+          },
+          "StopDistance": 5,
+          "TerritoryId": 1224,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "TerritoryId": 1224,
+          "InteractionType": "Duty",
+          "DutyOptions": {
+            "Enabled": false,
+            "ContentFinderConditionId": 1074
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1056316,
+          "Position": {
+            "X": -3.5858765,
+            "Y": 0.25695172,
+            "Z": -4.3793945
+          },
+          "TerritoryId": 1223,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 1049793,
+          "Position": {
+            "X": 364.3396,
+            "Y": 60.125,
+            "Z": 357.1068
+          },
+          "TerritoryId": 1186,
+          "InteractionType": "Interact",
+          "AethernetShortcut": [
+            "[Solution Nine] True Vue",
+            "[Solution Nine] The Arcadion"
+          ],
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": null,
+              "Yes": true
+            }
+          ]
+        },
+        {
+          "DataId": 1058423,
+          "Position": {
+            "X": -0.015319824,
+            "Y": -3.1291775E-12,
+            "Z": -15.42688
+          },
+          "TerritoryId": 1224,
+          "InteractionType": "Interact",
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": null,
+              "Yes": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1058424,
+          "Position": {
+            "X": 494.7433,
+            "Y": 59.55,
+            "Z": 125.10864
+          },
+          "TerritoryId": 1186,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/quest-v1.json
+++ b/QuestPaths/quest-v1.json
@@ -1546,7 +1546,8 @@
                           "Prompt": {
                             "type": [
                               "string",
-                              "integer"
+                              "integer",
+                              "null"
                             ]
                           },
                           "PromptIsRegularExpression": {

--- a/Questionable/Controller/GameUi/InteractionUiController.cs
+++ b/Questionable/Controller/GameUi/InteractionUiController.cs
@@ -593,7 +593,11 @@ internal sealed class InteractionUiController : IDisposable
 
         string? actualPrompt = addonSelectYesno->AtkUnitBase.AtkValues[0].ReadAtkString();
         if (actualPrompt == null)
+        {
+            //force Yes if prompt is set to `null` while an answer is still given - basically means no key is available for this said prompt yet
+            addonSelectYesno->AtkUnitBase.FireCallbackInt(0);
             return;
+        }
 
         _logger.LogTrace("Prompt: '{Prompt}'", actualPrompt);
         if (_shopController.IsAwaitingYesNo && _purchaseItemRegex.IsMatch(actualPrompt))
@@ -683,6 +687,14 @@ internal sealed class InteractionUiController : IDisposable
         {
             if (dialogueChoice.Type != EDialogChoiceType.YesNo)
                 continue;
+
+            //force Yes if prompt is set to `null` while an answer is still given - basically means no key is available on sheets yet
+            if (dialogueChoice.Prompt == null && dialogueChoice.Yes)
+            {
+                _logger.LogInformation("Forcing Yes because no key for this prompt is currently available.");
+                addonSelectYesno->AtkUnitBase.FireCallbackInt(0);
+                return true;
+            }
 
             if (dialogueChoice.DataId != null && dialogueChoice.DataId != GameFunctions.GetBaseID(_targetManager.Target))
             {

--- a/Questionable/Controller/GameUi/InteractionUiController.cs
+++ b/Questionable/Controller/GameUi/InteractionUiController.cs
@@ -593,11 +593,7 @@ internal sealed class InteractionUiController : IDisposable
 
         string? actualPrompt = addonSelectYesno->AtkUnitBase.AtkValues[0].ReadAtkString();
         if (actualPrompt == null)
-        {
-            //force Yes if prompt is set to `null` while an answer is still given - basically means no key is available for this said prompt yet
-            addonSelectYesno->AtkUnitBase.FireCallbackInt(0);
             return;
-        }
 
         _logger.LogTrace("Prompt: '{Prompt}'", actualPrompt);
         if (_shopController.IsAwaitingYesNo && _purchaseItemRegex.IsMatch(actualPrompt))

--- a/Questionable/Validation/Validators/DialogueChoiceValidator.cs
+++ b/Questionable/Validation/Validators/DialogueChoiceValidator.cs
@@ -18,9 +18,9 @@ internal sealed class DialogueChoiceValidator(ExcelFunctions excelFunctions) : I
 
             foreach (var dialogueChoice in x.Step.DialogueChoices)
             {
-                // Skip Excel validation entirely if it's a YesNo with null prompt
+                //skip validation if `YesNo` with `null` prompt
                 if (dialogueChoice.Type == EDialogChoiceType.YesNo && 
-                    dialogueChoice.Answer != null &&
+                    dialogueChoice.Answer != null && //most likely going to be a Yes
                     dialogueChoice.Prompt == null)
                     continue;
 

--- a/Questionable/Validation/Validators/DialogueChoiceValidator.cs
+++ b/Questionable/Validation/Validators/DialogueChoiceValidator.cs
@@ -18,6 +18,12 @@ internal sealed class DialogueChoiceValidator(ExcelFunctions excelFunctions) : I
 
             foreach (var dialogueChoice in x.Step.DialogueChoices)
             {
+                // Skip Excel validation entirely if it's a YesNo with null prompt
+                if (dialogueChoice.Type == EDialogChoiceType.YesNo && 
+                    dialogueChoice.Answer != null &&
+                    dialogueChoice.Prompt == null)
+                    continue;
+
                 ExcelRef? prompt = dialogueChoice.Prompt;
                 if (prompt != null)
                 {


### PR DESCRIPTION
- [x] Adjusted `YesNo` prompts - schema now allows `null` entry for `YesNo` prompts but will only work with `Yes` answers
- [x] Added `AAC Heavyweight` raid quests