### PR TITLE
Miscellaneous quest fixes

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/Side Stories/Delivery Moogle Quests/1532_Dubious Dancing.json
+++ b/QuestPaths/2.x - A Realm Reborn/Side Stories/Delivery Moogle Quests/1532_Dubious Dancing.json
@@ -112,7 +112,9 @@
           },
           "TerritoryId": 180,
           "InteractionType": "UseItem",
-          "ItemId": 2001334
+          "ItemId": 2001334,
+          "$": "Delay is needed; without it the step seems to have trouble using items consecutively",
+          "DelaySecondsAtStart": 1
         }
       ]
     },
@@ -128,7 +130,9 @@
           },
           "TerritoryId": 180,
           "InteractionType": "UseItem",
-          "ItemId": 2001334
+          "ItemId": 2001334,
+          "$": "Delay is needed; without it the step seems to have trouble using items consecutively",
+          "DelaySecondsAtStart": 1
         }
       ]
     },

--- a/QuestPaths/2.x - A Realm Reborn/Side Stories/Delivery Moogle Quests/1575_Hostages to Fortune.json
+++ b/QuestPaths/2.x - A Realm Reborn/Side Stories/Delivery Moogle Quests/1575_Hostages to Fortune.json
@@ -35,7 +35,8 @@
           },
           "TerritoryId": 154,
           "InteractionType": "Interact",
-          "AetheryteShortcut": "North Shroud - Fallgourd Float"
+          "AetheryteShortcut": "North Shroud - Fallgourd Float",
+          "Fly": true
         }
       ]
     },
@@ -125,7 +126,8 @@
             "Z": 140.91699
           },
           "TerritoryId": 154,
-          "InteractionType": "Interact"
+          "InteractionType": "Interact",
+          "Fly": true
         }
       ]
     },
@@ -157,6 +159,30 @@
     {
       "Sequence": 8,
       "Steps": [
+        {
+          "$": "Path out of The Bobbing Cork",
+          "Position": {
+            "X": -31.059683,
+            "Y": -40.708477,
+            "Z": 195.24632
+          },
+          "TerritoryId": 154,
+          "InteractionType": "WalkTo",
+          "Mount": true,
+          "SkipConditions": {
+            "StepIf": {
+              "NotNearPosition": {
+                "Position": {
+                  "X": -31.059683,
+                  "Y": -40.708477,
+                  "Z": 195.24632
+                },
+                "TerritoryId": 154,
+                "MaximumDistance": 30
+              }
+            }
+          }
+        },
         {
           "DataId": 1006406,
           "Position": {
@@ -190,6 +216,16 @@
       "Sequence": 10,
       "Steps": [
         {
+          "Position": {
+            "X": 63.714115,
+            "Y": -13.671487,
+            "Z": 143.30328
+          },
+          "TerritoryId": 154,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
           "DataId": 1010509,
           "Position": {
             "X": 63.370728,
@@ -197,8 +233,7 @@
             "Z": 141.86316
           },
           "TerritoryId": 154,
-          "InteractionType": "Interact",
-          "Fly": true
+          "InteractionType": "Interact"
         }
       ]
     },
@@ -230,6 +265,30 @@
     {
       "Sequence": 255,
       "Steps": [
+        {
+          "$": "Path out of The Bobbing Cork",
+          "Position": {
+            "X": -31.059683,
+            "Y": -40.708477,
+            "Z": 195.24632
+          },
+          "TerritoryId": 154,
+          "InteractionType": "WalkTo",
+          "Mount": true,
+          "SkipConditions": {
+            "StepIf": {
+              "NotNearPosition": {
+                "Position": {
+                  "X": -31.059683,
+                  "Y": -40.708477,
+                  "Z": 195.24632
+                },
+                "TerritoryId": 154,
+                "MaximumDistance": 30
+              }
+            }
+          }
+        },
         {
           "DataId": 1006406,
           "Position": {

--- a/QuestPaths/2.x - A Realm Reborn/Side Stories/Delivery Moogle Quests/1576_All in the Family.json
+++ b/QuestPaths/2.x - A Realm Reborn/Side Stories/Delivery Moogle Quests/1576_All in the Family.json
@@ -107,6 +107,18 @@
       "Sequence": 4,
       "Steps": [
         {
+          "$": "Fly near Hihibaru",
+          "Position": {
+            "X": -73.61801,
+            "Y": -22.01302,
+            "Z": -3.8327198
+          },
+          "TerritoryId": 145,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Eastern Thanalan - Camp Drybone",
+          "Fly": true
+        },
+        {
           "DataId": 1006196,
           "Position": {
             "X": -63.98114,
@@ -114,9 +126,7 @@
             "Z": -5.142395
           },
           "TerritoryId": 145,
-          "InteractionType": "Interact",
-          "AetheryteShortcut": "Eastern Thanalan - Camp Drybone",
-          "Fly": true
+          "InteractionType": "Interact"
         }
       ]
     },
@@ -161,13 +171,26 @@
           },
           "StopDistance": 5,
           "TerritoryId": 145,
-          "InteractionType": "Interact"
+          "InteractionType": "Interact",
+          "DelaySecondsAtStart": 1
         }
       ]
     },
     {
       "Sequence": 7,
       "Steps": [
+        {
+          "$": "Fly near Hihibaru first; otherwise gets caught on tent",
+          "Position": {
+            "X": -73.61801,
+            "Y": -22.01302,
+            "Z": -3.8327198
+          },
+          "TerritoryId": 145,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Eastern Thanalan - Camp Drybone",
+          "Fly": true
+        },
         {
           "DataId": 1006196,
           "Position": {
@@ -176,9 +199,7 @@
             "Z": -5.142395
           },
           "TerritoryId": 145,
-          "InteractionType": "Interact",
-          "AetheryteShortcut": "Eastern Thanalan - Camp Drybone",
-          "Fly": true
+          "InteractionType": "Interact"
         }
       ]
     },

--- a/QuestPaths/2.x - A Realm Reborn/Side Stories/Delivery Moogle Quests/241_Lone Survivor.json
+++ b/QuestPaths/2.x - A Realm Reborn/Side Stories/Delivery Moogle Quests/241_Lone Survivor.json
@@ -183,6 +183,7 @@
               "Answer": "TEXT_SUBPST021_00241_A1_000_001"
             }
           ],
