### PR TITLE
Added Significant ARR HW SB Yellow Quests

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/Side Quests/La Noscea/Upper La Noscea/866_The Monster of Bronze Lake.json
+++ b/QuestPaths/2.x - A Realm Reborn/Side Quests/La Noscea/Upper La Noscea/866_The Monster of Bronze Lake.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1006332,
+          "Position": {
+            "X": 426.96265,
+            "Y": 8.373348,
+            "Z": 20.004517
+          },
+          "TerritoryId": 139,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Upper La Noscea - Camp Bronze Lake",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 317.71744,
+            "Y": -3.1370237,
+            "Z": 62.031395
+          },
+          "TerritoryId": 139,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "KillEnemyDataIds": [
+            139
+          ],
+          "CompletionQuestVariablesFlags": [null,64,null,null,null,null],
+          "Fly": true,
+          "AetheryteShortcut": "Upper La Noscea - Camp Bronze Lake",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "$": "Don't be intimidated by Godbert, just imagine him in his underwe- oh no",
+          "DataId": 1006339,
+          "Position": {
+            "X": 496.57434,
+            "Y": 16.560684,
+            "Z": 64.530396
+          },
+          "TerritoryId": 139,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "Upper La Noscea - Camp Bronze Lake",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "$": "Pour the salamander oil on Godbert, and remember that generosity is a virtue",
+          "DataId": 1006339,
+          "Position": {
+            "X": 496.57434,
+            "Y": 16.560684,
+            "Z": 64.530396
+          },
+          "TerritoryId": 139,
+          "InteractionType": "UseItem",
+          "ItemId": 2000673
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "$": "Aetheryte shortcut & skip is needed to cause a micro-wait; without it the step seems to have trouble using items",
+      "Steps": [
+        {
+          "$": "Unfortunately, there is still plenty more of Godbert in need of oiling",
+          "DataId": 1006339,
+          "Position": {
+            "X": 496.57434,
+            "Y": 16.560684,
+            "Z": 64.530396
+          },
+          "TerritoryId": 139,
+          "InteractionType": "UseItem",
+          "ItemId": 2000673,
+          "AetheryteShortcut": "Upper La Noscea - Camp Bronze Lake",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 5,
+      "Steps": [
+        {
+          "$": "Knead the oil into Godbert's weary flesh",
+          "DataId": 1006339,
+          "Position": {
+            "X": 496.57434,
+            "Y": 16.560684,
+            "Z": 64.530396
+          },
+          "TerritoryId": 139,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 6,
+      "Steps": [
+        {
+          "$": "Keep working those knots out of Godbert's tense muscles",
+          "DataId": 1006339,
+          "Position": {
+            "X": 496.57434,
+            "Y": 16.560684,
+            "Z": 64.530396
+          },
+          "TerritoryId": 139,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1006332,
+          "Position": {
+            "X": 426.96265,
+            "Y": 8.373348,
+            "Z": 20.004517
+          },
+          "TerritoryId": 139,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Upper La Noscea - Camp Bronze Lake",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          },
+          "NextQuestId": 868,
+          "$": "Next quest: 'The Adventure of the Fainting Goldsmith'."
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Side Quests/La Noscea/Upper La Noscea/866_The Monster of Bronze Lake.json
+++ b/QuestPaths/2.x - A Realm Reborn/Side Quests/La Noscea/Upper La Noscea/866_The Monster of Bronze Lake.json
@@ -39,7 +39,6 @@
           "KillEnemyDataIds": [
             139
           ],
-          "CompletionQuestVariablesFlags": [null,64,null,null,null,null],
           "Fly": true,
           "AetheryteShortcut": "Upper La Noscea - Camp Bronze Lake",
           "SkipConditions": {

--- a/QuestPaths/2.x - A Realm Reborn/Side Quests/La Noscea/Upper La Noscea/868_The Adventure of the Fainting Goldsmith.json
+++ b/QuestPaths/2.x - A Realm Reborn/Side Quests/La Noscea/Upper La Noscea/868_The Adventure of the Fainting Goldsmith.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1006332,
+          "Position": {
+            "X": 426.96265,
+            "Y": 8.373348,
+            "Z": 20.004517
+          },
+          "TerritoryId": 139,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Upper La Noscea - Camp Bronze Lake",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "$": "See if a determined /poke will rouse him",
+          "DataId": 1006695,
+          "Position": {
+            "X": 507.86584,
+            "Y": 15.992688,
+            "Z": 58.335205
+          },
+          "TerritoryId": 139,
+          "InteractionType": "Emote",
+          "Emote": "poke",
+          "Fly": true,
+          "AetheryteShortcut": "Upper La Noscea - Camp Bronze Lake",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "$": "Do as the physicians do and douse him with a bottle of ice-cold lake water",
+          "DataId": 1006695,
+          "Position": {
+            "X": 507.86584,
+            "Y": 15.992688,
+            "Z": 58.335205
+          },
+          "TerritoryId": 139,
+          "InteractionType": "UseItem",
+          "ItemId": 2000676
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "$": "Aetheryte shortcut & skip is needed to cause a micro-wait; without it the step seems to have trouble using items",
+      "Steps": [
+        {
+          "$": "This calls for another dose of ice-cold lake water",
+          "DataId": 1006695,
+          "Position": {
+            "X": 507.86584,
+            "Y": 15.992688,
+            "Z": 58.335205
+          },
+          "TerritoryId": 139,
+          "InteractionType": "UseItem",
+          "ItemId": 2000676,
+          "AetheryteShortcut": "Upper La Noscea - Camp Bronze Lake",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "$": "Aetheryte shortcut & skip is needed to cause a micro-wait; without it the step seems to have trouble using items",
+      "Steps": [
+        {
+          "$": "Perhaps another dose of ice-cold lake water will do the trick",
+          "DataId": 1006695,
+          "Position": {
+            "X": 507.86584,
+            "Y": 15.992688,
+            "Z": 58.335205
+          },
+          "TerritoryId": 139,
+          "InteractionType": "UseItem",
+          "ItemId": 2000676,
+          "AetheryteShortcut": "Upper La Noscea - Camp Bronze Lake",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1006332,
+          "Position": {
+            "X": 426.96265,
+            "Y": 8.373348,
+            "Z": 20.004517
+          },
+          "TerritoryId": 139,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Upper La Noscea - Camp Bronze Lake",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Side Quests/Mor Dhona/164_Magiteknical Difficulties.json
+++ b/QuestPaths/2.x - A Realm Reborn/Side Quests/Mor Dhona/164_Magiteknical Difficulties.json
@@ -1,0 +1,269 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1006530,
+          "Position": {
+            "X": 21.927185,
+            "Y": 20.746975,
+            "Z": -682.06305
+          },
+          "TerritoryId": 156,
+          "InteractionType": "AcceptQuest",
+          "Mount": true,
+          "AetheryteShortcut": "Mor Dhona",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "$": "Enter workshop (Slafborn)",
+          "DataId": 1006530,
+          "Position": {
+            "X": 21.927185,
+            "Y": 20.746975,
+            "Z": -682.06305
+          },
+          "TerritoryId": 156,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Mor Dhona",
+          "TargetTerritoryId": 156,
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_SUBCTS818_00164_Q1_000_000",
+              "Yes": true
+            }
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                156
+              ]
+            },
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -7.1260376,
+                  "Y": -158.5813,
+                  "Z": -2.3651733
+                },
+                "TerritoryId": 156,
+                "MaximumDistance": 100
+              }
+            }
+          }
+        },
+        {
+          "$": "Talk to Jessie",
+          "DataId": 1006980,
+          "Position": {
+            "X": -7.1260376,
+            "Y": -158.5813,
+            "Z": -2.3651733
+          },
+          "TerritoryId": 156,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "$": "Exit workshop",
+          "DataId": 2002502,
+          "Position": {
+            "X": 0.7476196,
+            "Y": -156.93909,
+            "Z": 16.281311
+          },
+          "TerritoryId": 156,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Mor Dhona",
+          "TargetTerritoryId": 156,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                156
+              ]
+            },
+            "StepIf": {
+              "NotNearPosition": {
+                "Position": {
+                  "X": -7.1260376,
+                  "Y": -158.5813,
+                  "Z": -2.3651733
+                },
+                "TerritoryId": 156,
+                "MaximumDistance": 100
+              }
+            }
+          }
+        },
+        {
+          "$": "Magitek Converter #49 - PathTo",
+          "Position": {
+            "X": -643.4109,
+            "Y": -2.9330235,
+            "Z": -380.4485
+          },
+          "TerritoryId": 156,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,128]
+            }
+          }
+        },
+        {
+          "$": "Magitek Converter #49 - Pickup",
+          "DataId": 2004314,
+          "Position": {
+            "X": -644.67847,
+            "Y": -1.3580933,
+            "Z": -382.1012
+          },
+          "TerritoryId": 156,
+          "InteractionType": "Interact",
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,128]
+            }
+          }
+        },
+        {
+          "$": "Magitek Cannon Barrel #51 - PathTo",
+          "Position": {
+            "X": -568.7724,
+            "Y": -2.9615695,
+            "Z": -316.0917
+          },
+          "TerritoryId": 156,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,32]
+            }
+          }
+        },
+        {
+          "$": "Magitek Cannon Barrel #51 - Pickup",
+          "DataId": 2004316,
+          "Position": {
+            "X": -569.8787,
+            "Y": -1.3886108,
+            "Z": -318.07434
+          },
+          "TerritoryId": 156,
+          "InteractionType": "Interact",
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,32]
+            }
+          }
+        },
+        {
+          "$": "Magitek Oscillator #50 - PathTo",
+          "Position": {
+            "X": -449.4682,
+            "Y": -4.004792,
+            "Z": -280.67694
+          },
+          "TerritoryId": 156,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,64]
+            }
+          }
+        },
+        {
+          "$": "Magitek Oscillator #50 - Pickup",
+          "DataId": 2004315,
+          "Position": {
+            "X": -451.34668,
+            "Y": -2.395752,
+            "Z": -280.72028
+          },
+          "TerritoryId": 156,
+          "InteractionType": "Interact",
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,64]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "$": "Enter workshop (Slafborn)",
+          "DataId": 1006530,
+          "Position": {
+            "X": 21.927185,
+            "Y": 20.746975,
+            "Z": -682.06305
+          },
+          "TerritoryId": 156,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Mor Dhona",
+          "TargetTerritoryId": 156,
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_SUBCTS818_00164_Q1_000_000",
+              "Yes": true
+            }
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            },
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -7.1260376,
+                  "Y": -158.5813,
+                  "Z": -2.3651733
+                },
+                "TerritoryId": 156,
+                "MaximumDistance": 100
+              }
+            }
+          }
+        },
+        {
+          "$": "Talk to Jessie",
+          "DataId": 1006980,
+          "Position": {
+            "X": -7.1260376,
+            "Y": -158.5813,
+            "Z": -2.3651733
+          },
+          "TerritoryId": 156,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Side Quests/Ishgard/1729_Landing a Stable Job.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/Ishgard/1729_Landing a Stable Job.json
@@ -1,0 +1,198 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "$": "This quest rewards a Thavnairian Onion",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1012181,
+          "Position": {
+            "X": -248.55426,
+            "Y": -20.034918,
+            "Z": -90.98956
+          },
+          "TerritoryId": 419,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Ishgard",
+          "AethernetShortcut": [
+            "[Ishgard] Aetheryte Plaza",
+            "[Ishgard] The Jeweled Crozier"
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true,
+              "InTerritory": [
+                419
+              ]
+            },
+            "AethernetShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2006242,
+          "Position": {
+            "X": -245.4414,
+            "Y": -20.035156,
+            "Z": -87.66315
+          },
+          "TerritoryId": 419,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Ishgard",
+          "AethernetShortcut": [
+            "[Ishgard] Aetheryte Plaza",
+            "[Ishgard] The Jeweled Crozier"
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true,
+              "InTerritory": [
+                419
+              ]
+            },
+            "AethernetShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1012176,
+          "Position": {
+            "X": -164.69067,
+            "Y": 2.1700032,
+            "Z": 27.572998
+          },
+          "TerritoryId": 418,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Ishgard",
+          "AethernetShortcut": [
+            "[Ishgard] The Jeweled Crozier",
+            "[Ishgard] Skysteel Manufactory"
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true,
+              "InTerritory": [
+                419
+              ]
+            },
+            "AethernetShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "$": "Enter Proving Grounds",
+          "DataId": 1011214,
+          "Position": {
+            "X": 94.590576,
+            "Y": 24.06099,
+            "Z": -32.303406
+          },
+          "TerritoryId": 418,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Ishgard",
+          "AethernetShortcut": [
+            "[Ishgard] Skysteel Manufactory",
+            "[Ishgard] The Forgotten Knight"
+          ],
+          "TargetTerritoryId": 439,
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_HEAVNZ004_01729_Q1_000_000",
+              "Yes": true
+            }
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                418,
+                439
+              ]
+            },
+            "StepIf": {
+              "InTerritory": [
+                439
+              ]
+            }
+          }
+        },
+        {
+          "DataId": 1014710,
+          "Position": {
+            "X": 19.790894,
+            "Y": 4.1140323,
+            "Z": -8.529846
+          },
+          "TerritoryId": 439,
+          "InteractionType": "Interact",
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "$": "Exit Proving Grounds",
+          "DataId": 2005335,
+          "Position": {
+            "X": 30.777344,
+            "Y": 7.6447144,
+            "Z": -21.439026
+          },
+          "TerritoryId": 439,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Ishgard",
+          "TargetTerritoryId": 418,
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                418,
+                439
+              ]
+            },
+            "StepIf": {
+              "InTerritory": [
+                418
+              ]
+            }
+          }
+        },
+        {
+          "DataId": 1012176,
+          "Position": {
+            "X": -164.69067,
+            "Y": 2.1700032,
+            "Z": 27.572998
+          },
+          "TerritoryId": 418,
+          "InteractionType": "CompleteQuest",
+          "AethernetShortcut": [
+            "[Ishgard] The Forgotten Knight",
+            "[Ishgard] Skysteel Manufactory"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1775_I Wanna Be the Hunter.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1775_I Wanna Be the Hunter.json
@@ -1,0 +1,238 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1011917,
+          "Position": {
+            "X": 535.30164,
+            "Y": -51.340645,
+            "Z": 65.293335
+          },
+          "TerritoryId": 398,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1014480,
+          "Position": {
+            "X": 536.3087,
+            "Y": -51.32523,
+            "Z": 64.98816
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "$": "Top end of fallen tree/bridge to top",
+          "DataId": 2006129,
+          "Position": {
+            "X": 841.0924,
+            "Y": -5.2339478,
+            "Z": 216.26611
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            },
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,32]
+            }
+          }
+        },
+        {
+          "$": "Path to 'Under fallen tree/bridge to top'",
+          "Position": {
+            "X": 833.9071,
+            "Y": -7.1594114,
+            "Z": 226.18608
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,16]
+            }
+          }
+        },
+        {
+          "$": "Under fallen tree/bridge to top",
+          "DataId": 2006456,
+          "Position": {
+            "X": 832.4863,
+            "Y": -7.370178,
+            "Z": 222.70532
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Mount": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,16]
+            }
+          }
+        },
+        {
+          "$": "Path to 'By tree, top level'",
+          "Position": {
+            "X": 866.2793,
+            "Y": -4.5189195,
+            "Z": 214.97252
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,8]
+            }
+          }
+        },
+        {
+          "$": "By tree, top level",
+          "DataId": 2006457,
+          "Position": {
+            "X": 870.3898,
+            "Y": -4.715088,
+            "Z": 216.23547
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Mount": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,8]
+            }
+          }
+        },
+        {
+          "$": "Walk off ledge if flying not unlocked",
+          "Position": {
+            "X": 876.73785,
+            "Y": -17.366787,
+            "Z": 206.0773
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Mount": true,
+          "DisableNavmesh": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,8],
+              "Flying": "Unlocked"
+            }
+          }
+        },
+        {
+          "$": "By tree, low level",
+          "DataId": 2006127,
+          "Position": {
+            "X": 871.88513,
+            "Y": -20.615051,
+            "Z": 193.59119
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Mount": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,128]
+            }
+          }
+        },
+        {
+          "$": "By tree, under rocky outcropping",
+          "DataId": 2006128,
+          "Position": {
+            "X": 872.6481,
+            "Y": -16.434021,
+            "Z": 216.7544
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,64]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1014480,
+          "Position": {
+            "X": 536.3087,
+            "Y": -51.32523,
+            "Z": 64.98816
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Mount": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1011917,
+          "Position": {
+            "X": 535.30164,
+            "Y": -51.340645,
+            "Z": 65.293335
+          },
+          "TerritoryId": 398,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          },
+          "NextQuestId": 1776
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1776_A Natural Instinct.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1776_A Natural Instinct.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1011917,
+          "Position": {
+            "X": 535.30164,
+            "Y": -51.340645,
+            "Z": 65.293335
+          },
+          "TerritoryId": 398,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1014480,
+          "Position": {
+            "X": 536.3087,
+            "Y": -51.32523,
+            "Z": 64.98816
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2006130,
+          "Position": {
+            "X": 378.74414,
+            "Y": -42.557434,
+            "Z": -373.0984
+          },
+          "TerritoryId": 398,
+          "InteractionType": "UseItem",
+          "ItemId": 2001790,
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1014481,
+          "Position": {
+            "X": 352.01025,
+            "Y": -30.06939,
+            "Z": -413.10748
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 1014482,
+          "Position": {
+            "X": 380.7583,
+            "Y": -42.602375,
+            "Z": -371.63348
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1011917,
+          "Position": {
+            "X": 535.30164,
+            "Y": -51.340645,
+            "Z": 65.293335
+          },
+          "TerritoryId": 398,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "NextQuestId": 1777
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1777_First Impressions Last.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1777_First Impressions Last.json
@@ -1,0 +1,208 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1011917,
+          "Position": {
+            "X": 535.30164,
+            "Y": -51.340645,
+            "Z": 65.293335
+          },
+          "TerritoryId": 398,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1014486,
+          "Position": {
+            "X": 831.08264,
+            "Y": -22.251318,
+            "Z": 213.61096
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1011917,
+          "Position": {
+            "X": 535.30164,
+            "Y": -51.340645,
+            "Z": 65.293335
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather"
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1014484,
+          "Position": {
+            "X": 533.2263,
+            "Y": -51.380444,
+            "Z": 63.43164
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "$": "East",
+          "DataId": 2006133,
+          "Position": {
+            "X": 360.0365,
+            "Y": -44.449524,
+            "Z": -284.01617
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            },
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,64]
+            }
+          }
+        },
+        {
+          "$": "North",
+          "DataId": 2006134,
+          "Position": {
+            "X": 319.11182,
+            "Y": -48.20331,
+            "Z": -318.07434
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,32]
+            }
+          }
+        },
+        {
+          "$": "Southwest",
+          "DataId": 2006132,
+          "Position": {
+            "X": 312.79468,
+            "Y": -47.16565,
+            "Z": -256.27533
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,128]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 5,
+      "Steps": [
+        {
+          "DataId": 1014480,
+          "Position": {
+            "X": 536.3087,
+            "Y": -51.32523,
+            "Z": 64.98816
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather"
+        }
+      ]
+    },
+    {
+      "Sequence": 6,
+      "Steps": [
+        {
+          "DataId": 1014485,
+          "Position": {
+            "X": 832.7915,
+            "Y": -22.160456,
+            "Z": 214.3739
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1011917,
+          "Position": {
+            "X": 535.30164,
+            "Y": -51.340645,
+            "Z": 65.293335
+          },
+          "TerritoryId": 398,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "NextQuestId": 1781
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1779_Needs More Salt.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1779_Needs More Salt.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "$": "Path to building/Marchechamp",
+          "Position": {
+            "X": 471.40442,
+            "Y": -51.141407,
+            "Z": 36.84344
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            },
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 470.02356,
+                  "Y": -49.89133,
+                  "Z": 20.370789
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 10
+              }
+            }
+          }
+        },
+        {
+          "$": "Marcechamp",
+          "DataId": 1011916,
+          "Position": {
+            "X": 470.02356,
+            "Y": -49.89133,
+            "Z": 20.370789
+          },
+          "TerritoryId": 398,
+          "InteractionType": "AcceptQuest",
+          "Mount": false
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "$": "Path out of building",
+          "Position": {
+            "X": 471.40442,
+            "Y": -51.141407,
+            "Z": 36.84344
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Mount": false,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            },
+            "StepIf": {
+              "NotNearPosition": {
+                "Position": {
+                  "X": 470.02356,
+                  "Y": -49.89133,
+                  "Z": 20.370789
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 5
+              }
+            }
+          }
+        },
+        {
+          "$": "Fly to area",
+          "Position": {
+            "X": 643.0321,
+            "Y": -34.386024,
+            "Z": 324.79504
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "$": "West",
+          "DataId": 2005603,
+          "Position": {
+            "X": 641.90125,
+            "Y": -34.13446,
+            "Z": 332.0515
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterItemUse",
+          "ItemId": 2001609,
+          "KillEnemyDataIds": [
+            39
+          ],
+          "Mount": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,128]
+            }
+          }
+        },
+        {
+          "$": "Northeast",
+          "DataId": 2005605,
+          "Position": {
+            "X": 663.4164,
+            "Y": -32.48651,
+            "Z": 321.37012
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterItemUse",
+          "ItemId": 2001609,
+          "KillEnemyDataIds": [
+            39
+          ],
+          "Mount": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,32]
+            }
+          }
+        },
+        {
+          "$": "Southeast",
+          "DataId": 2005604,
+          "Position": {
+            "X": 665.3695,
+            "Y": -30.71643,
+            "Z": 340.6881
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterItemUse",
+          "ItemId": 2001609,
+          "KillEnemyDataIds": [
+            39
+          ],
+          "Mount": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,64]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "$": "Path to building/Marchechamp",
+          "Position": {
+            "X": 471.40442,
+            "Y": -51.141407,
+            "Z": 36.84344
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather"
+        },
+        {
+          "$": "Marcechamp",
+          "DataId": 1011916,
+          "Position": {
+            "X": 470.02356,
+            "Y": -49.89133,
+            "Z": 20.370789
+          },
+          "TerritoryId": 398,
+          "InteractionType": "CompleteQuest",
+          "Mount": false,
+          "NextQuestId": 1780
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1780_Uninvited Guests.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1780_Uninvited Guests.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "$": "Path out of Marcechamp's building (if you're still there from turning in the previous quest)",
+          "Position": {
+            "X": 471.40442,
+            "Y": -51.141407,
+            "Z": 36.84344
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Mount": false,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            },
+            "StepIf": {
+              "NotNearPosition": {
+                "Position": {
+                  "X": 470.02356,
+                  "Y": -49.89133,
+                  "Z": 20.370789
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 5
+              }
+            }
+          }
+        },
+        {
+          "DataId": 1013364,
+          "Position": {
+            "X": 344.93018,
+            "Y": -30.12832,
+            "Z": -419.21112
+          },
+          "TerritoryId": 398,
+          "InteractionType": "AcceptQuest",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 300.65573,
+            "Y": -20.856728,
+            "Z": -514.3892
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "KillEnemyDataIds": [
+            4029
+          ],
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1013364,
+          "Position": {
+            "X": 344.93018,
+            "Y": -30.12832,
+            "Z": -419.21112
+          },
+          "TerritoryId": 398,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            }
+          },
+          "NextQuestId": 1785
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1781_The Man Who Slew Too Much.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1781_The Man Who Slew Too Much.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1011917,
+          "Position": {
+            "X": 535.30164,
+            "Y": -51.340645,
+            "Z": 65.293335
+          },
+          "TerritoryId": 398,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1014490,
+          "Position": {
+            "X": 440.8789,
+            "Y": -51.077488,
+            "Z": 107.499756
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1014481,
+          "Position": {
+            "X": 352.01025,
+            "Y": -30.06939,
+            "Z": -413.10748
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1014491,
+          "Position": {
+            "X": 794.70496,
+            "Y": -33.55555,
+            "Z": -271.62585
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 1014481,
+          "Position": {
+            "X": 352.01025,
+            "Y": -30.06939,
+            "Z": -413.10748
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1011917,
+          "Position": {
+            "X": 535.30164,
+            "Y": -51.340645,
+            "Z": 65.293335
+          },
+          "TerritoryId": 398,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "NextQuestId": 1782
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1782_A Budding Partnership.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1782_A Budding Partnership.json
@@ -1,0 +1,300 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1011917,
+          "Position": {
+            "X": 535.30164,
+            "Y": -51.340645,
+            "Z": 65.293335
+          },
+          "TerritoryId": 398,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1014496,
+          "Position": {
+            "X": 481.8036,
+            "Y": -50.857147,
+            "Z": -5.2339478
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1014494,
+          "Position": {
+            "X": 479.7893,
+            "Y": -50.83053,
+            "Z": -5.722229
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "$": "Remaclon",
+          "DataId": 1011919,
+          "Position": {
+            "X": 497.82556,
+            "Y": -49.790283,
+            "Z": 11.825684
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            },
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,32]
+            }
+          }
+        },
+        {
+          "$": "Path to building/Marchechamp",
+          "Position": {
+            "X": 471.40442,
+            "Y": -51.141407,
+            "Z": 36.84344
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,64]
+            }
+          }
+        },
+        {
+          "$": "Marcechamp",
+          "DataId": 1011916,
+          "Position": {
+            "X": 470.02356,
+            "Y": -49.89133,
+            "Z": 20.370789
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Mount": false,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,64]
+            }
+          }
+        },
+        {
+          "$": "Path out of building",
+          "Position": {
+            "X": 471.40442,
+            "Y": -51.141407,
+            "Z": 36.84344
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Mount": false,
+          "SkipConditions": {
+            "StepIf": {
+              "NotNearPosition": {
+                "Position": {
+                  "X": 470.02356,
+                  "Y": -49.89133,
+                  "Z": 20.370789
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 5
+              }
+            }
+          }
+        },
+        {
+          "$": "Loupard",
+          "DataId": 1011917,
+          "Position": {
+            "X": 535.30164,
+            "Y": -51.340645,
+            "Z": 65.293335
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,128]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "$": "Path out of building (if Marchechamp was the last one you did)",
+          "Position": {
+            "X": 471.40442,
+            "Y": -51.141407,
+            "Z": 36.84344
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Mount": false,
+          "SkipConditions": {
+            "StepIf": {
+              "NotNearPosition": {
+                "Position": {
+                  "X": 470.02356,
+                  "Y": -49.89133,
+                  "Z": 20.370789
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 5
+              }
+            }
+          }
+        },
+        {
+          "DataId": 1014494,
+          "Position": {
+            "X": 479.7893,
+            "Y": -50.83053,
+            "Z": -5.722229
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 5,
+      "Steps": [
+        {
+          "DataId": 1014495,
+          "Position": {
+            "X": 665.8884,
+            "Y": -24.489628,
+            "Z": -289.17377
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 6,
+      "Steps": [
+        {
+          "DataId": 2006141,
+          "Position": {
+            "X": 664.57605,
+            "Y": -24.27716,
+            "Z": -289.02118
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "AetheryteShdortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 7,
+      "Steps": [
+        {
+          "DataId": 1014495,
+          "Position": {
+            "X": 665.8884,
+            "Y": -24.489628,
+            "Z": -289.17377
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1014494,
+          "Position": {
+            "X": 479.7893,
+            "Y": -50.83053,
+            "Z": -5.722229
+          },
+          "TerritoryId": 398,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "NextQuestId": 1783
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1783_Persistence Makes Perfect.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1783_Persistence Makes Perfect.json
@@ -1,0 +1,190 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1014494,
+          "Position": {
+            "X": 479.7893,
+            "Y": -50.83053,
+            "Z": -5.722229
+          },
+          "TerritoryId": 398,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1014495,
+          "Position": {
+            "X": 665.8884,
+            "Y": -24.489628,
+            "Z": -289.17377
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1014498,
+          "Position": {
+            "X": 527.9773,
+            "Y": -34.534286,
+            "Z": -389.1814
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1014499,
+          "Position": {
+            "X": 346.66968,
+            "Y": -30.197964,
+            "Z": -424.91803
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 1014500,
+          "Position": {
+            "X": 164.69055,
+            "Y": -18.146557,
+            "Z": -566.2471
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 5,
+      "Steps": [
+        {
+          "DataId": 2006143,
+          "Position": {
+            "X": 162.43225,
+            "Y": -17.95996,
+            "Z": -566.70483
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            },
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 162.43225,
+                  "Y": -17.95996,
+                  "Z": -566.70483
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 20
+              }
+            }
+          }
+        },
+        {
+          "DataId": 2006143,
+          "Position": {
+            "X": 162.43225,
+            "Y": -17.95996,
+            "Z": -566.70483
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "SkipConditions": {
+            "StepIf": {
+              "NotNearPosition": {
+                "Position": {
+                  "X": 162.43225,
+                  "Y": -17.95996,
+                  "Z": -566.70483
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 20
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1011917,
+          "Position": {
+            "X": 535.30164,
+            "Y": -51.340645,
+            "Z": 65.293335
+          },
+          "TerritoryId": 398,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "NextQuestId": 1922
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1785_What Remaclon Saw.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1785_What Remaclon Saw.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1011919,
+          "Position": {
+            "X": 497.82556,
+            "Y": -49.790283,
+            "Z": 11.825684
+          },
+          "TerritoryId": 398,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2005609,
+          "Position": {
+            "X": 44.47998,
+            "Y": -37.003174,
+            "Z": -309.65137
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1011919,
+          "Position": {
+            "X": 497.82556,
+            "Y": -49.790283,
+            "Z": 11.825684
+          },
+          "TerritoryId": 398,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "NextQuestId": 1922
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1922_Getting a Legtrap Up.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1922_Getting a Legtrap Up.json
@@ -1,0 +1,261 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "Comment": "Choice of Chocobo Dyeing rewards.\nYou may want to disable RewardPick (RP)\nin TextAdvance to choose what you want.",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "$": "Path to Hervoix",
+          "Position": {
+            "X": 453.9474,
+            "Y": -51.141403,
+            "Z": 19.29933
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            },
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 455.5581,
+                  "Y": -51.141403,
+                  "Z": 21.591492
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 5
+              }
+            }
+          }
+        },
+        {
+          "$": "Hervoix",
+          "DataId": 1014502,
+          "Position": {
+            "X": 455.5581,
+            "Y": -51.141403,
+            "Z": 21.591492
+          },
+          "TerritoryId": 398,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "$": "Fly to area",
+          "Position": {
+            "X": 855.29456,
+            "Y": -4.719991,
+            "Z": 247.32393
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            },
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 855.29456,
+                  "Y": -4.719991,
+                  "Z": 247.32393
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 15
+              }
+            }
+          }
+        },
+        {
+          "$": "Southwest",
+          "Position": {
+            "X": 847.1502,
+            "Y": -4.925739,
+            "Z": 275.1737
+          },
+          "StopDistance": 3.0,
+          "TerritoryId": 398,
+          "InteractionType": "Combat",
+          "Mount": true,
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [
+            22
+          ],
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,32]
+            }
+          }
+        },
+        {
+          "$": "Northeast",
+          "Position": {
+            "X": 868.00336,
+            "Y": -3.5871706,
+            "Z": 243.56834
+          },
+          "StopDistance": 3.0,
+          "TerritoryId": 398,
+          "InteractionType": "Combat",
+          "Mount": true,
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [
+            22
+          ],
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,128]
+            }
+          }
+        },
+        {
+          "$": "Path to Northwest, around rock",
+          "Position": {
+            "X": 844.26807,
+            "Y": -6.1181707,
+            "Z": 229.28525
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Mount": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,64]
+            }
+          }
+        },
+        {
+          "$": "Northwest",
+          "Position": {
+            "X": 838.4255,
+            "Y": -6.478032,
+            "Z": 237.16998
+          },
+          "StopDistance": 3.0,
+          "TerritoryId": 398,
+          "InteractionType": "Combat",
+          "Mount": true,
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [
+            22
+          ],
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,64]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "$": "Path to Hervoix",
+          "Position": {
+            "X": 453.9474,
+            "Y": -51.141403,
+            "Z": 19.29933
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 455.5581,
+                  "Y": -51.141403,
+                  "Z": 21.591492
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 5
+              }
+            }
+          }
+        },
+        {
+          "$": "Hervoix",
+          "DataId": 1014502,
+          "Position": {
+            "X": 455.5581,
+            "Y": -51.141403,
+            "Z": 21.591492
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1014504,
+          "Position": {
+            "X": 460.53247,
+            "Y": -53.537544,
+            "Z": 132.24988
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "$": "Path to Hervoix",
+          "Position": {
+            "X": 453.9474,
+            "Y": -51.141403,
+            "Z": 19.29933
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather"
+        },
+        {
+          "DataId": 1014502,
+          "Position": {
+            "X": 455.5581,
+            "Y": -51.141403,
+            "Z": 21.591492
+          },
+          "TerritoryId": 398,
+          "InteractionType": "CompleteQuest",
+          "NextQuestId": 1923,
+          "$": "Completing this quest unlocks 3 more quests; this will do them in index order (1923, 1924, 1925)"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1923_Pest Control.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1923_Pest Control.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "Comment": "Choice of Chocobo Dyeing rewards.\nYou may want to disable RewardPick (RP)\nin TextAdvance to choose what you want.",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "$": "Path to Hervoix",
+          "Position": {
+            "X": 453.9474,
+            "Y": -51.141403,
+            "Z": 19.29933
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            },
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 455.5581,
+                  "Y": -51.141403,
+                  "Z": 21.591492
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 5
+              }
+            }
+          }
+        },
+        {
+          "$": "Hervoix",
+          "DataId": 1014502,
+          "Position": {
+            "X": 455.5581,
+            "Y": -51.141403,
+            "Z": 21.591492
+          },
+          "TerritoryId": 398,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1011924,
+          "Position": {
+            "X": 849.0576,
+            "Y": -37.669926,
+            "Z": -39.56665
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "$": "Fly to area",
+          "Position": {
+            "X": 840.0293,
+            "Y": -32.40285,
+            "Z": -309.73672
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            },
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 840.0293,
+                  "Y": -32.40285,
+                  "Z": -309.73672
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 5
+              }
+            }
+          }
+        },
+        {
+          "$": "Combat",
+          "Position": {
+            "X": 839.72797,
+            "Y": -31.559177,
+            "Z": -319.8049
+          },
+          "StopDistance": 4.0,
+          "TerritoryId": 398,
+          "InteractionType": "Combat",
+          "Mount": false,
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [
+            4783,
+            4784
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "$": "Path to Hervoix",
+          "Position": {
+            "X": 453.9474,
+            "Y": -51.141403,
+            "Z": 19.29933
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather"
+        },
+        {
+          "DataId": 1014502,
+          "Position": {
+            "X": 455.5581,
+            "Y": -51.141403,
+            "Z": 21.591492
+          },
+          "TerritoryId": 398,
+          "InteractionType": "CompleteQuest",
+          "NextQuestId": 1924,
+          "$": "This is one of three quests unlocked by 1922; will do other quests in index order (1924, 1925)"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1924_A Step in the Right Direction.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1924_A Step in the Right Direction.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "$": "This quest rewards a Han Lemon",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "$": "Path to Hervoix",
+          "Position": {
+            "X": 453.9474,
+            "Y": -51.141403,
+            "Z": 19.29933
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            },
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 455.5581,
+                  "Y": -51.141403,
+                  "Z": 21.591492
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 5
+              }
+            }
+          }
+        },
+        {
+          "$": "Hervoix",
+          "DataId": 1014502,
+          "Position": {
+            "X": 455.5581,
+            "Y": -51.141403,
+            "Z": 21.591492
+          },
+          "TerritoryId": 398,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1013364,
+          "Position": {
+            "X": 344.93018,
+            "Y": -30.12832,
+            "Z": -419.21112
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "$": "Fly to area",
+          "Position": {
+            "X": 447.44937,
+            "Y": -33.461884,
+            "Z": -450.60486
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            },
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 448.36893,
+                  "Y": -35.84928,
+                  "Z": -426.83197
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 25
+              }
+            }
+          }
+        },
+        {
+          "$": "Northwest",
+          "DataId": 2006151,
+          "Position": {
+            "X": 439.44446,
+            "Y": -34.989014,
+            "Z": -444.11383
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Combat",
+          "Fly": true,
+          "EnemySpawnType": "AfterInteraction",
+          "KillEnemyDataIds": [
+            81
+          ],
+          "CompletionQuestVariablesFlags": [null,null,null,null,null,32],
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,32]
+            }
+          }
+        },
+        {
+          "$": "East",
+          "DataId": 2006150,
+          "Position": {
+            "X": 465.5984,
+            "Y": -34.77533,
+            "Z": -417.71576
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,64]
+            }
+          }
+        },
+        {
+          "$": "Southwest",
+          "DataId": 2006149,
+          "Position": {
+            "X": 431.26562,
+            "Y": -39.35309,
+            "Z": -413.65686
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,128]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "$": "Path to Hervoix",
+          "Position": {
+            "X": 453.9474,
+            "Y": -51.141403,
+            "Z": 19.29933
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather"
+        },
+        {
+          "DataId": 1014502,
+          "Position": {
+            "X": 455.5581,
+            "Y": -51.141403,
+            "Z": 21.591492
+          },
+          "TerritoryId": 398,
+          "InteractionType": "CompleteQuest",
+          "NextQuestId": 1925,
+          "$": "This is one of three quests unlocked by 1922; will do other quests in index order (1925)"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1925_Garbage Duty.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1925_Garbage Duty.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "$": "Path to Hervoix",
+          "Position": {
+            "X": 453.9474,
+            "Y": -51.141403,
+            "Z": 19.29933
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            },
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 455.5581,
+                  "Y": -51.141403,
+                  "Z": 21.591492
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 5
+              }
+            }
+          }
+        },
+        {
+          "$": "Hervoix",
+          "DataId": 1014502,
+          "Position": {
+            "X": 455.5581,
+            "Y": -51.141403,
+            "Z": 21.591492
+          },
+          "TerritoryId": 398,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1011932,
+          "Position": {
+            "X": 685.96924,
+            "Y": -24.382862,
+            "Z": -269.06238
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "$": "Fly near target",
+          "Position": {
+            "X": 650.8948,
+            "Y": -24.096365,
+            "Z": -479.5361
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            },
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 650.8948,
+                  "Y": -24.096365,
+                  "Z": -479.5361
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 15
+              }
+            }
+          }
+        },
+        {
+          "DataId": 1014505,
+          "Position": {
+            "X": 661.3717,
+            "Y": -24.312466,
+            "Z": -472.1599
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Combat",
+          "Mount": true,
+          "EnemySpawnType": "AfterInteraction",
+          "KillEnemyDataIds": [
+            5046
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "$": "Fly near target",
+          "Position": {
+            "X": 650.8948,
+            "Y": -24.096365,
+            "Z": -479.5361
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            },
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 650.8948,
+                  "Y": -24.096365,
+                  "Z": -479.5361
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 15
+              }
+            }
+          }
+        },
+        {
+          "DataId": 1014505,
+          "Position": {
+            "X": 661.3717,
+            "Y": -24.312466,
+            "Z": -472.1599
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "$": "Path to Hervoix",
+          "Position": {
+            "X": 453.9474,
+            "Y": -51.141403,
+            "Z": 19.29933
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather"
+        },
+        {
+          "DataId": 1014502,
+          "Position": {
+            "X": 455.5581,
+            "Y": -51.141403,
+            "Z": 21.591492
+          },
+          "TerritoryId": 398,
+          "InteractionType": "CompleteQuest",
+          "NextQuestId": 1926,
+          "$": "Next Quest: 'A Hunter's True Nature'."
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1926_A Hunter's True Nature.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1926_A Hunter's True Nature.json
@@ -1,0 +1,297 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "$": "This quest rewards a Thavnairian Onion",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "$": "Path to Hervoix",
+          "Position": {
+            "X": 453.9474,
+            "Y": -51.141403,
+            "Z": 19.29933
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            },
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 455.5581,
+                  "Y": -51.141403,
+                  "Z": 21.591492
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 5
+              }
+            }
+          }
+        },
+        {
+          "$": "Hervoix",
+          "DataId": 1014502,
+          "Position": {
+            "X": 455.5581,
+            "Y": -51.141403,
+            "Z": 21.591492
+          },
+          "TerritoryId": 398,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1014504,
+          "Position": {
+            "X": 460.53247,
+            "Y": -53.537544,
+            "Z": 132.24988
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "$": "Fly to location",
+          "Position": {
+            "X": 195.12386,
+            "Y": -28.197079,
+            "Z": -444.58627
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            },
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 195.12386,
+                  "Y": -28.197079,
+                  "Z": -444.58627
+                },
+                "TerritoryId": 398,
+                "MaximumDistance": 15
+              }
+            }
+          }
+        },
+        {
+          "$": "Combat",
+          "Position": {
+            "X": 184.67993,
+            "Y": -27.767006,
+            "Z": -443.28986
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [
+            81
+          ],
+          "CompletionQuestVariablesFlags": [1,null,null,null,null,null],
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [1,null,null,null,null,null]
+            }
+          }
+        },
+        {
+          "$": "Interact",
+          "DataId": 1014506,
+          "Position": {
+            "X": 184.67993,
+            "Y": -27.767006,
+            "Z": -443.28986
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "$": "Non-flying route 0",
+          "Position": {
+            "X": 86.77677,
+            "Y": -27.5831,
+            "Z": -410.85645
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "Mount": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            },
+            "StepIf": {
+              "Flying": "Unlocked"
+            }
+          }
+        },
+        {
+          "$": "Non-flying route 1",
+          "Position": {
+            "X": 110.30496,
+            "Y": -16.34831,
+            "Z": -401.4478
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "SkipConditions": {
+            "StepIf": {
+              "Flying": "Unlocked"
+            }
+          }
+        },
+        {
+          "$": "Non-flying route 2",
+          "Position": {
+            "X": 118.59972,
+            "Y": -20.556011,
+            "Z": -389.2515
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "DisableNavmesh": true,
+          "SkipConditions": {
+            "StepIf": {
+              "Flying": "Unlocked"
+            }
+          }
+        },
+        {
+          "$": "Non-flying route 3",
+          "Position": {
+            "X": 149.07782,
+            "Y": -17.796997,
+            "Z": -413.46735
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "SkipConditions": {
+            "StepIf": {
+              "Flying": "Unlocked"
+            }
+          }
+        },
+        {
+          "$": "Non-flying route 4",
+          "Position": {
+            "X": 148.45782,
+            "Y": -8.547052,
+            "Z": -426.11005
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "DisableNavmesh": true,
+          "SkipConditions": {
+            "StepIf": {
+              "Flying": "Unlocked"
+            }
+          }
+        },
+        {
+          "$": "Non-flying route 5",
+          "Position": {
+            "X": 152.01218,
+            "Y": -2.9488924,
+            "Z": -445.20065
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "DisableNavmesh": true,
+          "SkipConditions": {
+            "StepIf": {
+              "Flying": "Unlocked"
+            }
+          }
+        },
+        {
+          "$": "Non-flying route 6",
+          "Position": {
+            "X": 151.75952,
+            "Y": -5.3812466,
+            "Z": -454.7163
+          },
+          "TerritoryId": 398,
+          "InteractionType": "WalkTo",
+          "DisableNavmesh": true,
+          "SkipConditions": {
+            "StepIf": {
+              "Flying": "Unlocked"
+            }
+          }
+        },
+        {
+          "$": "Non-flying route 7",
+          "Position": {
+            "X": 151.61133,
+            "Y": -6.1493254,
+            "Z": -456.53964
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Jump",
+          "JumpDestination": {
+            "Position": {
+              "X": 151.91422,
+              "Y": -5.1268244,
+              "Z": -458.4945
+            }
+          },
+          "SkipConditions": {
+            "StepIf": {
+              "Flying": "Unlocked"
+            }
+          }
+        },
+        {
+          "DataId": 1014508,
+          "Position": {
+            "X": 98.527466,
+            "Y": -2.2554767,
+            "Z": -493.12582
+          },
+          "TerritoryId": 398,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "NextQuestId": 1927,
+          "$": "Next Quest: 'Smells Like Team Spirit'"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1927_Smells Like Team Spirit.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/The Dravanian Forelands/1927_Smells Like Team Spirit.json
@@ -1,0 +1,190 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1014507,
+          "Position": {
+            "X": 95.68933,
+            "Y": -2.2463098,
+            "Z": -492.79013
+          },
+          "TerritoryId": 398,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1014500,
+          "Position": {
+            "X": 164.69055,
+            "Y": -18.146557,
+            "Z": -566.2471
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1014514,
+          "Position": {
+            "X": 534.08093,
+            "Y": -51.36134,
+            "Z": 65.049194
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather"
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1011917,
+          "Position": {
+            "X": 535.30164,
+            "Y": -51.340645,
+            "Z": 65.293335
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 1014521,
+          "Position": {
+            "X": 496.42163,
+            "Y": -48.96616,
+            "Z": -56.595703
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 5,
+      "Steps": [
+        {
+          "$": "Sequence immediately starts with combat; resolve",
+          "Position": {
+            "X": 496.42163,
+            "Y": -48.96616,
+            "Z": -56.595703
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "FinishCombatIfAny",
+          "KillEnemyDataIds": [
+            5051
+          ]
+        },
+        {
+          "$": "Interact (O'bhen)",
+          "DataId": 1014521,
+          "Position": {
+            "X": 496.42163,
+            "Y": -48.96616,
+            "Z": -56.595703
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [
+                398
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 6,
+      "Steps": [
+        {
+          "DataId": 1014518,
+          "Position": {
+            "X": 354.3297,
+            "Y": -30.13275,
+            "Z": -414.4198
+          },
+          "TerritoryId": 398,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1011917,
+          "Position": {
+            "X": 535.30164,
+            "Y": -51.340645,
+            "Z": 65.293335
+          },
+          "TerritoryId": 398,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "AetheryteShortcut": "The Dravanian Forelands - Tailfeather"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/4.x - Stormblood/Side Quests/Rhalgr's Reach/2868_Ant Juice.json
+++ b/QuestPaths/4.x - Stormblood/Side Quests/Rhalgr's Reach/2868_Ant Juice.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "$": "This quest rewards the Head Bandage glamour",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1019477,
+          "Position": {
+            "X": 78.93494,
+            "Y": 0.04551731,
+            "Z": -25.467346
+          },
+          "TerritoryId": 635,
+          "InteractionType": "AcceptQuest",
+          "Mount": true,
+          "AetheryteShortcut": "Rhalgr's Reach",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2008088,
+          "Position": {
+            "X": 656.8856,
+            "Y": 86.19812,
+            "Z": 627.1305
+          },
+          "TerritoryId": 612,
+          "InteractionType": "Combat",
+          "Fly": true,
+          "EnemySpawnType": "AfterItemUse",
+          "ItemId": 2002091,
+          "KillEnemyDataIds": [
+            7213
+          ],
+          "AetheryteShortcut": "Fringes - Peering Stones",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1019477,
+          "Position": {
+            "X": 78.93494,
+            "Y": 0.04551731,
+            "Z": -25.467346
+          },
+          "TerritoryId": 635,
+          "InteractionType": "CompleteQuest",
+          "Mount": true,
+          "AetheryteShortcut": "Rhalgr's Reach",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Added yellow quests with notable rewards:
Magitek Armor mount action quest (164)
Meteor Survivor Ring quest (866, 868)
Thavnairian Onion quest (1729)
Dravanian Forelands quest chain; Thav Onion and Chocobo Dyeing (1775, 1776, 1777, 1779, 1780, 1781, 1782, 1783, 1785, 1922, 1924, 1925, 1926, 1927)
Head Bandage glamour unlock quest (2868)