### PR TITLE
Add Thavnair side quest paths

### DIFF
--- a/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4256_The Guardian's Shield.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4256_The Guardian's Shield.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1039517,
+          "Position": {
+            "X": 376.6078,
+            "Y": 5.709401,
+            "Z": -220.50812
+          },
+          "TerritoryId": 957,
+          "InteractionType": "AcceptQuest",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZF001_04256_Q1_000_004",
+              "Answer": "TEXT_AKTKZF001_04256_A1_000_001"
+            }
+          ],
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -19.096,
+            "Y": 19.9251,
+            "Z": -276.803
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "ComplexCombatData": [
+            {
+              "DataId": 13536,
+              "NameId": 10708,
+              "MinimumKillCount": 1,
+              "RewardItemId": 2003214,
+              "RewardItemCount": 1
+            }
+          ],
+          "AetheryteShortcut": "Thavnair - Palaka's Stand",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1039517,
+          "Position": {
+            "X": 376.6078,
+            "Y": 5.709401,
+            "Z": -220.50812
+          },
+          "TerritoryId": 957,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4258_Quick Heels.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4258_Quick Heels.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037707,
+          "Position": {
+            "X": 432.029,
+            "Y": 5.91269,
+            "Z": -225.197
+          },
+          "TerritoryId": 957,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041912,
+          "Position": {
+            "X": 404.653,
+            "Y": 5.61108,
+            "Z": -289.451
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": 396.07855,
+            "Y": 3.1168787,
+            "Z": -275.07068
+          },
+          "TerritoryId": 957,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand",
+          "Mount": false
+        },
+        {
+          "DataId": 1041913,
+          "Position": {
+            "X": 427.999,
+            "Y": 22.0824,
+            "Z": -468.493
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 2012256,
+          "Position": {
+            "X": 428.893,
+            "Y": 22.4415,
+            "Z": -467.529
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 1041912,
+          "Position": {
+            "X": 404.653,
+            "Y": 5.61108,
+            "Z": -289.451
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037707,
+          "Position": {
+            "X": 432.029,
+            "Y": 5.91269,
+            "Z": -225.197
+          },
+          "TerritoryId": 957,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4260_Treasure Hunters.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4260_Treasure Hunters.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1040851,
+          "Position": {
+            "X": 389.347,
+            "Y": 3.11688,
+            "Z": -278.657
+          },
+          "TerritoryId": 957,
+          "InteractionType": "AcceptQuest",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZF005_04260_Q1_000_000",
+              "Answer": "TEXT_AKTKZF005_04260_A1_000_002"
+            }
+          ],
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1040861,
+          "Position": {
+            "X": 150.31,
+            "Y": 11.2888,
+            "Z": 94.6108
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZF005_04260_Q1_001_000",
+              "Answer": "TEXT_AKTKZF005_04260_A1_001_001",
+              "AnswerIsRegularExpression": true
+            }
+          ],
+          "AetheryteShortcut": "Thavnair - Palaka's Stand",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": 112.046875,
+            "Y": -0.6,
+            "Z": 125.93262
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Dive",
+          "Fly": true
+        },
+        {
+          "DataId": 2012233,
+          "Position": {
+            "X": 112.046875,
+            "Y": -54.184875,
+            "Z": 125.93262
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "PickUpItemId": 2003241
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1040861,
+          "Position": {
+            "X": 150.31,
+            "Y": 11.2888,
+            "Z": 94.6108
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1040851,
+          "Position": {
+            "X": 389.347,
+            "Y": 3.11688,
+            "Z": -278.657
+          },
+          "TerritoryId": 957,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4261_Curry for the Watch.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4261_Curry for the Watch.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037627,
+          "Position": {
+            "X": 387.725,
+            "Y": 3.09947,
+            "Z": -223.319
+          },
+          "TerritoryId": 957,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 330.904,
+            "Y": 52.6869,
+            "Z": 442.036
+          },
+          "TerritoryId": 957,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1040852,
+          "Position": {
+            "X": 330.904,
+            "Y": 52.6869,
+            "Z": 442.036
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "DelaySecondsAtStart": 1,
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "Position": {
+            "X": 510.947,
+            "Y": 75.4707,
+            "Z": 413.792
+          },
+          "TerritoryId": 957,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1040853,
+          "Position": {
+            "X": 510.947,
+            "Y": 75.4707,
+            "Z": 413.792
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "DelaySecondsAtStart": 1,
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037627,
+          "Position": {
+            "X": 387.725,
+            "Y": 3.09947,
+            "Z": -223.319
+          },
+          "TerritoryId": 957,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4262_My Friend the Yeti.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4262_My Friend the Yeti.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1040856,
+          "Position": {
+            "X": 349.946,
+            "Y": 12.3757,
+            "Z": -269.487
+          },
+          "TerritoryId": 957,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2012260,
+          "Position": {
+            "X": 140.47858,
+            "Y": 14.903032,
+            "Z": -451.17844
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Say",
+          "ChatMessage": {
+            "Key": "TEXT_AKTKZF007_04262_SYSTEM_000_010"
+          },
+          "AetheryteShortcut": "Thavnair - Palaka's Stand",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1040855,
+          "Position": {
+            "X": 75.0302,
+            "Y": 27.426,
+            "Z": -440.885
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1040855,
+          "Position": {
+            "X": 75.0302,
+            "Y": 27.426,
+            "Z": -440.885
+          },
+          "TerritoryId": 957,
+          "InteractionType": "UseItem",
+          "ItemId": 2003384,
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1040856,
+          "Position": {
+            "X": 349.946,
+            "Y": 12.3757,
+            "Z": -269.487
+          },
+          "TerritoryId": 957,
+          "InteractionType": "CompleteQuest",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZF007_04262_Q1_000_000",
+              "Answer": "TEXT_AKTKZF007_04262_A1_000_001"
+            }
+          ],
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4263_Flowers for the Family.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4263_Flowers for the Family.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1040857,
+          "Position": {
+            "X": 372.829,
+            "Y": 12.8987,
+            "Z": -199.215
+          },
+          "TerritoryId": 957,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041513,
+          "Position": {
+            "X": 533.745,
+            "Y": 12.259,
+            "Z": -91.8746
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand",
+          "Fly": true,
+          "Land": true,
+          "SkipConditions": {
+            "StepIf": {
+              "Never": true
+            }
+          },
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZF008_04263_Q1_000_000",
+              "Answer": "TEXT_AKTKZF008_04263_A1_000_001"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2012257,
+          "Position": {
+            "X": 586.11414,
+            "Y": 22.2323,
+            "Z": 0.99176025
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2012258,
+          "Position": {
+            "X": 437.30823,
+            "Y": 6.790222,
+            "Z": 108.506836
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1040859,
+          "Position": {
+            "X": 580.835,
+            "Y": 15.152,
+            "Z": 240.436
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true,
+          "DelaySecondsAtStart": 2
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 2012612,
+          "Position": {
+            "X": 583.21497,
+            "Y": 15.42688,
+            "Z": 239.30713
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1040857,
+          "Position": {
+            "X": 372.829,
+            "Y": 12.8987,
+            "Z": -199.215
+          },
+          "TerritoryId": 957,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4264_My Father My Fisher.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4264_My Father My Fisher.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1040647,
+          "Position": {
+            "X": 416.425,
+            "Y": 5.60001,
+            "Z": -277.996
+          },
+          "TerritoryId": 957,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 494.94,
+            "Y": 4.8,
+            "Z": -423.588
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [
+            14110
+          ],
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1040648,
+          "Position": {
+            "X": 491.386,
+            "Y": 4.21987,
+            "Z": -420.188
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 2012060,
+          "Position": {
+            "X": 535.542,
+            "Y": 4.51961,
+            "Z": -481.1
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact"
+        },
+        {
+          "DataId": 2012061,
+          "Position": {
+            "X": 545.128,
+            "Y": 4.48835,
+            "Z": -446.036
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 1040648,
+          "Position": {
+            "X": 491.386,
+            "Y": 4.21987,
+            "Z": -420.188
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1040647,
+          "Position": {
+            "X": 416.425,
+            "Y": 5.60001,
+            "Z": -277.996
+          },
+          "TerritoryId": 957,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4265_A Pisaca's Purpose.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4265_A Pisaca's Purpose.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037703,
+          "Position": {
+            "X": 423.792,
+            "Y": 3.11688,
+            "Z": -269.716
+          },
+          "TerritoryId": 957,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 191.2356,
+            "Y": 8.472459,
+            "Z": 304.55252
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "ComplexCombatData": [
+            {
+              "DataId": 13530,
+              "RewardItemId": 2003216,
+              "RewardItemCount": 1
+            }
+          ],
+          "AetheryteShortcut": "Thavnair - Palaka's Stand",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2012063,
+          "Position": {
+            "X": 76.4554,
+            "Y": 14.4927,
+            "Z": -231.661
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 2012064,
+          "Position": {
+            "X": 59.4675,
+            "Y": 16.0202,
+            "Z": -253.664
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterInteraction",
+          "ComplexCombatData": [
+            {
+              "DataId": 14109,
+              "RewardItemId": 2003217,
+              "RewardItemCount": 1
+            }
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037703,
+          "Position": {
+            "X": 423.792,
+            "Y": 3.11688,
+            "Z": -269.716
+          },
+          "TerritoryId": 957,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4266_Tea Foretell.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4266_Tea Foretell.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1039518,
+          "Position": {
+            "X": 379.698,
+            "Y": 5.70939,
+            "Z": -213.587
+          },
+          "TerritoryId": 957,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 385.62238,
+            "Y": 3.1036642,
+            "Z": -225.968
+          },
+          "TerritoryId": 957,
+          "InteractionType": "WalkTo"
+        },
+        {
+          "DataId": 2012065,
+          "Position": {
+            "X": 241.01,
+            "Y": 8.0644,
+            "Z": 316.494
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "PickUpItemId": 2003218,
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_AKTKZF011_04266_Q1_000_000",
+              "Yes": true
+            },
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_AKTKZF011_04266_Q2_000_000",
+              "Yes": true
+            }
+          ],
+          "AetheryteShortcut": "Thavnair - Palaka's Stand",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2012066,
+          "Position": {
+            "X": 246.449,
+            "Y": 7.79675,
+            "Z": 296.929
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "PickUpItemId": 2003219,
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_AKTKZF011_04266_Q1_000_000",
+              "Yes": true
+            },
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_AKTKZF011_04266_Q2_000_000",
+              "Yes": true
+            }
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1039518,
+          "Position": {
+            "X": 379.698,
+            "Y": 5.70939,
+            "Z": -213.587
+          },
+          "TerritoryId": 957,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    }
+  ],
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  }
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4267_Dreams of Venom.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4267_Dreams of Venom.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1040649,
+          "Position": {
+            "X": 426.431,
+            "Y": 3.13038,
+            "Z": -223.405
+          },
+          "TerritoryId": 957,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1040650,
+          "Position": {
+            "X": 360.382,
+            "Y": 8.84281,
+            "Z": -405.41
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2012771,
+          "Position": {
+            "X": 474.746,
+            "Y": 9.94365,
+            "Z": -354.151
+          },
+          "TerritoryId": 957,
+          "InteractionType": "UseItem",
+          "ItemId": 2003222,
+          "Fly": true
+        },
+        {
+          "DataId": 2012772,
+          "Position": {
+            "X": 477.584,
+            "Y": 10.377,
+            "Z": -352.681
+          },
+          "TerritoryId": 957,
+          "InteractionType": "UseItem",
+          "ItemId": 2003222
+        },
+        {
+          "Position": {
+            "X": 535.337,
+            "Y": 7.7033,
+            "Z": -410.774
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AutoOnEnterArea",
+          "ComplexCombatData": [
+            {
+              "DataId": 14108,
+              "RewardItemId": 2003224,
+              "RewardItemCount": 1
+            }
+          ],
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2012773,
+          "Position": {
+            "X": 535.267,
+            "Y": 7.70393,
+            "Z": -410.77
+          },
+          "TerritoryId": 957,
+          "InteractionType": "UseItem",
+          "ItemId": 2003222
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1040650,
+          "Position": {
+            "X": 360.382,
+            "Y": 8.84281,
+            "Z": -405.41
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1040649,
+          "Position": {
+            "X": 426.431,
+            "Y": 3.13038,
+            "Z": -223.405
+          },
+          "TerritoryId": 957,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4268_An Unexpected Guide.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Thavnair/4268_An Unexpected Guide.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "$": "Sequence 1 follow segment uses in-game waypoints; verify the langur follow trigger in-game.",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1040654,
+          "Position": {
+            "X": 383.405,
+            "Y": 12.9764,
+            "Z": -199.884
+          },
+          "TerritoryId": 957,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1040655,
+          "Position": {
+            "X": 386.237,
+            "Y": 5.53589,
+            "Z": -132.074
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand",
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "Position": {
+            "X": 431.2758,
+            "Y": 7.22546,
+            "Z": -54.26365
+          },
+          "TerritoryId": 957,
+          "InteractionType": "WalkTo",
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "Position": {
+            "X": 449.42328,
+            "Y": 5.6711063,
+            "Z": -16.423714
+          },
+          "TerritoryId": 957,
+          "InteractionType": "WalkTo",
+          "DelaySecondsAtStart": 4,
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "Position": {
+            "X": 451.3584,
+            "Y": 6.4565706,
+            "Z": -13.095295
+          },
+          "TerritoryId": 957,
+          "InteractionType": "WalkTo",
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "Position": {
+            "X": 475.6763,
+            "Y": 6.6232376,
+            "Z": 25.261562
+          },
+          "TerritoryId": 957,
+          "InteractionType": "WalkTo",
+          "DelaySecondsAtStart": 4,
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "DataId": 1040656,
+          "Position": {
+            "X": 478.014,
+            "Y": 6.51299,
+            "Z": 27.1965
+          },
+          "StopDistance": 0.25,
+          "TerritoryId": 957,
+          "InteractionType": "WaitForNpcAtPosition",
+          "NpcWaitDistance": 6,
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1040657,
+          "Position": {
+            "X": 478.386,
+            "Y": 6.39349,
+            "Z": 29.8925
+          },
+          "TerritoryId": 957,
+          "InteractionType": "Interact",
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1040658,
+          "Position": {
+            "X": 383.531,
+            "Y": 13.0274,
+            "Z": -199.96
+          },
+          "TerritoryId": 957,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Thavnair - Palaka's Stand"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
  Adds the remaining side quest paths for Thavnair.

  Added quest paths:
  - 4256 - The Guardian's Shield
  - 4258 - Quick Heels
  - 4260 - Treasure Hunters
  - 4261 - Curry for the Watch
  - 4262 - My Friend the Yeti
  - 4263 - Flowers for the Family
  - 4264 - My Father My Fisher
  - 4265 - A Pisaca's Purpose
  - 4266 - Tea Foretell
  - 4267 - Dreams of Venom
  - 4268 - An Unexpected Guide

  All added paths were tested in-game.