### PR TITLE
Add AetheryteShortcut and update AethernetShortcut

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/PLD/262_That Old Familiar Feeling.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/PLD/262_That Old Familiar Feeling.json
@@ -130,8 +130,9 @@
           },
           "TerritoryId": 131,
           "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Ul'dah",
           "AethernetShortcut": [
-            "[Ul'dah] Adventurers' Guild",
+            "[Ul'dah] Aetheryte Plaza",
             "[Ul'dah] Gladiators' Guild"
           ],
           "NextQuestId": 263

--- a/QuestPaths/2.x - A Realm Reborn/MSQ-2/B5-Western Thanalan/517_All Good Things.json
+++ b/QuestPaths/2.x - A Realm Reborn/MSQ-2/B5-Western Thanalan/517_All Good Things.json
@@ -27,6 +27,42 @@
       "Sequence": 1,
       "Steps": [
         {
+          "Position": {
+            "X": 287.2875,
+            "Y": 41.545933,
+            "Z": -200.75758
+          },
+          "TerritoryId": 139,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "AetheryteShortcut": "Upper La Noscea - Camp Bronze Lake"
+        },
+        {
+          "Position": {
+            "X": 285.82883,
+            "Y": 42.26685,
+            "Z": -203.32939
+          },
+          "TerritoryId": 139,
+          "InteractionType": "WalkTo",
+          "TargetTerritoryId": 180
+        },
+        {
+          "Position": {
+            "X": -114.35803,
+            "Y": 64.464615,
+            "Z": -217.34372
+          },
+          "TerritoryId": 180,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "TerritoryId": 180,
+          "InteractionType": "AttuneAetheryte",
+          "Aetheryte": "Outer La Noscea - Camp Overlook"
+        },
+        {
           "DataId": 1003281,
           "Position": {
             "X": 97.520386,


### PR DESCRIPTION
After the battle ended, I started using Teleport because it didn't react to "Ul'dah Adventurers' Guild".
The release of "Camp Overlook" is happening too late, so we'll add a mechanism to release it here.