### PR TITLE
remove interupt on combat, again

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup Condition="$(MSBuildProjectName) != 'GatheringPathRenderer'">
-        <Version>15.281.4.2</Version>
+        <Version>15.281.4.3</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Questionable/Controller/Steps/Interactions/Interact.cs
+++ b/Questionable/Controller/Steps/Interactions/Interact.cs
@@ -133,14 +133,6 @@ internal static class Interact
         public Quest? Quest => Task.Quest;
         public EInteractionType InteractionType { get; set; }
 
-        public override bool WasInterrupted()         
-        {
-            if (condition[ConditionFlag.InCombat] && InteractionType != EInteractionType.Combat)
-                return true;
-
-            return base.WasInterrupted();
-        }
-
         public override ETaskResult Update()
         {
             logger.LogDebug($"Entered Update, _continueAt: {_continueAt}");


### PR DESCRIPTION
Causes weird rubberbanding attacking of mobs that are aggroed enroute and reset, leading you to chase invuln mobs,
also breaks interacts that are behind jumps or otherwise precision movement that you will fall off of in pursuit of enemies and then cannot path back to (738, others I'm sure)