### PR TITLE
Update `LangVersion` to the version used

### DIFF
--- a/GatheringPaths/GatheringPaths.csproj
+++ b/GatheringPaths/GatheringPaths.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net10.0-windows</TargetFramework>
-        <LangVersion>12</LangVersion>
+        <LangVersion>13</LangVersion>
         <Nullable>enable</Nullable>
         <RootNamespace>Questionable.GatheringPaths</RootNamespace>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/QuestPathGenerator.Tests/QuestPathGenerator.Tests.csproj
+++ b/QuestPathGenerator.Tests/QuestPathGenerator.Tests.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <LangVersion>12</LangVersion>
+        <LangVersion>13</LangVersion>
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/QuestPathGenerator/QuestPathGenerator.csproj
+++ b/QuestPathGenerator/QuestPathGenerator.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <IsPackable>false</IsPackable>
-        <LangVersion>12</LangVersion>
+        <LangVersion>13</LangVersion>
         <Nullable>enable</Nullable>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <RootNamespace>Questionable.QuestPathGenerator</RootNamespace>

--- a/QuestPaths/QuestPaths.csproj
+++ b/QuestPaths/QuestPaths.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
-        <LangVersion>12</LangVersion>
+        <LangVersion>13</LangVersion>
         <Nullable>enable</Nullable>
         <RootNamespace>Questionable.QuestPaths</RootNamespace>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/Questionable.Model/Questionable.Model.csproj
+++ b/Questionable.Model/Questionable.Model.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <LangVersion>12</LangVersion>
+        <LangVersion>13</LangVersion>
         <Nullable>enable</Nullable>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <PathMap Condition="$(SolutionDir) != ''">$(SolutionDir)=X:\</PathMap>


### PR DESCRIPTION
> [!Important]
> Needs qstxiv/LLib#2

This project uses at least one C#13 Feature: [`ref struct` interfaces](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13#ref-struct-interfaces); not certain why or how this is out of date.

Personally I'd update this to the current version, 14, but this is all that is currently used and needs to be updated, so I wasn't going to step behind that.

@WigglyMuffin Perhaps you want to implement this as well.