### PR TITLE
Added quests for Materia Melding/Mutation, Desynthesis, and NG+

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/Unlocks/Misc/1463_Marvelously Mutable Materia.json
+++ b/QuestPaths/2.x - A Realm Reborn/Unlocks/Misc/1463_Marvelously Mutable Materia.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "$": "May need possible consideration for non-flying route to avoid a possible A-rank?",
+          "DataId": 1001428,
+          "Position": {
+            "X": 116.80774,
+            "Y": 30.907087,
+            "Z": -359.63995
+          },
+          "TerritoryId": 141,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Central Thanalan - Black Brush Station",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1001425,
+          "Position": {
+            "X": 115.12927,
+            "Y": 31.876099,
+            "Z": -392.2027
+          },
+          "TerritoryId": 141,
+          "InteractionType": "CompleteQuest",
+          "Mount": false,
+          "Fly": false
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Unlocks/Misc/152_Gone to Pieces.json
+++ b/QuestPaths/2.x - A Realm Reborn/Unlocks/Misc/152_Gone to Pieces.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "Comment": "Requires a DoH class at level 30 or higher",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1001679,
+          "Position": {
+            "X": 140.48975,
+            "Y": 4.0099983,
+            "Z": -59.80017
+          },
+          "TerritoryId": 131,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Ul'dah",
+          "AethernetShortcut": [
+            "[Ul'dah] Aetheryte Plaza",
+            "[Ul'dah] Sapphire Avenue Exchange"
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true,
+              "InTerritory": [
+                131
+              ]
+            },
+            "AethernetShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "$": "May need possible consideration for non-flying route to avoid a possible A-rank?",
+          "DataId": 1009295,
+          "Position": {
+            "X": 97.09314,
+            "Y": 27.238445,
+            "Z": -352.55975
+          },
+          "TerritoryId": 141,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Central Thanalan - Black Brush Station",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ],
+      "$": "Possible consideration to have other quests at the Bonfire (Waking the Spirit, Melding Materia Muchly, Marvelously Mutable Materia) as NextQuestIds?"
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Unlocks/Misc/3759_Memories Rekindled.json
+++ b/QuestPaths/2.x - A Realm Reborn/Unlocks/Misc/3759_Memories Rekindled.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "$": "New Game Plus unlock",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "TerritoryId": 128,
+          "InteractionType": "UseItem",
+          "ItemId": 30362,
+          "SkipConditions": {
+            "StepIf": {
+              "InTerritory": [
+                140
+              ]
+            }
+          }
+        },
+        {
+          "DataId": 1032363,
+          "Position": {
+            "X": -472.6482,
+            "Y": 23.008791,
+            "Z": -373.22046
+          },
+          "TerritoryId": 140,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Unlocks/Misc/639_Waking the Spirit.json
+++ b/QuestPaths/2.x - A Realm Reborn/Unlocks/Misc/639_Waking the Spirit.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "Comment": "Requires a DoH class at level 19 or higher",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "$": "May need possible consideration for non-flying route to avoid a possible A-rank?",
+          "DataId": 1001427,
+          "Position": {
+            "X": 102.89148,
+            "Y": 30.941309,
+            "Z": -377.95074
+          },
+          "TerritoryId": 141,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Central Thanalan - Black Brush Station",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1001427,
+          "Position": {
+            "X": 102.89148,
+            "Y": 30.941309,
+            "Z": -377.95074
+          },
+          "TerritoryId": 141,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Unlocks/Misc/640_Melding Materia Muchly.json
+++ b/QuestPaths/2.x - A Realm Reborn/Unlocks/Misc/640_Melding Materia Muchly.json
@@ -1,22 +1,19 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "ShermTank",
-  "Comment": "Requires a DoH class at level 19 or higher",
   "QuestSequence": [
     {
       "Sequence": 0,
       "Steps": [
         {
-          "$": "May need possible consideration for non-flying route to avoid a possible A-rank?",
-          "DataId": 1001427,
+          "DataId": 1001425,
           "Position": {
-            "X": 102.89148,
-            "Y": 30.941309,
-            "Z": -377.95074
+            "X": 115.12927,
+            "Y": 31.876099,
+            "Z": -392.2027
           },
           "TerritoryId": 141,
           "InteractionType": "AcceptQuest",
-          "Fly": true,
           "AetheryteShortcut": "Central Thanalan - Black Brush Station",
           "SkipConditions": {
             "AetheryteShortcutIf": {
@@ -27,19 +24,29 @@
       ]
     },
     {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "TerritoryId": 141,
+          "Comment": "Meld 8 materia (any) while near Mutamix.\nRetrieving materia and re-melding is okay.",
+          "InteractionType": "WaitForManualProgress",
+          "$": "First byte of QW tracks the progress (1L->2L->3L->etc.); can maybe use this in a future auto implementation?"
+        }
+      ]
+    },
+    {
       "Sequence": 255,
       "Steps": [
         {
-          "DataId": 1001427,
+          "DataId": 1001425,
           "Position": {
-            "X": 102.89148,
-            "Y": 30.941309,
-            "Z": -377.95074
+            "X": 115.12927,
+            "Y": 31.876099,
+            "Z": -392.2027
           },
           "TerritoryId": 141,
           "InteractionType": "CompleteQuest"
-        },
-        "NextQuestId": 640
+        }
       ]
     }
   ]


### PR DESCRIPTION
Quests:
"Marvelously Mutable Materia" (materia mutation)
"Gone to Pieces" (desynthesis)
"Memories Rekindled" (NG+, Instant/pseudo-quest)
"Waking the Spirit" (materia melding)
"Melding Materia Muchly" (advanced materia melding)

"Melding Materia Muchly" currently has a manual step to meld materia in front of Mutamix. If we want to make it automatic, I noticed that the first byte in QW tracks progress.