### PR TITLE
Fix: Add aetheryte shortcut to Eastern Thanalan in Power Struggles quest

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/PLD/1057_Power Struggles.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/PLD/1057_Power Struggles.json
@@ -46,7 +46,9 @@
           "KillEnemyDataIds": [
             383
           ],
-          "Fly": true
+          "AetheryteShortcut": "Eastern Thanalan - Camp Drybone",
+          "Fly": true,
+          "Comment": "The Level 50 mob Gatling may be nearby causing the AI to use AoE attacks and hit it"
         }
       ]
     },


### PR DESCRIPTION
After accepting the quest, the player does nothing. This will get the player to teleport and continue the quest.