### PR TITLE
Fix: Dangling Else If in Emote.cs

### DIFF
--- a/Questionable/Controller/Steps/Interactions/Emote.cs
+++ b/Questionable/Controller/Steps/Interactions/Emote.cs
@@ -17,9 +17,9 @@ internal static class Emote
             {
                 if (step.Emote == null)
                     return [];
-                else if (step.InteractionType != EInteractionType.Emote)
-                    return [];
             }
+            else if (step.InteractionType != EInteractionType.Emote)
+                return [];
 
             ArgumentNullException.ThrowIfNull(step.Emote);
 


### PR DESCRIPTION
Looks like a bug got introduced in Emote.cs when styling was applied in e587001a allowing Combat steps to fall through and crash like on quest On Holy Ground causing the following error:

```
08:49:28.812 | INF | [Questionable] QuestController: Next quest  
  264 accepted or completed                                                                                                                                     
  08:49:28.812 | DBG | [Questionable] QuestController: Started: 264                                                                                             
  08:49:28.814 | ERR | [Questionable] <New sequence True/QuestReference { CurrentQuest = 264, Sequence = 1, State = Complete }> QuestController: Failed to      
  create tasks                                                                                                                                                  
      System.ArgumentNullException: Value cannot be null. (Parameter 'step.Emote')                                                                              
         at System.ArgumentNullException.Throw(String paramName)                                                                                                
         at System.ArgumentNullException.ThrowIfNull(Object argument, String paramName)                                                                         
         at Questionable.Controller.Steps.Interactions.Emote.Factory.CreateAllTasks(Quest quest, QuestSequence sequence, QuestStep step) in                     
  X:\Questionable\Controller\Steps\Interactions\Emote.cs:line 24                                                                                                
         at Questionable.Controller.Steps.TaskCreator.<>c__DisplayClass6_0.<CreateTasks>b__1(ITaskFactory x) in                                                 
  X:\Questionable\Controller\Steps\TaskCreator.cs:line 62                                                                                                       
         at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.ToList()                                                                                  
         at Questionable.Controller.Steps.TaskCreator.CreateTasks(Quest quest, Byte sequenceNumber, QuestSequence sequence, QuestStep step) in                  
  X:\Questionable\Controller\Steps\TaskCreator.cs:line 59                                                                                                       
         at Questionable.Controller.QuestController.ExecuteNextStep() in X:\Questionable\Controller\QuestController.cs:line 938                                 
  08:49:28.815 | INF | [Questionable] <New sequence True/QuestReference { CurrentQuest = 264, Sequence = 1, State = Complete }> <Stop/Tasks failed to create>   
  QuestController: Setting automation type to Manual (previous: Automatic)                                                                                      
  08:49:28.827 | DBG | [Questionable] HighlightObject: Setting highlight to
```
This fixes those situations (tested myself)