+          "DelaySecondsAtStart": 1,
           "NextQuestId": 242
         }
       ]

--- a/QuestPaths/2.x - A Realm Reborn/Side Stories/Delivery Moogle Quests/244_The Hazy Professor.json
+++ b/QuestPaths/2.x - A Realm Reborn/Side Stories/Delivery Moogle Quests/244_The Hazy Professor.json
@@ -205,7 +205,8 @@
           },
           "TerritoryId": 145,
           "InteractionType": "UseItem",
-          "ItemId": 2001488
+          "ItemId": 2001488,
+          "DelaySecondsAtStart": 1
         }
       ]
     },

--- a/QuestPaths/3.x - Heavensward/Side Quests/The Churning Mists/1832_A Nutty Initiation.json
+++ b/QuestPaths/3.x - Heavensward/Side Quests/The Churning Mists/1832_A Nutty Initiation.json
@@ -10,6 +10,23 @@
       "Sequence": 0,
       "Steps": [
         {
+          "Position": {
+            "X": 455.38995,
+            "Y": -23.982193,
+            "Z": 106.70966
+          },
+          "TerritoryId": 400,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "The Churning Mists - Moghome",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        },
+        {
           "DataId": 1014442,
           "Position": {
             "X": 455.28345,
@@ -17,14 +34,7 @@
             "Z": 109.05615
           },
           "TerritoryId": 400,
-          "InteractionType": "AcceptQuest",
-          "Fly": true,
-          "AetheryteShortcut": "The Churning Mists - Moghome",
-          "SkipConditions": {
-            "AetheryteShortcutIf": {
-              "InSameTerritory": true
-            }
-          }
+          "InteractionType": "AcceptQuest"
         }
       ]
     },

