### PR TITLE
Add Mare Lamentorum side quest paths

### DIFF
--- a/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4242_A Strange New Moon.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4242_A Strange New Moon.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037807,
+          "Position": {
+            "X": -110.12,
+            "Y": -133.073,
+            "Z": -466.04
+          },
+          "TerritoryId": 959,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -97.6998,
+            "Y": 54.4054,
+            "Z": 94.015
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "ComplexCombatData": [
+            {
+              "DataId": 13367,
+              "RewardItemId": 2003366,
+              "RewardItemCount": 1
+            }
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037807,
+          "Position": {
+            "X": -110.12,
+            "Y": -133.073,
+            "Z": -466.04
+          },
+          "TerritoryId": 959,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Mare Lamentorum - Bestways Burrow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4243_Getting to Know You.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4243_Getting to Know You.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041792,
+          "Position": {
+            "X": -270.652,
+            "Y": -144.0,
+            "Z": -475.698
+          },
+          "TerritoryId": 959,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2012591,
+          "Position": {
+            "X": -272.572,
+            "Y": -144.03,
+            "Z": -475.456
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZE004_04243_Q1_000_000",
+              "Answer": "TEXT_AKTKZE004_04243_A1_000_001"
+            },
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZE004_04243_Q2_000_000",
+              "Answer": "TEXT_AKTKZE004_04243_A2_000_001"
+            },
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZE004_04243_Q3_000_000",
+              "Answer": "TEXT_AKTKZE004_04243_A3_000_003"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041792,
+          "Position": {
+            "X": -270.652,
+            "Y": -144.0,
+            "Z": -475.698
+          },
+          "TerritoryId": 959,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Mare Lamentorum - Bestways Burrow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4244_Over the Rainbow Crystal.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4244_Over the Rainbow Crystal.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041795,
+          "Position": {
+            "X": -356.741,
+            "Y": -168.0,
+            "Z": -606.134
+          },
+          "TerritoryId": 959,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2012593,
+          "Position": {
+            "X": -725.154,
+            "Y": -141.371,
+            "Z": -588.185
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 128],
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2012594,
+          "Position": {
+            "X": -655.972,
+            "Y": -140.948,
+            "Z": -724.268
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 64],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1041796,
+          "Position": {
+            "X": -418.889,
+            "Y": -167.5,
+            "Z": -741.17
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1037866,
+          "Position": {
+            "X": -286.821,
+            "Y": -143.5,
+            "Z": -500.802
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041795,
+          "Position": {
+            "X": -356.741,
+            "Y": -168.0,
+            "Z": -606.134
+          },
+          "TerritoryId": 959,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Mare Lamentorum - Bestways Burrow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4246_Clothes Maketh the Man.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4246_Clothes Maketh the Man.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041799,
+          "Position": {
+            "X": 127.805,
+            "Y": -132.62,
+            "Z": -554.489
+          },
+          "TerritoryId": 959,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041801,
+          "Position": {
+            "X": 192.367,
+            "Y": -49.6071,
+            "Z": -399.789
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1041801,
+          "Position": {
+            "X": 192.367,
+            "Y": -49.6071,
+            "Z": -399.789
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Emote",
+          "Emote": "pose",
+          "Fly": true,
+          "Land": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZE007_04246_Q1_000_000",
+              "Answer": "TEXT_AKTKZE007_04246_A1_000_001"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1041801,
+          "Position": {
+            "X": 192.367,
+            "Y": -49.6071,
+            "Z": -399.789
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Emote",
+          "Emote": "battlestance",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041799,
+          "Position": {
+            "X": 127.805,
+            "Y": -132.62,
+            "Z": -554.489
+          },
+          "TerritoryId": 959,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Mare Lamentorum - Bestways Burrow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4247_A Test of Mettle.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4247_A Test of Mettle.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1040865,
+          "Position": {
+            "X": 45.7247,
+            "Y": -137.417,
+            "Z": -612.957
+          },
+          "TerritoryId": 959,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1040866,
+          "Position": {
+            "X": 528.369,
+            "Y": -167.865,
+            "Z": -711.319
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterInteraction",
+          "KillEnemyDataIds": [
+            14052,
+            14051
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1040866,
+          "Position": {
+            "X": 528.369,
+            "Y": -167.865,
+            "Z": -711.319
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterInteraction",
+          "CombatDelaySecondsAtStart": 8,
+          "KillEnemyDataIds": [
+            14052,
+            14051
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1040866,
+          "Position": {
+            "X": 528.369,
+            "Y": -167.865,
+            "Z": -711.319
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "DelaySecondsAtStart": 5,
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1040865,
+          "Position": {
+            "X": 45.7247,
+            "Y": -137.417,
+            "Z": -612.957
+          },
+          "TerritoryId": 959,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Mare Lamentorum - Bestways Burrow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4248_Unfortunate Fortune-telling.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4248_Unfortunate Fortune-telling.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037861,
+          "Position": {
+            "X": 320.511,
+            "Y": -144.0,
+            "Z": -479.444
+          },
+          "TerritoryId": 959,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041804,
+          "Position": {
+            "X": 310.436,
+            "Y": -161.139,
+            "Z": -743.365
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2012596,
+          "Position": {
+            "X": 311.452,
+            "Y": -161.972,
+            "Z": -746.423
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1041804,
+          "Position": {
+            "X": 310.436,
+            "Y": -161.139,
+            "Z": -743.365
+          },
+          "TerritoryId": 959,
+          "InteractionType": "UseItem",
+          "ItemId": 2003370
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037861,
+          "Position": {
+            "X": 320.511,
+            "Y": -144.0,
+            "Z": -479.444
+          },
+          "TerritoryId": 959,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Mare Lamentorum - Bestways Burrow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4249_Dangerous Work.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4249_Dangerous Work.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041809,
+          "Position": {
+            "X": 12.3751,
+            "Y": -127.349,
+            "Z": -573.998
+          },
+          "TerritoryId": 959,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041808,
+          "Position": {
+            "X": 354.818,
+            "Y": 89.25,
+            "Z": 527.001
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Mare Lamentorum - Sinus Lacrimarum",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1041805,
+          "Position": {
+            "X": 109.36429,
+            "Y": 49.45694,
+            "Z": 369.7881
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 128],
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1041807,
+          "Position": {
+            "X": 478.39474,
+            "Y": 63.885937,
+            "Z": 450.003
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 32],
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1041806,
+          "Position": {
+            "X": 494.28403,
+            "Y": 70.07297,
+            "Z": 531.951
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 64],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1042131,
+          "Position": {
+            "X": 354.818,
+            "Y": 89.25,
+            "Z": 527.001
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "Position": {
+            "X": 12.3751,
+            "Y": -127.349,
+            "Z": -573.998
+          },
+          "TerritoryId": 959,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Mare Lamentorum - Bestways Burrow",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1041809,
+          "Position": {
+            "X": 12.3751,
+            "Y": -127.349,
+            "Z": -573.998
+          },
+          "TerritoryId": 959,
+          "InteractionType": "CompleteQuest",
+          "DelaySecondsAtStart": 2,
+          "Mount": false
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4250_Material Woes.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4250_Material Woes.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037817,
+          "Position": {
+            "X": 123.583,
+            "Y": -137.438,
+            "Z": -525.536
+          },
+          "TerritoryId": 959,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 172.04109,
+            "Y": 77.32776,
+            "Z": 5.062954
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "ComplexCombatData": [
+            {
+              "DataId": 13362,
+              "NameId": 10458,
+              "RewardItemId": 2003371,
+              "RewardItemCount": 1
+            }
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037817,
+          "Position": {
+            "X": 123.583,
+            "Y": -137.438,
+            "Z": -525.536
+          },
+          "TerritoryId": 959,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Mare Lamentorum - Bestways Burrow",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZE011_04250_Q1_000_000",
+              "Answer": "TEXT_AKTKZE011_04250_A1_000_001"
+            }
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4251_For a Greater Garden.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4251_For a Greater Garden.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041820,
+          "Position": {
+            "X": 277.032,
+            "Y": -144.0,
+            "Z": -525.93
+          },
+          "TerritoryId": 959,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 225.946,
+            "Y": 96.971,
+            "Z": -59.4212
+          },
+          "TerritoryId": 959,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "Position": {
+            "X": 225.946,
+            "Y": 96.971,
+            "Z": -59.4212
+          },
+          "TerritoryId": 959,
+          "InteractionType": "WalkTo",
+          "DelaySecondsAtStart": 2,
+          "Mount": false,
+          "Sprint": false,
+          "DisableNavmesh": true
+        },
+        {
+          "DataId": 1041821,
+          "Position": {
+            "X": 225.946,
+            "Y": 96.971,
+            "Z": -59.4212
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "DelaySecondsAtStart": 2,
+          "Mount": false
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2012597,
+          "Position": {
+            "X": 228.522,
+            "Y": 98.5295,
+            "Z": -62.7299
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_AKTKZE012_04251_SYSTEM_100_022",
+              "Yes": true
+            }
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041820,
+          "Position": {
+            "X": 277.032,
+            "Y": -144.0,
+            "Z": -525.93
+          },
+          "TerritoryId": 959,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Mare Lamentorum - Bestways Burrow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4252_Lone Loporrit.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4252_Lone Loporrit.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041822,
+          "Position": {
+            "X": -20.6497,
+            "Y": -137.417,
+            "Z": -615.323
+          },
+          "TerritoryId": 959,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041823,
+          "Position": {
+            "X": -86.8696,
+            "Y": 76.9186,
+            "Z": -31.7235
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2012600,
+          "Position": {
+            "X": -89.8168,
+            "Y": 76.3823,
+            "Z": -31.5481
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Say",
+          "ChatMessage": {
+            "Key": "TEXT_AKTKZE013_04252_SAYTODO_000_020"
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "Position": {
+            "X": -120.386635,
+            "Y": 60.49149,
+            "Z": -89.006065
+          },
+          "TerritoryId": 959,
+          "InteractionType": "WalkTo"
+        },
+        {
+          "Position": {
+            "X": -130.58957,
+            "Y": 60.532887,
+            "Z": -95.791954
+          },
+          "TerritoryId": 959,
+          "InteractionType": "WalkTo"
+        },
+        {
+          "DataId": 1041825,
+          "Position": {
+            "X": -132.40259,
+            "Y": 60.491486,
+            "Z": -93.70575
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041822,
+          "Position": {
+            "X": -20.6497,
+            "Y": -137.417,
+            "Z": -615.323
+          },
+          "TerritoryId": 959,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Mare Lamentorum - Bestways Burrow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4254_Overexcited Admirer.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4254_Overexcited Admirer.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041826,
+          "Position": {
+            "X": 38.7582,
+            "Y": -129.0,
+            "Z": -501.906
+          },
+          "TerritoryId": 959,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041827,
+          "Position": {
+            "X": 300.744,
+            "Y": 71.8707,
+            "Z": 335.68
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Mare Lamentorum - Sinus Lacrimarum",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": 241.1552,
+            "Y": 66.47317,
+            "Z": 444.5359
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "ComplexCombatData": [
+            {
+              "DataId": 13361,
+              "RewardItemId": 2003375,
+              "RewardItemCount": 1
+            }
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "Position": {
+            "X": 52.5849,
+            "Y": 73.2411,
+            "Z": 3.48112
+          },
+          "TerritoryId": 959,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1041828,
+          "Position": {
+            "X": 52.5849,
+            "Y": 73.2411,
+            "Z": 3.48112
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "DelaySecondsAtStart": 5
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041826,
+          "Position": {
+            "X": 38.7582,
+            "Y": -129.0,
+            "Z": -501.906
+          },
+          "TerritoryId": 959,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Mare Lamentorum - Bestways Burrow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4255_Troubled Waters.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Mare Lamentorum/4255_Troubled Waters.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037856,
+          "Position": {
+            "X": 292.886,
+            "Y": -144.0,
+            "Z": -537.865
+          },
+          "TerritoryId": 959,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2012601,
+          "Position": {
+            "X": 359.51782,
+            "Y": -161.08954,
+            "Z": -769.3752
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 128],
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2012602,
+          "Position": {
+            "X": 659.4186,
+            "Y": -161.42523,
+            "Z": -809.4758
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 64],
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2012603,
+          "Position": {
+            "X": 336.5376,
+            "Y": -161.45575,
+            "Z": -775.9365
+          },
+          "TerritoryId": 959,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 32],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037856,
+          "Position": {
+            "X": 292.886,
+            "Y": -144.0,
+            "Z": -537.865
+          },
+          "TerritoryId": 959,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Mare Lamentorum - Bestways Burrow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
  Adds quest paths for the following Mare Lamentorum side quests:
  - 4242 A Strange New Moon
  - 4243 Getting to Know You
  - 4244 Over the Rainbow Crystal
  - 4246 Clothes Maketh the Man
  - 4247 A Test of Mettle
  - 4248 Unfortunate Fortune-telling
  - 4249 Dangerous Work
  - 4250 Material Woes
  - 4251 For a Greater Garden
  - 4252 Lone Loporrit
  - 4254 Overexcited Admirer
  - 4255 Troubled Waters
 
Only 4245 All Fun and Games is not included.
Tested the added paths in-game.