### PR TITLE
Quest Fixes

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/Allied Societies/Sylphs/Dailies/1280_No Root for You.json
+++ b/QuestPaths/2.x - A Realm Reborn/Allied Societies/Sylphs/Dailies/1280_No Root for You.json
@@ -1,7 +1,7 @@
 ﻿{
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "alydev",
-  "LastChecked":{"Username": "alydev", "Date": "2025-12-12"},
+  "LastChecked":{"Username": "ShermTank", "Date": "2026-04-17"},
   "QuestSequence": [
     {
       "Sequence": 0,
@@ -171,7 +171,7 @@
       "Sequence": 255,
       "Steps": [
         {
-          "DataId": 1005562,
+          "DataId": 1005563,
           "Position": {
             "X": 48.874634,
             "Y": 6.0734596,

--- a/QuestPaths/6.x - Endwalker/Side Stories/Hildibrand/4542_The Sleeping Gentleman.json
+++ b/QuestPaths/6.x - Endwalker/Side Stories/Hildibrand/4542_The Sleeping Gentleman.json
@@ -44,6 +44,29 @@
       "Sequence": 2,
       "Steps": [
         {
+          "$": "Path to aetheryte manually first; normal pathing bypasses the aethernet shortcut for some reason",
+          "Position": {
+            "X": 33.341263,
+            "Y": 0.09998739,
+            "Z": -30.881794
+          },
+          "TerritoryId": 963,
+          "InteractionType": "WalkTo",
+          "SkipConditions": {
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 129.59485,
+                  "Y": 26.993164,
+                  "Z": 13.473633
+                },
+                "TerritoryId": 963,
+                "MaximumDistance": 30
+              }
+            }
+          }
+        },
+        {
           "DataId": 1042489,
           "Position": {
             "X": 147.75305,
@@ -163,13 +186,29 @@
         {
           "DataId": 1042492,
           "Position": {
+            "X": -219.96817,
+            "Y": 1.8110301,
+            "Z": 756.0097
+          },
+          "TerritoryId": 813,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "SkipConditions": {
+            "StepIf": {
+              "CompletionQuestVariablesFlags": [null,null,null,null,null,64]
+            }
+          }
+        },
+        {
+          "DataId": 1042492,
+          "Position": {
             "X": -218.76862,
             "Y": 1.9084097,
             "Z": 756.16077
           },
           "TerritoryId": 813,
           "InteractionType": "Interact",
-          "Fly": true,
           "CompletionQuestVariablesFlags": [null,null,null,null,null,64]
         }
       ]

--- a/QuestPaths/6.x - Endwalker/Unlocks/Variant Dungeons/4646_A Key to the Past.json
+++ b/QuestPaths/6.x - Endwalker/Unlocks/Variant Dungeons/4646_A Key to the Past.json
@@ -81,7 +81,24 @@
       "Sequence": 4,
       "Steps": [
         {
-          "DataId": 1043777,
+          "DataId": 1043626,
+          "Position": {
+            "X": -230.94531,
+            "Y": -32,
+            "Z": 110.185425
+          },
+          "TerritoryId": 141,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "AetheryteShortcut": "Central Thanalan - Black Brush Station"
+        }
+      ]
+    },
+    {
+      "Sequence": 5,
+      "Steps": [
+        {
+          "DataId": 1044158,
           "Position": {
             "X": 66.20886,
             "Y": 4.0999947,
@@ -93,7 +110,12 @@
           "AethernetShortcut": [
             "[Ul'dah] Aetheryte Plaza",
             "[Ul'dah] Adventurers' Guild"
-          ]
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
         }
       ]
     },

--- a/QuestPaths/6.x - Endwalker/Unlocks/Variant Dungeons/4733_Mononoke Aware.json
+++ b/QuestPaths/6.x - Endwalker/Unlocks/Variant Dungeons/4733_Mononoke Aware.json
@@ -79,7 +79,12 @@
             "Z": -121.049866
           },
           "TerritoryId": 628,
-          "InteractionType": "Interact"
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Kugane",
+          "AethernetShortcut": [
+            "[Kugane] Aetheryte Plaza",
+            "[Kugane] Bokairo Inn"
+          ]
         }
       ]
     },


### PR DESCRIPTION
1280 Fixed CompleteQuest NPC ID _(Coords were correct but the NPC id was for a different sylph)_
4542 Fixed pathing not taking Aethernet shortcut into account
4646 Fixed sequence 4, added missing sequence 5
4733 Added teleport to post-dungeon step