--- a/QuestPaths/3.x - Heavensward/Side Stories/Tales of the Dragonsong War/1477_The Legacies We Leave.json
+++ b/QuestPaths/3.x - Heavensward/Side Stories/Tales of the Dragonsong War/1477_The Legacies We Leave.json
@@ -78,6 +78,12 @@
           "TerritoryId": 400,
           "InteractionType": "WalkTo",
           "Fly": true,
+          "AetheryteShortcut": "The Churning Mists - Moghome",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          },
           "$": "Moglin"
         },
         {

--- a/QuestPaths/3.x - Heavensward/Side Stories/Tales of the Dragonsong War/1479_The Burdens We Bear.json
+++ b/QuestPaths/3.x - Heavensward/Side Stories/Tales of the Dragonsong War/1479_The Burdens We Bear.json
@@ -34,6 +34,7 @@
             "[Idyllshire] Prologue Gate (Western Hinterlands)"
           ],
           "Fly": true,
+          "Land": true,
           "TargetTerritoryId": 463
         },
         {
@@ -84,6 +85,18 @@
       "Sequence": 4,
       "Steps": [
         {
+          "$": "Move to Tiamat's location before interaction; without this step, would often see qst stop before pathfinding",
+          "Position": {
+            "X": -698.36835,
+            "Y": -45.76334,
+            "Z": 415.04565
+          },
+          "TerritoryId": 402,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
           "DataId": 2007064,
           "Position": {
             "X": -696.0708,
@@ -91,8 +104,7 @@
             "Z": 432.33386
           },
           "TerritoryId": 402,
-          "InteractionType": "Interact",
-          "Fly": true
+          "InteractionType": "Interact"
         }
       ]
     },

--- a/QuestPaths/4.x - Stormblood/Alliance Raid Quests/3090_My Power, My Pleasure, My Pain.json
+++ b/QuestPaths/4.x - Stormblood/Alliance Raid Quests/3090_My Power, My Pleasure, My Pain.json
@@ -6,6 +6,37 @@
       "Sequence": 0,
       "Steps": [
         {
+          "$": "TP to Kugane > Airship Landing > Prima Vista if not there already",
+          "DataId": 1024156,
+          "Position": {
+            "X": -59.098206,
+            "Y": 79.05602,
+            "Z": 45.303955
+          },
+          "StopDistance": 7,
+          "TerritoryId": 628,
+          "InteractionType": "Interact",
+          "TargetTerritoryId": 735,
+          "AetheryteShortcut": "Kugane",
+          "AethernetShortcut": [
+            "[Kugane] Aetheryte Plaza",
+            "[Kugane] Airship Landing"
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true,
+              "InTerritory": [
+                735
+              ]
+            },
+            "StepIf": {
+              "InTerritory": [
+                735
+              ]
+            }
+          }
+        },
+        {
           "DataId": 1026029,
           "Position": {
             "X": 1.3274536,

--- a/QuestPaths/5.x - Shadowbringers/Alliance Raid Quests/4051_The Merchant of Komra.json
+++ b/QuestPaths/5.x - Shadowbringers/Alliance Raid Quests/4051_The Merchant of Komra.json
@@ -130,10 +130,7 @@
           "TerritoryId": 928,
           "InteractionType": "Interact",
           "DisableNavmesh": true,
-          "RequiredQuestVariables": [null,null,null,[
-              1
-            ],null,null
-          ],
+          "RequiredQuestVariables": [null,null,null,[1,3],null,null],
           "CompletionQuestVariablesFlags": [null,null,null,null,null,128]
         },
         {
@@ -226,6 +223,7 @@
           },
           "TerritoryId": 928,
           "InteractionType": "Interact",
+          "RequiredQuestVariables": [null,null,null,[2,17],null,null],
           "CompletionQuestVariablesFlags": [null,null,null,null,null,64]
         },
         {
@@ -238,7 +236,7 @@
           "InteractionType": "WalkTo",
           "RestartNavigationIfCancelled": false,
           "DelaySecondsAtStart": 2,
-          "RequiredQuestVariables": [null,null,null,[2],null,null]
+          "RequiredQuestVariables": [null,null,null,[2,19],null,null]
         },
         {
           "TerritoryId": 928,
@@ -263,7 +261,7 @@
             }
           },
           "DelaySecondsAtStart": 2,
