### PR TITLE
Add Labyrinthos side quest paths

### DIFF
--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4184_It's Not the Heat, It's the Humidity.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4184_It's Not the Heat, It's the Humidity.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1039329,
+          "Position": {
+            "X": 15.4074,
+            "Y": 170.403,
+            "Z": -752.161
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1039347,
+          "Position": {
+            "X": 115.101,
+            "Y": 172.563,
+            "Z": -670.167
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": 179.05104,
+            "Y": 188.94865,
+            "Z": -730.1896
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2011788,
+          "Position": {
+            "X": 179.05104,
+            "Y": 188.94865,
+            "Z": -730.1896
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "DelaySecondsAtStart": 1,
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "Position": {
+            "X": 252.90591,
+            "Y": 187.0367,
+            "Z": -721.9887
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2011789,
+          "Position": {
+            "X": 252.90591,
+            "Y": 187.0367,
+            "Z": -721.9887
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "DelaySecondsAtStart": 1,
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "Position": {
+            "X": 249.21896,
+            "Y": 209.46693,
+            "Z": -781.99304
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2011792,
+          "Position": {
+            "X": 249.21896,
+            "Y": 209.46693,
+            "Z": -781.99304
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "DelaySecondsAtStart": 1,
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1039348,
+          "Position": {
+            "X": 399.151,
+            "Y": 184.683,
+            "Z": -701.722
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1039329,
+          "Position": {
+            "X": 15.4074,
+            "Y": 170.403,
+            "Z": -752.161
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4185_No Laughing Matter.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4185_No Laughing Matter.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037492,
+          "Position": {
+            "X": -4.3794,
+            "Y": 170.403,
+            "Z": -735.714
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZA006_04185_Q1_000_000",
+              "Answer": "TEXT_AKTKZA006_04185_A1_000_001"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1039331,
+          "Position": {
+            "X": -394.974,
+            "Y": 203.152,
+            "Z": -816.74
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037492,
+          "Position": {
+            "X": -4.3794,
+            "Y": 170.403,
+            "Z": -735.714
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4186_Building Good Habitats.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4186_Building Good Habitats.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1039332,
+          "Position": {
+            "X": -109.578,
+            "Y": 170.25,
+            "Z": -792.192
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -274.06415,
+            "Y": 171.39311,
+            "Z": -777.5237
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "KillEnemyDataIds": [
+            13390
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1039332,
+          "Position": {
+            "X": -109.578,
+            "Y": 170.25,
+            "Z": -792.192
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4187_An Ore-ful Lot.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4187_An Ore-ful Lot.json
@@ -1,0 +1,179 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1039333,
+          "Position": {
+            "X": 372.091,
+            "Y": 166.204,
+            "Z": -470.878
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1039334,
+          "Position": {
+            "X": 563.47,
+            "Y": 164.255,
+            "Z": -400.87
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2011822,
+          "Position": {
+            "X": 561.761,
+            "Y": 164.5,
+            "Z": -402.304
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_AKTKZA008_04187_SYSTEM_000_020",
+              "PromptIsRegularExpression": true,
+              "Yes": true
+            },
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_AKTKZA008_04187_SYSTEM_100_021",
+              "Yes": true
+            }
+          ],
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1039334,
+          "Position": {
+            "X": 563.47,
+            "Y": 164.255,
+            "Z": -400.87
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_AKTKZA008_04187_SYSTEM_000_020",
+              "PromptIsRegularExpression": true,
+              "Yes": true
+            },
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_AKTKZA008_04187_SYSTEM_100_021",
+              "Yes": true
+            }
+          ],
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "Position": {
+            "X": 577.5832,
+            "Y": 163.4699,
+            "Z": -362.29752
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "Mount": false,
+          "Sprint": false,
+          "Comment": "Follow the lightly built lab assistant."
+        },
+        {
+          "Position": {
+            "X": 615.75146,
+            "Y": 168.56168,
+            "Z": -294.40198
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "DelaySecondsAtStart": 20,
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "Position": {
+            "X": 618.61115,
+            "Y": 172.58095,
+            "Z": -256.74924
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "DelaySecondsAtStart": 20,
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "Position": {
+            "X": 579.22754,
+            "Y": 167.59027,
+            "Z": -233.25731
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "DelaySecondsAtStart": 20,
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "DataId": 1039335,
+          "Position": {
+            "X": 575.799,
+            "Y": 167.59,
+            "Z": -228.046
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1039333,
+          "Position": {
+            "X": 372.091,
+            "Y": 166.204,
+            "Z": -470.878
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4188_Raised on the Fallen.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4188_Raised on the Fallen.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "Position": {
+            "X": 400.6186,
+            "Y": 170.17088,
+            "Z": -432.8058
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        },
+        {
+          "DataId": 1037506,
+          "Position": {
+            "X": 373.734,
+            "Y": 170.1,
+            "Z": -399.437
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 400.6186,
+            "Y": 170.17088,
+            "Z": -432.8058
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "DataId": 2011802,
+          "Position": {
+            "X": 269.985,
+            "Y": 185.517,
+            "Z": -696.331
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 2011803,
+          "Position": {
+            "X": 222.163,
+            "Y": 181.636,
+            "Z": -693.864
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "Position": {
+            "X": 400.6186,
+            "Y": 170.17088,
+            "Z": -432.8058
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        },
+        {
+          "DataId": 1037506,
+          "Position": {
+            "X": 373.734,
+            "Y": 170.1,
+            "Z": -399.437
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4189_Pot Luck.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4189_Pot Luck.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037514,
+          "Position": {
+            "X": 401.298,
+            "Y": 166.193,
+            "Z": -474.141
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1039350,
+          "Position": {
+            "X": 614.314,
+            "Y": 172.358,
+            "Z": -563.073
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZA010_04189_Q1_000_000",
+              "Answer": "TEXT_AKTKZA010_04189_A1_000_001"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037514,
+          "Position": {
+            "X": 401.298,
+            "Y": 166.193,
+            "Z": -474.141
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4190_Uncommon Scents.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4190_Uncommon Scents.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1039513,
+          "Position": {
+            "X": 416.064,
+            "Y": 166.3,
+            "Z": -486.388
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2011808,
+          "Position": {
+            "X": 645.289,
+            "Y": 180.721,
+            "Z": -299.824
+          },
+          "TerritoryId": 956,
+          "InteractionType": "UseItem",
+          "ItemId": 2003119,
+          "Fly": true
+        },
+        {
+          "DataId": 2011809,
+          "Position": {
+            "X": 529.503,
+            "Y": 176.475,
+            "Z": -502.861
+          },
+          "TerritoryId": 956,
+          "InteractionType": "UseItem",
+          "ItemId": 2003119,
+          "Fly": true
+        },
+        {
+          "DataId": 2011810,
+          "Position": {
+            "X": 285.939,
+            "Y": 163.789,
+            "Z": -584.192
+          },
+          "TerritoryId": 956,
+          "InteractionType": "UseItem",
+          "ItemId": 2003119,
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1039513,
+          "Position": {
+            "X": 416.064,
+            "Y": 166.3,
+            "Z": -486.388
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4191_A Hard Task to Digest.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4191_A Hard Task to Digest.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1039515,
+          "Position": {
+            "X": 464.553,
+            "Y": 166.204,
+            "Z": -426.016
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2011790,
+          "Position": {
+            "X": 501.205,
+            "Y": 174.271,
+            "Z": -521.06
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterInteraction",
+          "CombatItemUse": {
+            "ItemId": 2003108,
+            "Condition": "Health%",
+            "Value": 50
+          },
+          "ComplexCombatData": [
+            {
+              "DataId": 14124,
+              "RewardItemId": 2003109,
+              "RewardItemCount": 1
+            }
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1039515,
+          "Position": {
+            "X": 464.553,
+            "Y": 166.204,
+            "Z": -426.016
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4192_Learning to Sow.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4192_Learning to Sow.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037523,
+          "Position": {
+            "X": 430.747,
+            "Y": 65.162,
+            "Z": -150.012
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2011811,
+          "Position": {
+            "X": 500.225,
+            "Y": 65.162,
+            "Z": -112.021
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 2011812,
+          "Position": {
+            "X": 472.478,
+            "Y": 65.162,
+            "Z": -93.8455
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 2011813,
+          "Position": {
+            "X": 490.663,
+            "Y": 65.162,
+            "Z": -78.7372
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037523,
+          "Position": {
+            "X": 430.747,
+            "Y": 65.162,
+            "Z": -150.012
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4193_A Ripe Trade.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4193_A Ripe Trade.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037522,
+          "Position": {
+            "X": 454.97104,
+            "Y": 65.16198,
+            "Z": -142.64313
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1037538,
+          "Position": {
+            "X": -283.711,
+            "Y": 59.193,
+            "Z": -428.946
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037522,
+          "Position": {
+            "X": 454.97104,
+            "Y": 65.16198,
+            "Z": -142.64313
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4194_It's Not Mud.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4194_It's Not Mud.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037527,
+          "Position": {
+            "X": 442.889,
+            "Y": 65.162,
+            "Z": -93.4299
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 735.042,
+            "Y": 170.636,
+            "Z": -414.633
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2011814,
+          "Position": {
+            "X": 735.042,
+            "Y": 170.636,
+            "Z": -414.633
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "DelaySecondsAtStart": 1,
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "Position": {
+            "X": 837.705,
+            "Y": 171.405,
+            "Z": -477.745
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2011815,
+          "Position": {
+            "X": 837.705,
+            "Y": 171.405,
+            "Z": -477.745
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "DelaySecondsAtStart": 1,
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "Position": {
+            "X": 843.608,
+            "Y": 177.07,
+            "Z": -386.455
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2011816,
+          "Position": {
+            "X": 843.608,
+            "Y": 177.07,
+            "Z": -386.455
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "DelaySecondsAtStart": 1,
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037527,
+          "Position": {
+            "X": 442.889,
+            "Y": 65.162,
+            "Z": -93.4299
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4195_Not Mushroom for Error.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4195_Not Mushroom for Error.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1039514,
+          "Position": {
+            "X": 415.824,
+            "Y": 66.162,
+            "Z": -102.556
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2011821,
+          "Position": {
+            "X": 794.14,
+            "Y": 156.654,
+            "Z": 51.6805
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1039514,
+          "Position": {
+            "X": 415.824,
+            "Y": 66.162,
+            "Z": -102.556
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4321_A Job for a Loporrit.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4321_A Job for a Loporrit.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041315,
+          "Position": {
+            "X": 32.7555,
+            "Y": -17.5304,
+            "Z": -118.944
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "Land": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZI006_04321_Q1_000_000",
+              "Answer": "TEXT_AKTKZI006_04321_A1_000_001"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041512,
+          "Position": {
+            "X": 93.4661,
+            "Y": -29.5304,
+            "Z": 7.7484
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": -636.71326,
+            "Y": -19.150085,
+            "Z": -32.028687
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2012497,
+          "Position": {
+            "X": -636.71326,
+            "Y": -19.150085,
+            "Z": -32.028687
+          },
+          "TerritoryId": 956,
+          "InteractionType": "UseItem",
+          "ItemId": 2003310,
+          "DelaySecondsAtStart": 1,
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "Position": {
+            "X": -613.3059,
+            "Y": -19.150085,
+            "Z": -56.717834
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2012495,
+          "Position": {
+            "X": -613.3059,
+            "Y": -19.150085,
+            "Z": -56.717834
+          },
+          "TerritoryId": 956,
+          "InteractionType": "UseItem",
+          "ItemId": 2003310,
+          "DelaySecondsAtStart": 1,
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "Position": {
+            "X": -636.4386,
+            "Y": -19.150085,
+            "Z": -57.02301
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2012496,
+          "Position": {
+            "X": -636.4386,
+            "Y": -19.150085,
+            "Z": -57.02301
+          },
+          "TerritoryId": 956,
+          "InteractionType": "UseItem",
+          "ItemId": 2003310,
+          "DelaySecondsAtStart": 1,
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1041512,
+          "Position": {
+            "X": 93.4661,
+            "Y": -29.5304,
+            "Z": 7.7484
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041315,
+          "Position": {
+            "X": 32.7555,
+            "Y": -17.5304,
+            "Z": -118.944
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4322_Gift for a Fan.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4322_Gift for a Fan.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-06"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037564,
+          "Position": {
+            "X": -93.5836,
+            "Y": -31.5304,
+            "Z": -14.847
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1037581,
+          "Position": {
+            "X": -2.96649,
+            "Y": -28.6056,
+            "Z": 586.375
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": -3.44256,
+            "Y": -28.3524,
+            "Z": 587.134
+          },
+          "TerritoryId": 956,
+          "InteractionType": "UseItem",
+          "ItemId": 2003312,
+          "Fly": true,
+          "Land": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZI007_04322_Q1_000_000",
+              "Answer": "TEXT_AKTKZI007_04322_A1_000_001"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037564,
+          "Position": {
+            "X": -93.5836,
+            "Y": -31.5304,
+            "Z": -14.847
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4323_Wayward Carbuncle.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4323_Wayward Carbuncle.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041316,
+          "Position": {
+            "X": 17.2274,
+            "Y": -17.5304,
+            "Z": -215.564
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -604.12726,
+            "Y": -16.640757,
+            "Z": 783.93506
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Labyrinthos - Aporia",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1041317,
+          "Position": {
+            "X": -602.478,
+            "Y": -16.6873,
+            "Z": 784.892
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Mount": false,
+          "SkipConditions": {
+            "StepIf": {
+              "Never": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1041317,
+          "Position": {
+            "X": -602.478,
+            "Y": -16.6873,
+            "Z": 784.892
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Emote",
+          "Emote": "soothe"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041316,
+          "Position": {
+            "X": 17.2274,
+            "Y": -17.5304,
+            "Z": -215.564
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4324_Don't Philter Yourself.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4324_Don't Philter Yourself.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041319,
+          "Position": {
+            "X": 7.04093,
+            "Y": -31.5304,
+            "Z": -94.1386
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041318,
+          "Position": {
+            "X": 32.6321,
+            "Y": -28.6056,
+            "Z": 642.285
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1041318,
+          "Position": {
+            "X": 32.6321,
+            "Y": -28.6056,
+            "Z": 642.285
+          },
+          "TerritoryId": 956,
+          "InteractionType": "UseItem",
+          "ItemId": 2003315,
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041319,
+          "Position": {
+            "X": 7.04093,
+            "Y": -31.5304,
+            "Z": -94.1386
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZI009_04324_Q1_000_000",
+              "Answer": "TEXT_AKTKZI009_04324_A1_000_002"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4325_Take a Look, It's in a Book.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4325_Take a Look, It's in a Book.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041320,
+          "Position": {
+            "X": 211.462,
+            "Y": -17.5326,
+            "Z": -42.1759
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZI010_04325_Q1_000_000",
+              "Answer": "TEXT_AKTKZI010_04325_A1_000_002"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2012499,
+          "Position": {
+            "X": 211.289,
+            "Y": -16.5245,
+            "Z": -40.5866
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1041374,
+          "Position": {
+            "X": 203.301,
+            "Y": -23.5753,
+            "Z": 313.235
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041320,
+          "Position": {
+            "X": 211.462,
+            "Y": -17.5326,
+            "Z": -42.1759
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4327_To Care Enough to Send the Very Best.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4327_To Care Enough to Send the Very Best.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041375,
+          "Position": {
+            "X": -58.352,
+            "Y": -31.5304,
+            "Z": -95.6814
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZI012_04327_Q1_000_000",
+              "Answer": "TEXT_AKTKZI012_04327_A1_000_001"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041376,
+          "Position": {
+            "X": 406.774,
+            "Y": 166.193,
+            "Z": -474.853
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041375,
+          "Position": {
+            "X": -58.352,
+            "Y": -31.5304,
+            "Z": -95.6814
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4328_Herbicidal Tendencies.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4328_Herbicidal Tendencies.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037567,
+          "Position": {
+            "X": 42.4048,
+            "Y": -28.5492,
+            "Z": 44.2664
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -618.86,
+            "Y": -4.26108,
+            "Z": -121.019
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2012254,
+          "Position": {
+            "X": -618.86,
+            "Y": -4.26108,
+            "Z": -121.019
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "DelaySecondsAtStart": 1,
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "DataId": 14090,
+          "Position": {
+            "X": -626.465,
+            "Y": -3.74359,
+            "Z": -127.515
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterItemUse",
+          "ItemId": 2003263,
+          "KillEnemyDataIds": [
+            14090
+          ],
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037567,
+          "Position": {
+            "X": 42.4048,
+            "Y": -28.5492,
+            "Z": 44.2664
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZI013_04328_Q1_000_000",
+              "Answer": "TEXT_AKTKZI013_04328_A1_000_001"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4330_Apple-y Ever After.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4330_Apple-y Ever After.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041377,
+          "Position": {
+            "X": 18.9202,
+            "Y": -31.5304,
+            "Z": -3.47303
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -146.746,
+            "Y": -9.659,
+            "Z": -255.299
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "Position": {
+            "X": -146.746,
+            "Y": -9.659,
+            "Z": -255.299
+          },
+          "TerritoryId": 956,
+          "InteractionType": "UseItem",
+          "ItemId": 2003319,
+          "GroundTarget": true,
+          "DelaySecondsAtStart": 1,
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2012757,
+          "Position": {
+            "X": -146.105,
+            "Y": -9.48161,
+            "Z": -253.864
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact"
+        },
+        {
+          "DataId": 2012758,
+          "Position": {
+            "X": -147.449,
+            "Y": -9.3564,
+            "Z": -257.047
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact"
+        },
+        {
+          "DataId": 2012759,
+          "Position": {
+            "X": -145.775,
+            "Y": -9.46139,
+            "Z": -256.488
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact"
+        },
+        {
+          "DataId": 2012760,
+          "Position": {
+            "X": -147.821,
+            "Y": -9.3107,
+            "Z": -255.79
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact"
+        },
+        {
+          "DataId": 2012761,
+          "Position": {
+            "X": -145.708,
+            "Y": -9.50674,
+            "Z": -255.177
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041377,
+          "Position": {
+            "X": 18.9202,
+            "Y": -31.5304,
+            "Z": -3.47303
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4331_The Dry Eyes Have It.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4331_The Dry Eyes Have It.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037560,
+          "Position": {
+            "X": 62.3942,
+            "Y": -29.5568,
+            "Z": -43.6866
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041381,
+          "Position": {
+            "X": -52.5485,
+            "Y": -17.5304,
+            "Z": -224.033
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1041382,
+          "Position": {
+            "X": -54.6022,
+            "Y": -17.5304,
+            "Z": -222.178
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Emote",
+          "Emote": "pet",
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1041382,
+          "Position": {
+            "X": -54.6022,
+            "Y": -17.5304,
+            "Z": -222.178
+          },
+          "TerritoryId": 956,
+          "InteractionType": "UseItem",
+          "ItemId": 2003321,
+          "DelaySecondsAtStart": 1,
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037560,
+          "Position": {
+            "X": 62.3942,
+            "Y": -29.5568,
+            "Z": -43.6866
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4332_Dolling out Punishment.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4332_Dolling out Punishment.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037565,
+          "Position": {
+            "X": 27.7256,
+            "Y": -17.5304,
+            "Z": -91.5389
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 195.036,
+            "Y": -5.43588,
+            "Z": 623.371
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 195.036,
+            "Y": -5.43588,
+            "Z": 623.371
+          },
+          "TerritoryId": 956,
+          "InteractionType": "None",
+          "Land": true
+        },
+        {
+          "DataId": 2012778,
+          "Position": {
+            "X": 195.036,
+            "Y": -5.43588,
+            "Z": 623.371
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterInteraction",
+          "CombatItemUse": {
+            "ItemId": 2003270,
+            "Condition": "Health%",
+            "Value": 50
+          },
+          "ComplexCombatData": [
+            {
+              "DataId": 14122,
+              "RewardItemId": 2003271,
+              "RewardItemCount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037565,
+          "Position": {
+            "X": 27.7256,
+            "Y": -17.5304,
+            "Z": -91.5389
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4333_The Case of the Missing Gleaner.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4333_The Case of the Missing Gleaner.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041383,
+          "Position": {
+            "X": -42.71,
+            "Y": -29.53,
+            "Z": -140.246
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041384,
+          "Position": {
+            "X": -183.219,
+            "Y": -14.0164,
+            "Z": -245.488
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041383,
+          "Position": {
+            "X": -42.71,
+            "Y": -29.53,
+            "Z": -140.246
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4334_Cooler than Being Cool.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4334_Cooler than Being Cool.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "Position": {
+            "X": -681.62787,
+            "Y": -27.599773,
+            "Z": 302.4099
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Labyrinthos - Aporia",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1037593,
+          "Position": {
+            "X": -628.167,
+            "Y": -27.6706,
+            "Z": 308.615
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -681.62787,
+            "Y": -27.599773,
+            "Z": 302.4099
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Labyrinthos - Aporia",
+          "Fly": true,
+          "Land": true,
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "Position": {
+            "X": -234.355,
+            "Y": -31.4335,
+            "Z": 757.53
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "ComplexCombatData": [
+            {
+              "DataId": 13954,
+              "NameId": 10696,
+              "MinimumKillCount": 2,
+              "RewardItemId": 2003322,
+              "RewardItemCount": 2
+            }
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "Position": {
+            "X": -681.62787,
+            "Y": -27.599773,
+            "Z": 302.4099
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Labyrinthos - Aporia",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1037593,
+          "Position": {
+            "X": -628.167,
+            "Y": -27.6706,
+            "Z": 308.615
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4335_For the Record.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4335_For the Record.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "Position": {
+            "X": -681.62787,
+            "Y": -27.599773,
+            "Z": 302.4099
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Labyrinthos - Aporia",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1037591,
+          "Position": {
+            "X": -664.846,
+            "Y": -27.67,
+            "Z": 306.236
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2012503,
+          "Position": {
+            "X": -636.195,
+            "Y": -26.435,
+            "Z": 289.674
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_AKTKZI020_04335_Q1_000_000",
+              "Yes": true
+            }
+          ]
+        },
+        {
+          "DataId": 2012504,
+          "Position": {
+            "X": -647.852,
+            "Y": -25.7129,
+            "Z": 289.689
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_AKTKZI020_04335_Q2_000_000",
+              "Yes": true
+            }
+          ]
+        },
+        {
+          "DataId": 2012505,
+          "Position": {
+            "X": -622.133,
+            "Y": -25.6558,
+            "Z": 310.248
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_AKTKZI020_04335_Q3_000_000",
+              "Yes": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037591,
+          "Position": {
+            "X": -664.846,
+            "Y": -27.67,
+            "Z": 306.236
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4336_Harbinger of Breath.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4336_Harbinger of Breath.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1037606,
+          "Position": {
+            "X": -770.2592,
+            "Y": -17.530392,
+            "Z": 292.082
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Aporia",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -700.00946,
+            "Y": -23.281668,
+            "Z": 34.953636
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "ComplexCombatData": [
+            {
+              "DataId": 13949,
+              "NameId": 10691,
+              "MinimumKillCount": 1,
+              "RewardItemId": 2003326,
+              "RewardItemCount": 1
+            }
+          ],
+          "AetheryteShortcut": "Labyrinthos - Aporia",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1037606,
+          "Position": {
+            "X": -770.2592,
+            "Y": -17.530392,
+            "Z": 292.082
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Aporia",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4481_Problematic Pests.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4481_Problematic Pests.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041721,
+          "Position": {
+            "X": 285.156,
+            "Y": 185.653,
+            "Z": -729.59
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041673,
+          "Position": {
+            "X": 475.469,
+            "Y": 65.162,
+            "Z": -105.612
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1041676,
+          "Position": {
+            "X": 326.494,
+            "Y": 90.9016,
+            "Z": -381.322
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041673,
+          "Position": {
+            "X": 475.469,
+            "Y": 65.162,
+            "Z": -105.612
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4482_Pests Be Gone.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4482_Pests Be Gone.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041673,
+          "Position": {
+            "X": 475.469,
+            "Y": 65.162,
+            "Z": -105.612
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 45.54789,
+            "Y": 72.1013,
+            "Z": -403.74484
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "ComplexCombatData": [
+            {
+              "DataId": 13393,
+              "NameId": 10673,
+              "MinimumKillCount": 1,
+              "RewardItemId": 2003332,
+              "RewardItemCount": 1
+            }
+          ],
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041673,
+          "Position": {
+            "X": 475.469,
+            "Y": 65.162,
+            "Z": -105.612
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4483_Dream Big.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4483_Dream Big.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041682,
+          "Position": {
+            "X": 474.578,
+            "Y": 65.162,
+            "Z": -104.234
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041679,
+          "Position": {
+            "X": 297.493,
+            "Y": 72.0351,
+            "Z": -32.7492
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Emote",
+          "Emote": "pet",
+          "StopDistance": 5,
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1041679,
+          "Position": {
+            "X": 297.493,
+            "Y": 72.0351,
+            "Z": -32.7492
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Emote",
+          "Emote": "pet",
+          "StopDistance": 5,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZA104_04483_Q1_000_000",
+              "Answer": "TEXT_AKTKZA104_04483_A1_000_002"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 2012571,
+          "Position": {
+            "X": 724.117,
+            "Y": 113.327,
+            "Z": 8.59076
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2012570,
+          "Position": {
+            "X": 821.5575,
+            "Y": 161.03755,
+            "Z": 101.16489
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2012569,
+          "Position": {
+            "X": 870.114,
+            "Y": 163.849,
+            "Z": 167.273
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041680,
+          "Position": {
+            "X": 437.113,
+            "Y": 166.186,
+            "Z": -431.217
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "Land": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZA104_04483_Q2_000_000",
+              "Answer": "TEXT_AKTKZA104_04483_A2_000_002"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4485_Here Comes the Sun.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4485_Here Comes the Sun.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041685,
+          "Position": {
+            "X": 154.902,
+            "Y": -17.5304,
+            "Z": -66.2112
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041686,
+          "Position": {
+            "X": 228.398,
+            "Y": -18.7419,
+            "Z": 297.849
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true,
+          "DialogueChoices": [
+            {
+              "Type": "YesNo",
+              "Prompt": "TEXT_AKTKZI102_04485_Q1_000_000",
+              "Yes": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1041687,
+          "Position": {
+            "X": 455.281,
+            "Y": 77.1362,
+            "Z": 230.111
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041688,
+          "Position": {
+            "X": 285.831,
+            "Y": 86.5318,
+            "Z": -144.579
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4486_Fiery Thirst.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4486_Fiery Thirst.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041688,
+          "Position": {
+            "X": 285.831,
+            "Y": 86.5318,
+            "Z": -144.579
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041690,
+          "Position": {
+            "X": 464.334,
+            "Y": 66.1619,
+            "Z": -136.175
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Labyrinthos - Archeion",
+          "Fly": true,
+          "Land": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZI103_04486_Q1_000_000",
+              "Answer": "TEXT_AKTKZI103_04486_A1_000_001"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1041691,
+          "Position": {
+            "X": 455.931,
+            "Y": 81.1368,
+            "Z": 64.4963
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "Position": {
+            "X": 449.507,
+            "Y": 81.4173,
+            "Z": 83.6619
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AutoOnEnterArea",
+          "ComplexCombatData": [
+            {
+              "DataId": 14068,
+              "MinimumKillCount": 1,
+              "RewardItemId": 2003334,
+              "RewardItemCount": 1
+            }
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041691,
+          "Position": {
+            "X": 455.931,
+            "Y": 81.1368,
+            "Z": 64.4963
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4487_The Hero in Labyrinthos.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4487_The Hero in Labyrinthos.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041691,
+          "Position": {
+            "X": 455.931,
+            "Y": 81.1368,
+            "Z": 64.4963
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZI104_04487_Q1_000_000",
+              "Answer": "TEXT_AKTKZI104_04487_A1_000_002"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -234.355,
+            "Y": -31.4335,
+            "Z": 757.53
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "ComplexCombatData": [
+            {
+              "DataId": 13954,
+              "NameId": 10696,
+              "MinimumKillCount": 2,
+              "RewardItemId": 2003335,
+              "RewardItemCount": 2
+            }
+          ],
+          "AetheryteShortcut": "Labyrinthos - Aporia",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1041693,
+          "Position": {
+            "X": 286.457,
+            "Y": 86.5318,
+            "Z": -145.098
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041696,
+          "Position": {
+            "X": -32.539,
+            "Y": -31.5304,
+            "Z": -33.3491
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4488_Thick as Thieves.json
+++ b/QuestPaths/6.x - Endwalker/Side Quests/Labyrinthos/4488_Thick as Thieves.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-07"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1041696,
+          "Position": {
+            "X": -32.539,
+            "Y": -31.5304,
+            "Z": -33.3491
+          },
+          "TerritoryId": 956,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZI201_04488_Q1_000_000",
+              "Answer": "TEXT_AKTKZI201_04488_A1_000_001"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1041724,
+          "Position": {
+            "X": 201.261,
+            "Y": -23.5462,
+            "Z": 266.44
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZI201_04488_Q2_000_000",
+              "Answer": "TEXT_AKTKZI201_04488_A2_000_001"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1041612,
+          "Position": {
+            "X": -610.299,
+            "Y": -19.1261,
+            "Z": -35.0956
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1041613,
+          "Position": {
+            "X": -610.952,
+            "Y": -19.1261,
+            "Z": -34.7777
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "Position": {
+            "X": -718.372,
+            "Y": -1.62884,
+            "Z": -37.6963
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1041613,
+          "Position": {
+            "X": -718.372,
+            "Y": -1.62884,
+            "Z": -37.6963
+          },
+          "TerritoryId": 956,
+          "InteractionType": "WaitForNpcAtPosition",
+          "NpcWaitDistance": 8,
+          "StopDistance": 100,
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "DataId": 1041613,
+          "Position": {
+            "X": -718.372,
+            "Y": -1.62884,
+            "Z": -37.6963
+          },
+          "TerritoryId": 956,
+          "InteractionType": "Interact",
+          "Mount": false,
+          "Sprint": false
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1041727,
+          "Position": {
+            "X": -29.0207,
+            "Y": -31.5304,
+            "Z": -22.9506
+          },
+          "TerritoryId": 956,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Labyrinthos - Sharlayan Hamlet",
+          "Fly": true,
+          "Land": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_AKTKZI201_04488_Q4_000_000",
+              "Answer": "TEXT_AKTKZI201_04488_A4_000_001"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds the remaining side quest paths for  Labyrinthos.

  4184 - It's Not the Heat, It's the Humidity
  4185 - No Laughing Matter
  4186 - Building Good Habitats
  4187 - An Ore-ful Lot
  4188 - Raised on the Fallen
  4189 - Pot Luck
  4190 - Uncommon Scents
  4191 - A Hard Task to Digest
  4192 - Learning to Sow
  4193 - A Ripe Trade
  4194 - It's Not Mud
  4195 - Not Mushroom for Error

  4321 - A Job for a Loporrit
  4322 - Gift for a Fan
  4323 - Wayward Carbuncle
  4324 - Don't Philter Yourself
  4325 - Take a Look, It's in a Book
  4327 - To Care Enough to Send the Very Best
  4328 - Herbicidal Tendencies
  4330 - Apple-y Ever After
  4331 - The Dry Eyes Have It
  4332 - Dolling out Punishment
  4333 - The Case of the Missing Gleaner
  4334 - Cooler than Being Cool
  4335 - For the Record
  4336 - Harbinger of Breath

  4481 - Problematic Pests
  4482 - Pests Be Gone
  4483 - Dream Big
  4485 - Here Comes the Sun
  4486 - Fiery Thirst
  4487 - The Hero in Labyrinthos
  4488 - Thick as Thieves

  All added paths were tested in-game.