### PR TITLE
 Add remaining Ultima Thule side quest paths

### DIFF
--- a/QuestPaths/6.x - Endwalker/Side Quests/Ultima Thule/4344_Come Back to Us.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Ultima Thule/4344_Come Back to Us.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1038030,
+          "Position": {
+            "X": 92.8706,
+            "Y": 270.128,
+            "Z": -597.096
+          },
+          "TerritoryId": 960,
+          "InteractionType": "AcceptQuest",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZJ008_04344_Q1_000_000",
+              "Answer": "TEXT_AKTKZJ008_04344_A1_000_001"
+            }
+          ],
+          "Fly": true,
+          "AetheryteShortcut": "Ultima Thule - Abode of the Ea",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 92.8706,
+                  "Y": 270.128,
+                  "Z": -597.096
+                },
+                "TerritoryId": 960,
+                "MaximumDistance": 100
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2012313,
+          "Position": {
+            "X": 356.051,
+            "Y": 282.276,
+            "Z": -628.642
+          },
+          "TerritoryId": 960,
+          "InteractionType": "Say",
+          "ChatMessage": {
+            "Key": "TEXT_AKTKZJ008_04344_SYSTEM_000_010"
+          },
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1040877,
+          "Position": {
+            "X": 398.565,
+            "Y": 281.776,
+            "Z": -739.186
+          },
+          "TerritoryId": 960,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1038030,
+          "Position": {
+            "X": 92.8706,
+            "Y": 270.128,
+            "Z": -597.096
+          },
+          "TerritoryId": 960,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Ultima Thule - Abode of the Ea",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 92.8706,
+                  "Y": 270.128,
+                  "Z": -597.096
+                },
+                "TerritoryId": 960,
+                "MaximumDistance": 100
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Ultima Thule/4345_Eat Like an Ea.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Ultima Thule/4345_Eat Like an Ea.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1038031,
+          "Position": {
+            "X": 43.7501,
+            "Y": 269.0,
+            "Z": -666.432
+          },
+          "TerritoryId": 960,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "StopDistance": 5,
+          "AetheryteShortcut": "Ultima Thule - Abode of the Ea",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 43.7501,
+                  "Y": 269.0,
+                  "Z": -666.432
+                },
+                "TerritoryId": 960,
+                "MaximumDistance": 150
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1040878,
+          "Position": {
+            "X": 581.292,
+            "Y": 286.081,
+            "Z": -520.288
+          },
+          "TerritoryId": 960,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterInteraction",
+          "KillEnemyDataIds": [
+            14096
+          ],
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZJ009_04345_Q1_000_000",
+              "Answer": "TEXT_AKTKZJ009_04345_A1_000_001"
+            }
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1038031,
+          "Position": {
+            "X": 43.7501,
+            "Y": 269.0,
+            "Z": -666.432
+          },
+          "TerritoryId": 960,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "StopDistance": 5,
+          "AetheryteShortcut": "Ultima Thule - Abode of the Ea",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 43.7501,
+                  "Y": 269.0,
+                  "Z": -666.432
+                },
+                "TerritoryId": 960,
+                "MaximumDistance": 150
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Ultima Thule/4347_The Body Beautiful.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Ultima Thule/4347_The Body Beautiful.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1040882,
+          "Position": {
+            "X": 65.7187,
+            "Y": 270.086,
+            "Z": -448.959
+          },
+          "TerritoryId": 960,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "StopDistance": 5,
+          "AetheryteShortcut": "Ultima Thule - Abode of the Ea",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 65.7187,
+                  "Y": 270.086,
+                  "Z": -448.959
+                },
+                "TerritoryId": 960,
+                "MaximumDistance": 150
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 225.082,
+            "Y": 269.0,
+            "Z": -537.484
+          },
+          "TerritoryId": 960,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "ComplexCombatData": [
+            {
+              "DataId": 13327,
+              "RewardItemId": 2003255,
+              "RewardItemCount": 2
+            },
+            {
+              "DataId": 13328,
+              "RewardItemId": 2003255,
+              "RewardItemCount": 2
+            },
+            {
+              "DataId": 13329,
+              "RewardItemId": 2003255,
+              "RewardItemCount": 2
+            }
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1040882,
+          "Position": {
+            "X": 65.7187,
+            "Y": 270.086,
+            "Z": -448.959
+          },
+          "TerritoryId": 960,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "StopDistance": 5,
+          "AetheryteShortcut": "Ultima Thule - Abode of the Ea",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 65.7187,
+                  "Y": 270.086,
+                  "Z": -448.959
+                },
+                "TerritoryId": 960,
+                "MaximumDistance": 150
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Ultima Thule/4351_Remember Me.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Ultima Thule/4351_Remember Me.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1038025,
+          "Position": {
+            "X": 191.516,
+            "Y": 268.914,
+            "Z": -689.174
+          },
+          "TerritoryId": 960,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "StopDistance": 5,
+          "AetheryteShortcut": "Ultima Thule - Abode of the Ea",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 191.516,
+                  "Y": 268.914,
+                  "Z": -689.174
+                },
+                "TerritoryId": 960,
+                "MaximumDistance": 150
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2012333,
+          "Position": {
+            "X": -27.5487,
+            "Y": 272.379,
+            "Z": -437.276
+          },
+          "TerritoryId": 960,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterInteraction",
+          "KillEnemyDataIds": [
+            14045
+          ],
+          "CombatItemUse": {
+            "ItemId": 2003386,
+            "Condition": "Health%",
+            "Value": 50
+          },
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1038025,
+          "Position": {
+            "X": 191.516,
+            "Y": 268.914,
+            "Z": -689.174
+          },
+          "TerritoryId": 960,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "StopDistance": 5,
+          "AetheryteShortcut": "Ultima Thule - Abode of the Ea",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 191.516,
+                  "Y": 268.914,
+                  "Z": -689.174
+                },
+                "TerritoryId": 960,
+                "MaximumDistance": 150
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Ultima Thule/4352_Bodily Curiosity.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Ultima Thule/4352_Bodily Curiosity.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1042074,
+          "Position": {
+            "X": 124.111,
+            "Y": 269.373,
+            "Z": -509.683
+          },
+          "TerritoryId": 960,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "StopDistance": 5,
+          "AetheryteShortcut": "Ultima Thule - Abode of the Ea",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 124.111,
+                  "Y": 269.373,
+                  "Z": -509.683
+                },
+                "TerritoryId": 960,
+                "MaximumDistance": 150
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1042074,
+          "Position": {
+            "X": 124.111,
+            "Y": 269.373,
+            "Z": -509.683
+          },
+          "TerritoryId": 960,
+          "InteractionType": "Emote",
+          "Emote": "joy",
+          "Fly": true,
+          "StopDistance": 5
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1042074,
+          "Position": {
+            "X": 124.111,
+            "Y": 269.373,
+            "Z": -509.683
+          },
+          "TerritoryId": 960,
+          "InteractionType": "Emote",
+          "Emote": "slap",
+          "Fly": true,
+          "StopDistance": 5,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZJ016_04352_Q1_000_100",
+              "Answer": "TEXT_AKTKZJ016_04352_A2_000_100"
+            }
+          ]
+        },
+        {
+          "DataId": 1042074,
+          "Position": {
+            "X": 124.111,
+            "Y": 269.373,
+            "Z": -509.683
+          },
+          "TerritoryId": 960,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "StopDistance": 5,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZJ016_04352_Q1_000_100",
+              "Answer": "TEXT_AKTKZJ016_04352_A2_000_100"
+            }
+          ],
+          "AetheryteShortcut": "Ultima Thule - Abode of the Ea",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 124.111,
+                  "Y": 269.373,
+                  "Z": -509.683
+                },
+                "TerritoryId": 960,
+                "MaximumDistance": 150
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Ultima Thule/4353_A Life of Regret.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Ultima Thule/4353_A Life of Regret.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1042075,
+          "Position": {
+            "X": 3.77302,
+            "Y": 269.758,
+            "Z": -679.625
+          },
+          "TerritoryId": 960,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "StopDistance": 5,
+          "AetheryteShortcut": "Ultima Thule - Abode of the Ea",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 3.77302,
+                  "Y": 269.758,
+                  "Z": -679.625
+                },
+                "TerritoryId": 960,
+                "MaximumDistance": 150
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2012688,
+          "Position": {
+            "X": 6.75813,
+            "Y": 272.348,
+            "Z": -685.423
+          },
+          "TerritoryId": 960,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "StopDistance": 1
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1042075,
+          "Position": {
+            "X": 3.77302,
+            "Y": 269.758,
+            "Z": -679.625
+          },
+          "TerritoryId": 960,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "StopDistance": 5
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "Position": {
+            "X": -355.569,
+            "Y": 263.133,
+            "Z": -422.697
+          },
+          "TerritoryId": 960,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "ComplexCombatData": [
+            {
+              "DataId": 13330,
+              "RewardItemId": 2003385,
+              "RewardItemCount": 1
+            }
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1042075,
+          "Position": {
+            "X": 3.77302,
+            "Y": 269.758,
+            "Z": -679.625
+          },
+          "TerritoryId": 960,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "StopDistance": 5,
+          "AetheryteShortcut": "Ultima Thule - Abode of the Ea",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 3.77302,
+                  "Y": 269.758,
+                  "Z": -679.625
+                },
+                "TerritoryId": 960,
+                "MaximumDistance": 150
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Ultima Thule/4356_Work Woes.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Ultima Thule/4356_Work Woes.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041660,
+          "Position": {
+            "X": 482.365,
+            "Y": 437.001,
+            "Z": 311.945
+          },
+          "TerritoryId": 960,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "StopDistance": 5,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZK003_04356_Q1_000_100",
+              "Answer": "TEXT_AKTKZK003_04356_A2_000_100"
+            }
+          ],
+          "AetheryteShortcut": "Ultima Thule - Base Omicron",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 482.365,
+                  "Y": 437.001,
+                  "Z": 311.945
+                },
+                "TerritoryId": 960,
+                "MaximumDistance": 150
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041660,
+          "Position": {
+            "X": 482.365,
+            "Y": 437.001,
+            "Z": 311.945
+          },
+          "TerritoryId": 960,
+          "InteractionType": "Emote",
+          "Emote": "dance",
+          "Fly": true,
+          "StopDistance": 5
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1041661,
+          "Position": {
+            "X": 618.8,
+            "Y": 440.463,
+            "Z": 381.421
+          },
+          "TerritoryId": 960,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "StopDistance": 5,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZK003_04356_Q2_000_200",
+              "Answer": "TEXT_AKTKZK003_04356_A1_000_200"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041660,
+          "Position": {
+            "X": 482.365,
+            "Y": 437.001,
+            "Z": 311.945
+          },
+          "TerritoryId": 960,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "StopDistance": 5,
+          "AetheryteShortcut": "Ultima Thule - Base Omicron",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "NearPosition": {
+                "Position": {
+                  "X": 482.365,
+                  "Y": 437.001,
+                  "Z": 311.945
+                },
+                "TerritoryId": 960,
+                "MaximumDistance": 150
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
  Adds quest paths for the remaining Ultima Thule side quests:

  - 4344 Come Back to Us
  - 4345 Eat Like an Ea
  - 4347 The Body Beautiful
  - 4351 Remember Me
  - 4352 Bodily Curiosity
  - 4353 A Life of Regret
  - 4356 Work Woes

  Tested successfully in game on 2026-05-06.