-          "RequiredQuestVariables": [null,null,null,[2],null,null]
+          "RequiredQuestVariables": [null,null,null,[2,19],null,null]
         },
         {
           "DataId": 2011269,
@@ -275,7 +273,7 @@
           "TerritoryId": 928,
           "InteractionType": "Interact",
           "TargetTerritoryId": 928,
-          "RequiredQuestVariables": [null,null,null,[2],null,null]
+          "RequiredQuestVariables": [null,null,null,[2,19],null,null]
         },
         {
           "DataId": 2011459,
@@ -286,7 +284,7 @@
           },
           "TerritoryId": 928,
           "InteractionType": "Interact",
-          "RequiredQuestVariables": [null,null,null,[2],null,null]
+          "RequiredQuestVariables": [null,null,null,[2,19],null,null]
         }
       ]
     },

--- a/QuestPaths/5.x - Shadowbringers/Unlocks/Dungeons/3595_By the Time You Hear This.json
+++ b/QuestPaths/5.x - Shadowbringers/Unlocks/Dungeons/3595_By the Time You Hear This.json
@@ -13,7 +13,8 @@
             "Z": -14.023071
           },
           "TerritoryId": 819,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Crystarium"
         }
       ]
     },

--- a/QuestPaths/5.x - Shadowbringers/Unlocks/Dungeons/3596_Akadaemia Anyder.json
+++ b/QuestPaths/5.x - Shadowbringers/Unlocks/Dungeons/3596_Akadaemia Anyder.json
@@ -13,7 +13,12 @@
             "Z": 59.494873
           },
           "TerritoryId": 820,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Eulmore",
+          "AethernetShortcut": [
+            "[Eulmore] Aetheryte Plaza",
+            "[Eulmore] Southeast Derelicts"
+          ]
         }
       ]
     },

--- a/QuestPaths/7.x - Dawntrail/Side Stories/Hildibrand/5378_A Vandal in the Wild.json
+++ b/QuestPaths/7.x - Dawntrail/Side Stories/Hildibrand/5378_A Vandal in the Wild.json
@@ -151,6 +151,22 @@
           ]
         },
         {
+          "Position": {
+            "X": -323.35175,
+            "Y": 18.487406,
+            "Z": -112.28544
+          },
+          "TerritoryId": 1190,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,{"High": 4}]
+            }
+          }
+        },
+        {
           "DataId": 1049384,
           "Position": {
             "X": -321.98065,
@@ -159,7 +175,6 @@
           },
           "TerritoryId": 1190,
           "InteractionType": "Interact",
-          "Fly": true,
           "CompletionQuestVariablesFlags": [null,null,null,null,
             null,
             {"High": 4}


### PR DESCRIPTION
Delivery Moogle
- 1532 Added delay for consecutive item interactions
- 1575 Added paths out of the Bobbing Cork, added some missing flying toggles
- 1576 Added flying path near Hihibaru before interaction, otherwise would get stuck on tent; added some delays between combat and interaction
- 241 Added delay between combat and interaction
- 244 Added delay for consecutive item interactions

Dragonsong War
- 1477 Added missing teleport to Moghome
- 1479 Added Land before entering Matoya's Cave; added WalkTo step before interaction with Tiamat

ShB optional dungeons
- 3595 3596 added teleports to AcceptQuest step

Moogle unlock quest chain
- 1832 Added land near quest accept before accepting; without this, flying pathing was stuck on nearby ruins

Post-SB ARaid quests
- 3090 Added teleport to AcceptQuest step

Hildibrand DT
- 5378 Added land before interact (was getting caught on clothesline with regular pathing)

NieR weekly quests
- 4051 Updated quest flags to account for different permutations of this quest

---------
Notably, as part of 4051, I learned that "RequiredQuestVariables" is _not_ a bit flag check like "CompletionQuestVariableFlags", but instead compares the whole value to the specified numbers. For example, if the QW variable is `00010001`, it will _not_ satisfy `"RequiredQuestVariables":[1,...]`, as it compares the whole value (in this case, 17) rather than checking if the bit is flipped.