### PR TITLE
Lominsan Side Quests

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/Side Quests/La Noscea/Limsa/118_Licensed to Reave.json
+++ b/QuestPaths/2.x - A Realm Reborn/Side Quests/La Noscea/Limsa/118_Licensed to Reave.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "h-y3na",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1000916,
+          "Position": {
+            "X": 1.7547607,
+            "Y": 43.999996,
+            "Z": -164.23291
+          },
+          "TerritoryId": 128,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Limsa Lominsa",
+          "AethernetShortcut": [
+            "[Limsa Lominsa] Aetheryte Plaza",
+            "[Limsa Lominsa] Marauders' Guild"
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                128,
+                129
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1000915,
+          "Position": {
+            "X": 18.387085,
+            "Y": 47.600006,
+            "Z": -162.12714
+          },
+          "TerritoryId": 128,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1000938,
+          "Position": {
+            "X": -4.654114,
+            "Y": 44.999847,
+            "Z": -241.84027
+          },
+          "TerritoryId": 128,
+          "InteractionType": "Interact"
+        },
+        {
+          "DataId": 1000947,
+          "Position": {
+            "X": -54.64258,
+            "Y": 44.000008,
+            "Z": -151.23218
+          },
+          "TerritoryId": 128,
+          "InteractionType": "Interact",
+          "AethernetShortcut": [
+            "[Limsa Lominsa] Marauders' Guild",
+            "[Limsa Lominsa] Culinarians' Guild"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1000915,
+          "Position": {
+            "X": 18.387085,
+            "Y": 47.600006,
+            "Z": -162.12714
+          },
+          "TerritoryId": 128,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Side Quests/La Noscea/Limsa/119_Lost and Found.json
+++ b/QuestPaths/2.x - A Realm Reborn/Side Quests/La Noscea/Limsa/119_Lost and Found.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "h-y3na",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1000938,
+          "Position": {
+            "X": -4.654114,
+            "Y": 44.999847,
+            "Z": -241.84027
+          },
+          "TerritoryId": 128,
+          "InteractionType": "AcceptQuest",
+          "AethernetShortcut": [
+            "[Limsa Lominsa] Aetheryte Plaza",
+            "[Limsa Lominsa] Marauders' Guild"
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                128,
+                129
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1002433,
+          "Position": {
+            "X": -6.729248,
+            "Y": 20.333345,
+            "Z": -0.7477417
+          },
+          "TerritoryId": 129,
+          "InteractionType": "CompleteQuest",
+          "AethernetShortcut": [
+            "[Limsa Lominsa] Marauders' Guild",
+            "[Limsa Lominsa] Aetheryte Plaza"
+          ],
+          "NextQuestId": 120
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Side Quests/La Noscea/Limsa/120_I Stay the Streetlight.json
+++ b/QuestPaths/2.x - A Realm Reborn/Side Quests/La Noscea/Limsa/120_I Stay the Streetlight.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "h-y3na",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1002434,
+          "Position": {
+            "X": -6.7597656,
+            "Y": 20.333345,
+            "Z": 0.5340576
+          },
+          "TerritoryId": 129,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Limsa Lominsa",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2001578,
+          "Position": {
+            "X": -67.083435,
+            "Z": 16.706673,
+            "Y": 18.000334
+          },
+          "StopDistance": 0.25,
+          "TerritoryId": 129,
+          "InteractionType": "UseItem",
+          "ItemId": 2000444
+        },
+        {
+          "DataId": 2001572,
+          "Position": {
+            "X": -65.38495,
+            "Y": 21.560913,
+            "Z": 54.398315
+          },
+          "TerritoryId": 129,
+          "InteractionType": "UseItem",
+          "ItemId": 2000444
+        },
+        {
+          "DataId": 2001573,
+          "Position": {
+            "X": -84.397705,
+            "Y": 21.499878,
+            "Z": 81.16272
+          },
+          "TerritoryId": 129,
+          "InteractionType": "UseItem",
+          "ItemId": 2000444
+        },
+        {
+          "DataId": 2001574,
+          "Position": {
+            "X": -117.66235,
+            "Y": 21.591492,
+            "Z": 134.93542
+          },
+          "TerritoryId": 129,
+          "InteractionType": "UseItem",
+          "ItemId": 2000444
+        },
+        {
+          "DataId": 2001575,
+          "Position": {
+            "X": -145.34222,
+            "Y": 22.934265,
+            "Z": 159.71619
+          },
+          "TerritoryId": 129,
+          "InteractionType": "UseItem",
+          "ItemId": 2000444
+        },
+        {
+          "DataId": 2001576,
+          "Position": {
+            "X": -162.49341,
+            "Y": 15.060608,
+            "Z": 136.5835
+          },
+          "TerritoryId": 129,
+          "InteractionType": "UseItem",
+          "ItemId": 2000444
+        },
+        {
+          "DataId": 2001577,
+          "Position": {
+            "X": -137.5296,
+            "Y": 9.781006,
+            "Z": 170.6416
+          },
+          "TerritoryId": 129,
+          "InteractionType": "UseItem",
+          "ItemId": 2000444
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1000857,
+          "Position": {
+            "X": -165.27051,
+            "Y": 5.2500057,
+            "Z": 164.29382
+          },
+          "TerritoryId": 129,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Side Quests/La Noscea/Limsa/122_Glory Days.json
+++ b/QuestPaths/2.x - A Realm Reborn/Side Quests/La Noscea/Limsa/122_Glory Days.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "h-y3na",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1003601,
+          "Position": {
+            "X": -3.2807007,
+            "Y": 39.51757,
+            "Z": -9.414856
+          },
+          "TerritoryId": 128,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Limsa Lominsa",
+          "AethernetShortcut": [
+            "[Limsa Lominsa] Aetheryte Plaza",
+            "[Limsa Lominsa] The Aftcastle"
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                128,
+                129
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1001024,
+          "Position": {
+            "X": 28.519043,
+            "Y": 44.499977,
+            "Z": 176.3789
+          },
+          "TerritoryId": 128,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": 24.89683,
+            "Z": 181.44658,
+            "Y": 44.499924
+          },
+          "TerritoryId": 128,
+          "InteractionType": "WalkTo",
+          "SkipConditions": {
+            "StepIf": {
+              "InTerritory": [
+                135
+              ]
+            }
+          }
+        },
+        {
+          "Position": {
+            "X": 219.17522,
+            "Y": 42.332607,
+            "Z": 54.36626
+          },
+          "TerritoryId": 135,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "ComplexCombatData": [
+            {
+              "DataId": 324,
+              "CompletionQuestVariablesFlags": [
+                {
+                  "Low": 4
+                },
+                null,
+                null,
+                null,
+                null,
+                null
+              ]
+            }
+          ],
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1000972,
+          "Position": {
+            "X": 20.279175,
+            "Y": 40.19993,
+            "Z": -6.1189575
+          },
+          "TerritoryId": 128,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Limsa Lominsa",
+          "AethernetShortcut": [
+            "[Limsa Lominsa] Aetheryte Plaza",
+            "[Limsa Lominsa] The Aftcastle"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Side Quests/La Noscea/Limsa/662_Soothing the Savage Siren.json
+++ b/QuestPaths/2.x - A Realm Reborn/Side Quests/La Noscea/Limsa/662_Soothing the Savage Siren.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "h-y3na",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1000919,
+          "Position": {
+            "X": 46.67737,
+            "Y": 44.65997,
+            "Z": 137.1023
+          },
+          "TerritoryId": 128,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Limsa Lominsa",
+          "AethernetShortcut": [
+            "[Limsa Lominsa] Aetheryte Plaza",
+            "[Limsa Lominsa] The Aftcastle"
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                128,
+                129
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1000918,
+          "Position": {
+            "X": 84.09241,
+            "Y": 44.399914,
+            "Z": 132.34143
+          },
+          "TerritoryId": 128,
+          "InteractionType": "Emote",
+          "Emote": "kneel"
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1000918,
+          "Position": {
+            "X": 84.09241,
+            "Y": 44.399914,
+            "Z": 132.34143
+          },
+          "TerritoryId": 128,
+          "InteractionType": "Emote",
+          "Emote": "disappointed"
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1000918,
+          "Position": {
+            "X": 84.09241,
+            "Y": 44.399914,
+            "Z": 132.34143
+          },
+          "TerritoryId": 128,
+          "InteractionType": "Emote",
+          "Emote": "rally"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1000919,
+          "Position": {
+            "X": 46.67737,
+            "Y": 44.65997,
+            "Z": 137.1023
+          },
+          "TerritoryId": 128,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Position for the first lamp in 120_I Stay the Streetlight is offset for more natural pathfinding as it is in a crowded spot. Otherwise your character runs into a ledge for a bit before jumping. StopDistance set to 0.25 so your character doesn't interact from too far away, again to look more natural.

SkipCondition added to WalkTo step in 122_Glory Days in sequence 2 in case combat messes up and user has to reload.

663_Fool Me Once starts a quest chain of 6 quests, will implement separately later.