### PR TITLE
Added missing Crystalline Mean quests; Gathering steps are WIP

### DIFF
--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/3242_For Every Child a Star.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/3242_For Every Child a Star.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027232,
+          "Position": {
+            "X": -9.323303,
+            "Y": 20.1973,
+            "Z": -136.52252
+          },
+          "TerritoryId": 819,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1031093,
+          "Position": {
+            "X": 59.80005,
+            "Y": -4.970777E-05,
+            "Z": 197.07019
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null,null,null,null,null,32],
+          "AethernetShortcut": [
+            "[Crystarium] The Crystalline Mean",
+            "[Crystarium] The Pendants"
+          ]
+        },
+        {
+          "DataId": 1031091,
+          "Position": {
+            "X": 60.440918,
+            "Y": -2.1575283E-05,
+            "Z": 194.20154
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null,null,null,null,null,128]
+        },
+        {
+          "DataId": 1031092,
+          "Position": {
+            "X": 62.485718,
+            "Y": -2.636388E-05,
+            "Z": 194.68982
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null,null,null,null,null,64]
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1027232,
+          "Position": {
+            "X": -9.323303,
+            "Y": 20.1973,
+            "Z": -136.52252
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "DialogueChoices": [
+            {
+              "Prompt": "TEXT_LUCKLZ001_03242_Q1_000_000",
+              "Type": "List",
+              "Answer": "TEXT_LUCKLZ001_03242_A1_000_001"
+            }
+          ],
+          "AethernetShortcut": [
+            "[Crystarium] The Pendants",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "$": "Interact in clockwise order",
+      "Steps": [
+        {
+          "$": "Qeshi-Rae",
+          "DataId": 1027236,
+          "Position": {
+            "X": -3.1586914,
+            "Y": 20.186,
+            "Z": -148.91284
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null,null,null,null,null,16]
+        },
+        {
+          "$": "Thiuna",
+          "DataId": 1027234,
+          "Position": {
+            "X": 10.2387085,
+            "Y": 20.185999,
+            "Z": -138.2315
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null,null,null,null,null,64]
+        },
+        {
+          "$": "Iola",
+          "DataId": 1027233,
+          "Position": {
+            "X": 9.292725,
+            "Y": 20.186,
+            "Z": -124.55945
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null,null,null,null,null,128]
+        },
+        {
+          "$": "Frithrik",
+          "DataId": 1027237,
+          "Position": {
+            "X": -8.957031,
+            "Y": 20.186,
+            "Z": -119.18823
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null,null,null,null,null,8]
+        },
+        {
+          "$": "Bethric",
+          "DataId": 1027235,
+          "Position": {
+            "X": -19.516357,
+            "Y": 20.186,
+            "Z": -130.1748
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null,null,null,null,null,32]
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 1027232,
+          "Position": {
+            "X": -9.323303,
+            "Y": 20.1973,
+            "Z": -136.52252
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 2010514,
+          "Position": {
+            "X": -125.383484,
+            "Y": -0.015319824,
+            "Z": 14.389221
+          },
+          "TerritoryId": 819,
+          "InteractionType": "CompleteQuest",
+          "AethernetShortcut": [
+            "[Crystarium] The Crystalline Mean",
+            "[Crystarium] Aetheryte Plaza"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/3655_The Crystalline Mean.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/3655_The Crystalline Mean.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027232,
+          "Position": {
+            "X": -9.323303,
+            "Y": 20.1973,
+            "Z": -136.52252
+          },
+          "TerritoryId": 819,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027232,
+          "Position": {
+            "X": -9.323303,
+            "Y": 20.1973,
+            "Z": -136.52252
+          },
+          "TerritoryId": 819,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Crafting/3230_Cherished Memories.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Crafting/3230_Cherished Memories.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Comment": "Requires CRP, LTW, or WVR",
+      "Steps": [
+        {
+          "DataId": 1028326,
+          "Position": {
+            "X": 10.940674,
+            "Y": 20.186,
+            "Z": -142.53455
+          },
+          "TerritoryId": 819,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1028436,
+          "Position": {
+            "X": -19.394226,
+            "Y": 19.999794,
+            "Z": -29.58728
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "AethernetShortcut": [
+            "[Crystarium] The Crystalline Mean",
+            "[Crystarium] Aetheryte Plaza"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Comment": "Crafting turn-ins will need to be done manually",
+      "Steps": [
+        {
+          "DataId": 1027234,
+          "Position": {
+            "X": 10.2387085,
+            "Y": 20.185999,
+            "Z": -138.2315
+          },
+          "TerritoryId": 819,
+          "InteractionType": "CompleteQuest",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ],
+          "$": "No next quest, since that requires turn-ins before being available"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Crafting/3231_For Sentimental Reasons.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Crafting/3231_For Sentimental Reasons.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027234,
+          "Position": {
+            "X": 10.2387085,
+            "Y": 20.185999,
+            "Z": -138.2315
+          },
+          "TerritoryId": 819,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1028438,
+          "Position": {
+            "X": -55.832825,
+            "Y": 3.9998174,
+            "Z": 198.6571
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "AethernetShortcut": [
+            "[Crystarium] The Crystalline Mean",
+            "[Crystarium] Musica Universalis Markets"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1027234,
+          "Position": {
+            "X": 10.2387085,
+            "Y": 20.185999,
+            "Z": -138.2315
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "DialogueChoices": [
+            {
+              "Prompt": "TEXT_LUCKLA202_03231_Q1_000_000",
+              "Type": "List",
+              "Answer": "TEXT_LUCKLA202_03231_A1_000_002"
+            }
+          ],
+          "AethernetShortcut": [
+            "[Crystarium] Musica Universalis Markets",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "TerritoryId": 819,
+          "InteractionType": "Craft",
+          "ItemId": 27245,
+          "ItemCount": 1
+        },
+        {
+          "DataId": 1027234,
+          "Position": {
+            "X": 10.2387085,
+            "Y": 20.185999,
+            "Z": -138.2315
+          },
+          "TerritoryId": 819,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Crafting/3232_The Notes of Bond Restoring.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Crafting/3232_The Notes of Bond Restoring.json
@@ -13,7 +13,12 @@
             "Z": -138.2315
           },
           "TerritoryId": 819,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
         }
       ]
     },

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Fishing/3239_Well Eel Be Damned.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Fishing/3239_Well Eel Be Damned.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Comment": "Requires FSH",
+      "Steps": [
+        {
+          "DataId": 1027237,
+          "Position": {
+            "X": -8.957031,
+            "Y": 20.186,
+            "Z": -119.18823
+          },
+          "TerritoryId": 819,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "TerritoryId": 819,
+          "InteractionType": "None",
+          "AethernetShortcut": [
+            "[Crystarium] The Crystalline Mean",
+            "[Crystarium] Tessellation (Lakeland)"
+          ]
+        },
+        {
+          "Position": {
+            "X": 55.589294,
+            "Y": 2.0276523,
+            "Z": 669.1557
+          },
+          "TerritoryId": 813,
+          "InteractionType": "WalkTo",
+          "SkipConditions": {
+            "StepIf": {
+              "Flying": "Unlocked"
+            }
+          },
+          "$": "bridges have navmesh problems"
+        },
+        {
+          "Position": {
+            "X": 20.713037,
+            "Y": 1.7985868,
+            "Z": 675.3628
+          },
+          "TerritoryId": 813,
+          "InteractionType": "WalkTo",
+          "DisableNavmesh": true,
+          "SkipConditions": {
+            "StepIf": {
+              "Flying": "Unlocked"
+            }
+          }
+        },
+        {
+          "Position": {
+            "X": 16.098186,
+            "Y": 2.2509232,
+            "Z": 671.5291
+          },
+          "TerritoryId": 813,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "DataId": 2009924,
+          "Position": {
+            "X": 16.922241,
+            "Y": 2.304016,
+            "Z": 669.8862
+          },
+          "TerritoryId": 813,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1028472,
+          "Position": {
+            "X": -66.819336,
+            "Y": -36.75,
+            "Z": -273.27386
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Cabinet of Curiosity"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Comment": "Fishing turn-ins will need to be done manually",
+      "Steps": [
+        {
+          "DataId": 1027237,
+          "Position": {
+            "X": -8.957031,
+            "Y": 20.186,
+            "Z": -119.18823
+          },
+          "TerritoryId": 819,
+          "InteractionType": "CompleteQuest",
+          "AethernetShortcut": [
+            "[Crystarium] The Cabinet of Curiosity",
+            "[Crystarium] The Crystalline Mean"
+          ],
+          "$": "No next quest, since that requires turn-ins before being available"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Fishing/3239_Well Eel Be Damned.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Fishing/3239_Well Eel Be Damned.json
@@ -7,6 +7,11 @@
       "Comment": "Requires FSH",
       "Steps": [
         {
+          "TerritoryId": 819,
+          "InteractionType": "SwitchClass",
+          "TargetClass": "Fisher"
+        },
+        {
           "DataId": 1027237,
           "Position": {
             "X": -8.957031,

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Fishing/3240_Fishing for Confidence.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Fishing/3240_Fishing for Confidence.json
@@ -114,9 +114,14 @@
         },
         {
           "TerritoryId": 816,
-          "InteractionType": "Instruction",
           "Comment": "Fish for 1x Calico Trout (!) using Fruit Worm or Versatile Lure",
-          "$": "Use Instruction since turn-in is part of the same Sequence and has no QW flags (unlike tribal dailies); otherwise we'd fish forever"
+          "InteractionType": "Gather",
+          "ItemsToGather": [
+            {
+              "ItemId": 26750,
+              "ItemCount": 1
+            }
+          ]
         },
         {
           "DataId": 1031217,

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Fishing/3240_Fishing for Confidence.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Fishing/3240_Fishing for Confidence.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "Comment": "WIP; Manual fishing step",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "TerritoryId": 819,
+          "InteractionType": "SwitchClass",
+          "TargetClass": "Fisher"
+        },
+        {
+          "DataId": 1027237,
+          "Position": {
+            "X": -8.957031,
+            "Y": 20.186,
+            "Z": -119.18823
+          },
+          "TerritoryId": 819,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1028473,
+          "Position": {
+            "X": -59.18976,
+            "Y": -27.235973,
+            "Z": -270.19153
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "AethernetShortcut": [
+            "[Crystarium] The Crystalline Mean",
+            "[Crystarium] The Cabinet of Curiosity"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": -437.83975,
+            "Y": 53.93014,
+            "Z": -331.56207
+          },
+          "TerritoryId": 816,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "Il Mheg - Lydha Lran"
+        },
+        {
+          "DataId": 1028474,
+          "Position": {
+            "X": -435.75195,
+            "Y": 53.79563,
+            "Z": -332.23468
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "Position": {
+            "X": -437.83975,
+            "Y": 53.93014,
+            "Z": -331.56207
+          },
+          "TerritoryId": 816,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "SkipConditions": {
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": -435.4137,
+                  "Y": 52.479874,
+                  "Z": -328.0926
+                },
+                "TerritoryId": 816,
+                "MaximumDistance": 20
+              }
+            }
+          }
+        },
+        {
+          "Position": {
+            "X": -435.4137,
+            "Y": 52.479874,
+            "Z": -328.0926
+          },
+          "TerritoryId": 816,
+          "InteractionType": "WalkTo",
+          "Comment": "Fish for 1x Calico Trout (!) using Fruit Worm or Versatile Lure",
+          "Mount": false
+        },
+        {
+          "TerritoryId": 816,
+          "InteractionType": "Instruction",
+          "Comment": "Fish for 1x Calico Trout (!) using Fruit Worm or Versatile Lure",
+          "$": "Use Instruction since turn-in is part of the same Sequence and has no QW flags (unlike tribal dailies); otherwise we'd fish forever"
+        },
+        {
+          "DataId": 1031217,
+          "Position": {
+            "X": -13.626343,
+            "Y": 20.185999,
+            "Z": -119.523926
+          },
+          "TerritoryId": 819,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Fishing/3241_Morsel of the Deep.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Fishing/3241_Morsel of the Deep.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "Comment": "WIP; Manual fishing step",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "TerritoryId": 819,
+          "InteractionType": "SwitchClass",
+          "TargetClass": "Fisher"
+        },
+        {
+          "DataId": 1027237,
+          "Position": {
+            "X": -8.957031,
+            "Y": 20.186,
+            "Z": -119.18823
+          },
+          "TerritoryId": 819,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1028475,
+          "Position": {
+            "X": 719.173,
+            "Y": 26.886168,
+            "Z": 298.39014
+          },
+          "TerritoryId": 814,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Kholusia - Stilltide",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1028476,
+          "Position": {
+            "X": 695.12463,
+            "Y": 28.117487,
+            "Z": 274.92175
+          },
+          "TerritoryId": 814,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Comment": "Fish for 1x Prospero Eel (!) using Moyebi Shrimp or Versatile Lure",
+      "Steps": [
+        {
+          "$": "Teleport and fly to fishing hole",
+          "Position": {
+            "X": 463.6224,
+            "Y": 312.5834,
+            "Z": -292.67758
+          },
+          "TerritoryId": 818,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true,
+          "AetheryteShortcut": "Tempest - Ondo Cups",
+          "SkipConditions": {
+            "StepIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 463.6224,
+                  "Y": 312.5834,
+                  "Z": -292.67758
+                },
+                "TerritoryId": 818,
+                "MaximumDistance": 20
+              }
+            },
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        },
+        {
+          "TerritoryId": 818,
+          "InteractionType": "Instruction",
+          "Comment": "Fish for 1x Prospero Eel (!) using Moyebi Shrimp or Versatile Lure",
+          "$": "Use Instruction since turn-in is part of the same Sequence and has no QW flags (unlike tribal dailies); otherwise we'd fish forever"
+        },
+        {
+          "DataId": 1027237,
+          "Position": {
+            "X": -8.957031,
+            "Y": 20.186,
+            "Z": -119.18823
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 1029869,
+          "Position": {
+            "X": -3.7995605,
+            "Y": -7.264316E-07,
+            "Z": -63.70642
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "AethernetShortcut": [
+            "[Crystarium] The Crystalline Mean",
+            "[Crystarium] The Dossal Gate"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027237,
+          "Position": {
+            "X": -8.957031,
+            "Y": 20.186,
+            "Z": -119.18823
+          },
+          "TerritoryId": 819,
+          "InteractionType": "CompleteQuest",
+          "AethernetShortcut": [
+            "[Crystarium] The Dossal Gate",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Fishing/3241_Morsel of the Deep.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Fishing/3241_Morsel of the Deep.json
@@ -95,9 +95,14 @@
         },
         {
           "TerritoryId": 818,
-          "InteractionType": "Instruction",
           "Comment": "Fish for 1x Prospero Eel (!) using Moyebi Shrimp or Versatile Lure",
-          "$": "Use Instruction since turn-in is part of the same Sequence and has no QW flags (unlike tribal dailies); otherwise we'd fish forever"
+          "InteractionType": "Gather",
+          "ItemsToGather": [
+            {
+              "ItemId": 26751,
+              "ItemCount": 1
+            }
+          ]
         },
         {
           "DataId": 1027237,

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Forging/3227_Iola, Forgemaster.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Forging/3227_Iola, Forgemaster.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Comment": "Requires BSM, ARM, or GSM",
+      "Steps": [
+        {
+          "DataId": 1027233,
+          "Position": {
+            "X": 9.292725,
+            "Y": 20.186,
+            "Z": -124.55945
+          },
+          "TerritoryId": 819,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1028448,
+          "Position": {
+            "X": 76.98169,
+            "Y": 35.999687,
+            "Z": -135.69855
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "AethernetShortcut": [
+            "[Crystarium] The Crystalline Mean",
+            "[Crystarium] The Amaro Launch"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Comment": "Crafting turn-ins will need to be done manually",
+      "Steps": [
+        {
+          "DataId": 1027233,
+          "Position": {
+            "X": 9.292725,
+            "Y": 20.186,
+            "Z": -124.55945
+          },
+          "TerritoryId": 819,
+          "InteractionType": "CompleteQuest",
+          "AethernetShortcut": [
+            "[Crystarium] The Amaro Launch",
+            "[Crystarium] The Crystalline Mean"
+          ],
+          "$": "No next quest, since that requires turn-ins before being available"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Gathering/3236_On the Trail of a Myth.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Gathering/3236_On the Trail of a Myth.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Comment": "Requires MIN or BTN",
+      "Steps": [
+        {
+          "DataId": 1027236,
+          "Position": {
+            "X": -3.1586914,
+            "Y": 20.186,
+            "Z": -148.91284
+          },
+          "TerritoryId": 819,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1028494,
+          "Position": {
+            "X": 49.362915,
+            "Y": 36.19769,
+            "Z": -162.24927
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "AethernetShortcut": [
+            "[Crystarium] The Crystalline Mean",
+            "[Crystarium] The Amaro Launch"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1027834,
+          "Position": {
+            "X": -139.29962,
+            "Y": -47.649208,
+            "Z": -201.49542
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "AethernetShortcut": [
+            "[Crystarium] The Amaro Launch",
+            "[Crystarium] The Cabinet of Curiosity"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Comment": "Gathering turn-ins will need to be done manually",
+      "Steps": [
+        {
+          "DataId": 1027236,
+          "Position": {
+            "X": -3.1586914,
+            "Y": 20.186,
+            "Z": -148.91284
+          },
+          "TerritoryId": 819,
+          "InteractionType": "CompleteQuest",
+          "AethernetShortcut": [
+            "[Crystarium] The Cabinet of Curiosity",
+            "[Crystarium] The Crystalline Mean"
+          ],
+          "$": "No next quest, since that requires turn-ins before being available"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Gathering/3237_Shedding Light on the Myth.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Gathering/3237_Shedding Light on the Myth.json
@@ -105,9 +105,15 @@
       "Steps": [
         {
           "TerritoryId": 816,
-          "InteractionType": "Instruction",
-          "Comment": "Gather manually; Ancient Animal Skin is not currently supported\nMIN node: ( 8.6 , 19.6 )\nBTN node: ( 11.5 , 20.3 )",
-          "$": "QST is stuck at 'Gather(Pending for 26756)', even if specifying the gathering point id (MIN: 32627, BTN:32721)."
+          "Comment": "MIN node: ( 8.6 , 19.6 )\nBTN node: ( 11.5 , 20.3 )",
+          "$": "QST is stuck at 'Gather(Pending for 26756)', even if specifying the gathering point id (MIN: 32627, BTN:32721).",
+          "InteractionType": "Gather",
+          "ItemsToGather": [
+            {
+              "ItemId": 26756,
+              "ItemCount": 1
+            }
+          ]
         },
         {
           "DataId": 1028501,

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Gathering/3237_Shedding Light on the Myth.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Gathering/3237_Shedding Light on the Myth.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "Comment": "WIP; Manual gathering step",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027236,
+          "Position": {
+            "X": -3.1586914,
+            "Y": 20.186,
+            "Z": -148.91284
+          },
+          "TerritoryId": 819,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1028500,
+          "Position": {
+            "X": -400.10687,
+            "Y": 56.978058,
+            "Z": 451.89587
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "CompletionQuestVariablesFlags": [null,null,null,null,null,32],
+          "AetheryteShortcut": "Il Mheg - Lydha Lran",
+          "SkipConditions": {
+            "AetheryteShortcutIf": { "InSameTerritory": true }
+          }
+        },
+        {
+          "DataId": 1028499,
+          "Position": {
+            "X": -470.08472,
+            "Y": 70.15228,
+            "Z": 481.95605
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "CompletionQuestVariablesFlags": [null,null,null,null,null,64]
+        },
+        {
+          "DataId": 1028498,
+          "Position": {
+            "X": -508.7816,
+            "Y": 72.426414,
+            "Z": 533.56213
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "CompletionQuestVariablesFlags": [null,null,null,null,null,128]
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1028496,
+          "Position": {
+            "X": -586.511,
+            "Y": 90.98404,
+            "Z": 579.6139
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1028503,
+          "Position": {
+            "X": -496.42178,
+            "Y": 3.886272,
+            "Z": -80.857605
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "TerritoryId": 816,
+          "InteractionType": "Instruction",
+          "Comment": "Gather manually; Ancient Animal Skin is not currently supported\nMIN node: ( 8.6 , 19.6 )\nBTN node: ( 11.5 , 20.3 )",
+          "$": "QST is stuck at 'Gather(Pending for 26756)', even if specifying the gathering point id (MIN: 32627, BTN:32721)."
+        },
+        {
+          "DataId": 1028501,
+          "Position": {
+            "X": -494.4076,
+            "Y": 3.763135,
+            "Z": -78.78235
+          },
+          "TerritoryId": 816,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027236,
+          "Position": {
+            "X": -3.1586914,
+            "Y": 20.186,
+            "Z": -148.91284
+          },
+          "TerritoryId": 819,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Gathering/3238_The Myth Takes Form.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Gathering/3238_The Myth Takes Form.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "Comment": "WIP; Manual gathering step",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027236,
+          "Position": {
+            "X": -3.1586914,
+            "Y": 20.186,
+            "Z": -148.91284
+          },
+          "TerritoryId": 819,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1028504,
+          "Position": {
+            "X": 119.035645,
+            "Y": 361.51562,
+            "Z": -463.88953
+          },
+          "TerritoryId": 814,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Kholusia - Tomra",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "TerritoryId": 814,
+          "InteractionType": "Instruction",
+          "Comment": "Gather manually; Black Aethersand is not currently supported\nMIN node: ( 23.0 , 16.7 )\nBTN node: ( 15.4 , 13.7 )",
+          "$": "QST is stuck at 'Gather(Pending for 26757)', even if specifying the gathering point id (MIN: 32664, BTN:32764)."
+        },
+        {
+          "DataId": 1028504,
+          "Position": {
+            "X": 119.035645,
+            "Y": 361.51562,
+            "Z": -463.88953
+          },
+          "TerritoryId": 814,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 2009806,
+          "Position": {
+            "X": 125.596924,
+            "Y": 361.16577,
+            "Z": -471.30542
+          },
+          "TerritoryId": 814,
+          "InteractionType": "UseItem",
+          "ItemId": 2002566,
+          "Mount": false
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031128,
+          "Position": {
+            "X": -3.1586914,
+            "Y": 20.186,
+            "Z": -148.91284
+          },
+          "TerritoryId": 819,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Gathering/3238_The Myth Takes Form.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Gathering/3238_The Myth Takes Form.json
@@ -45,9 +45,15 @@
       "Steps": [
         {
           "TerritoryId": 814,
-          "InteractionType": "Instruction",
-          "Comment": "Gather manually; Black Aethersand is not currently supported\nMIN node: ( 23.0 , 16.7 )\nBTN node: ( 15.4 , 13.7 )",
-          "$": "QST is stuck at 'Gather(Pending for 26757)', even if specifying the gathering point id (MIN: 32664, BTN:32764)."
+          "Comment": "MIN node: ( 23.0 , 16.7 )\nBTN node: ( 15.4 , 13.7 )",
+          "$": "QST is stuck at 'Gather(Pending for 26757)', even if specifying the gathering point id (MIN: 32664, BTN:32764).",
+          "InteractionType": "Gather",
+          "ItemsToGather": [
+            {
+              "ItemId": 26757,
+              "ItemCount": 1
+            }
+          ]
         },
         {
           "DataId": 1028504,

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Nourishing/3233_Friends of a Feather.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Nourishing/3233_Friends of a Feather.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Comment": "Requires ALC or CUL",
+      "Steps": [
+        {
+          "DataId": 1027235,
+          "Position": {
+            "X": -19.516357,
+            "Y": 20.186,
+            "Z": -130.1748
+          },
+          "TerritoryId": 819,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1028481,
+          "Position": {
+            "X": 52.96399,
+            "Y": 36.197685,
+            "Z": -179.46143
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "AethernetShortcut": [
+            "[Crystarium] The Crystalline Mean",
+            "[Crystarium] The Amaro Launch"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1028482,
+          "Position": {
+            "X": 54.184692,
+            "Y": 36.197685,
+            "Z": -182.69635
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Emote",
+          "Emote": "pet"
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1029854,
+          "Position": {
+            "X": -130.20526,
+            "Y": 0,
+            "Z": -63.95056
+          },
+          "TerritoryId": 819,
+          "InteractionType": "Interact",
+          "AethernetShortcut": [
+            "[Crystarium] The Amaro Launch",
+            "[Crystarium] Temenos Rookery"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Comment": "Crafting turn-ins will need to be done manually",
+      "Steps": [
+        {
+          "DataId": 1027235,
+          "Position": {
+            "X": -19.516357,
+            "Y": 20.186,
+            "Z": -130.1748
+          },
+          "TerritoryId": 819,
+          "InteractionType": "CompleteQuest",
+          "AethernetShortcut": [
+            "[Crystarium] Temenos Rookery",
+            "[Crystarium] The Crystalline Mean"
+          ],
+          "$": "No next quest, since that requires turn-ins before being available"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Nourishing/3235_Healing Old Wounds.json
+++ b/QuestPaths/5.x - Shadowbringers/Custom Deliveries/Crystalline Mean Quests/Facet of Nourishing/3235_Healing Old Wounds.json
@@ -13,7 +13,12 @@
             "Z": -130.1748
           },
           "TerritoryId": 819,
-          "InteractionType": "AcceptQuest"
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Crystarium",
+          "AethernetShortcut": [
+            "[Crystarium] Aetheryte Plaza",
+            "[Crystarium] The Crystalline Mean"
+          ]
         }
       ]
     },


### PR DESCRIPTION
* No quests for intermediate turn-ins (like with Studium/Wachumeqimeqi), so these will need to be done manually no matter what
* Gathering steps require manual interaction at time of writing; GatheringPaths are not in place