### PR TITLE
Feat: Retry Single Player Duties at Specified Difficulty Level in Config

### DIFF
--- a/Questionable/Configuration.cs
+++ b/Questionable/Configuration.cs
@@ -74,12 +74,18 @@ internal sealed class Configuration : IPluginConfiguration
         public Dictionary<string, bool> ExpansionHeaderStates { get; set; } = [];
     }
 
+    internal enum EQuestBattleDifficulty : byte
+    {
+        Normal = 0,
+        Easy = 1,
+        VeryEasy = 2,
+    }
+
     internal sealed class SinglePlayerDutyConfiguration
     {
         public bool RunSoloInstancesWithBossMod { get; set; }
 
-        [SuppressMessage("Performance", "CA1822", Justification = "Will be fixed when no longer WIP")]
-        public byte RetryDifficulty => 0;
+        public EQuestBattleDifficulty RetryDifficulty { get; set; } = EQuestBattleDifficulty.Normal;
 
         public HashSet<uint> WhitelistedSinglePlayerDutyCfcIds { get; set; } = [];
         public HashSet<uint> BlacklistedSinglePlayerDutyCfcIds { get; set; } = [];

--- a/Questionable/Configuration.cs
+++ b/Questionable/Configuration.cs
@@ -87,6 +87,11 @@ internal sealed class Configuration : IPluginConfiguration
 
         public EQuestBattleDifficulty RetryDifficulty { get; set; } = EQuestBattleDifficulty.Normal;
 
+        /// <summary>
+        /// -1 = retry indefinitely, 0 = do not retry, positive = max retry count.
+        /// </summary>
+        public int MaxRetries { get; set; } = 0;
+
         public HashSet<uint> WhitelistedSinglePlayerDutyCfcIds { get; set; } = [];
         public HashSet<uint> BlacklistedSinglePlayerDutyCfcIds { get; set; } = [];
         public Dictionary<string, bool> HeaderStates { get; set; } = [];

--- a/Questionable/Configuration.cs
+++ b/Questionable/Configuration.cs
@@ -90,7 +90,7 @@ internal sealed class Configuration : IPluginConfiguration
         /// <summary>
         /// -1 = retry indefinitely, 0 = do not retry, positive = max retry count.
         /// </summary>
-        public int MaxRetries { get; set; } = 0;
+        public int MaxRetries { get; set; }
 
         public HashSet<uint> WhitelistedSinglePlayerDutyCfcIds { get; set; } = [];
         public HashSet<uint> BlacklistedSinglePlayerDutyCfcIds { get; set; } = [];

--- a/Questionable/Controller/GameUi/InteractionUiController.cs
+++ b/Questionable/Controller/GameUi/InteractionUiController.cs
@@ -843,7 +843,7 @@ internal sealed class InteractionUiController : IDisposable
             AtkValue* selectChoice = stackalloc AtkValue[]
             {
                 new() { Type = AtkValueType.Int, Int = 0 },
-                new() { Type = AtkValueType.Int, Int = _configuration.SinglePlayerDuties.RetryDifficulty }
+                new() { Type = AtkValueType.Int, Int = (int)_configuration.SinglePlayerDuties.RetryDifficulty }
             };
             addonDifficultySelectYesNo->FireCallback(2, selectChoice);
         }

--- a/Questionable/Controller/QuestController.cs
+++ b/Questionable/Controller/QuestController.cs
@@ -286,6 +286,11 @@ internal sealed class QuestController : MiniTaskController<QuestController>
             {
                 // ignoring death in a dungeon if it is being run by AD
             }
+            else if ((_taskQueue.CurrentTaskExecutor?.CurrentTask.IgnoreDeath ?? false)
+                     || _taskQueue.RemainingTasks.Any(t => t.IgnoreDeath))
+            {
+                // a queued task has declared that death should not interrupt automation
+            }
             else if (!_taskQueue.AllTasksComplete)
                 StopAllDueToConditionFailed("HP = 0");
         }

--- a/Questionable/Controller/Steps/ITask.cs
+++ b/Questionable/Controller/Steps/ITask.cs
@@ -3,4 +3,5 @@
 internal interface ITask
 {
     bool ShouldRedoOnInterrupt() => false;
+    bool IgnoreDeath => false;
 }

--- a/Questionable/Controller/Steps/Interactions/SinglePlayerDuty.cs
+++ b/Questionable/Controller/Steps/Interactions/SinglePlayerDuty.cs
@@ -10,6 +10,8 @@ using ECommons.Throttlers;
 using ECommons.UIHelpers.AddonMasterImplementations;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+using Questionable.Controller;
+using Questionable.Controller.Steps;
 using Questionable.Controller.Steps.Common;
 using Questionable.Controller.Steps.Shared;
 using Questionable.Data;
@@ -29,13 +31,29 @@ internal static class SinglePlayerDuty
         public const ushort Patisserie = 1298;
     }
 
+    internal sealed class RetryTracker
+    {
+        private readonly Dictionary<(ElementId, byte), int> _counts = [];
+
+        public int GetCount(ElementId questId, byte dutyIndex) =>
+            _counts.GetValueOrDefault((questId, dutyIndex));
+
+        public void Increment(ElementId questId, byte dutyIndex) =>
+            _counts[(questId, dutyIndex)] = GetCount(questId, dutyIndex) + 1;
+
+        public void Reset(ElementId questId, byte dutyIndex) =>
+            _counts.Remove((questId, dutyIndex));
+    }
+
     internal sealed class Factory
     (
         BossModIpc bossModIpc,
         TerritoryData territoryData,
         IObjectTable objectTable,
         ICondition condition,
-        IClientState clientState) : ITaskFactory
+        IClientState clientState,
+        QuestFunctions questFunctions,
+        RetryTracker retryTracker) : ITaskFactory
     {
         public IEnumerable<ITask> CreateAllTasks(Quest quest, QuestSequence sequence, QuestStep step)
         {
@@ -60,6 +78,8 @@ internal static class SinglePlayerDuty
                     cfcId = cfcData.ContentFinderConditionId;
                     tId = cfcData.TerritoryId;
                 }
+
+                byte sequenceBeforeEntering = questFunctions.GetQuestProgressInfo(quest.Id)?.Sequence ?? 0;
 
                 yield return new Mount.UnmountTask();
                 if (tId == SpecialTerritories.Patisserie)
@@ -107,7 +127,8 @@ internal static class SinglePlayerDuty
 
                 yield return new WaitSinglePlayerDuty(cfcId);
                 yield return new DisableAi();
-                yield return new WaitAtEnd.WaitNextStepOrSequence();
+                yield return new CheckSinglePlayerDutyOutcome(
+                    quest, sequence, (byte)sequence.Sequence, step, sequenceBeforeEntering);
             }
         }
 
@@ -299,6 +320,65 @@ internal static class SinglePlayerDuty
             return DateTime.Now - _enteredAt >= TimeSpan.FromSeconds(2)
                 ? ETaskResult.TaskComplete
                 : ETaskResult.StillRunning;
+        }
+
+        public override bool ShouldInterruptOnDamage() => false;
+    }
+
+    internal sealed record CheckSinglePlayerDutyOutcome(
+        Quest Quest,
+        QuestSequence QuestSequence,
+        byte SequenceNumber,
+        QuestStep QuestStep,
+        byte SequenceBeforeEntering) : ITask
+    {
+        public override string ToString() => "CheckSinglePlayerDutyOutcome";
+    }
+
+    internal sealed class CheckSinglePlayerDutyOutcomeExecutor
+    (
+        QuestFunctions questFunctions,
+        QuestController questController,
+        TaskCreator taskCreator,
+        RetryTracker retryTracker,
+        Configuration configuration) : TaskExecutor<CheckSinglePlayerDutyOutcome>
+    {
+        private DateTime _checkAt = DateTime.MinValue;
+
+        protected override bool Start()
+        {
+            _checkAt = DateTime.Now.AddSeconds(2);
+            return true;
+        }
+
+        public override ETaskResult Update()
+        {
+            if (DateTime.Now < _checkAt)
+                return ETaskResult.StillRunning;
+
+            QuestProgressInfo? progress = questFunctions.GetQuestProgressInfo(Task.Quest.Id);
+            byte dutyIndex = Task.QuestStep.SinglePlayerDutyIndex;
+
+            if (progress == null || progress.Sequence > Task.SequenceBeforeEntering)
+            {
+                retryTracker.Reset(Task.Quest.Id, dutyIndex);
+                return ETaskResult.TaskComplete;
+            }
+
+            int retriesUsed = retryTracker.GetCount(Task.Quest.Id, dutyIndex);
+            int maxRetries = configuration.SinglePlayerDuties.MaxRetries;
+
+            if (maxRetries == 0 || (maxRetries > 0 && retriesUsed >= maxRetries))
+            {
+                questController.TaskQueue.EnqueueAll([new WaitAtEnd.EndAutomation()]);
+                return ETaskResult.TaskComplete;
+            }
+
+            retryTracker.Increment(Task.Quest.Id, dutyIndex);
+            IReadOnlyList<ITask> retryTasks = taskCreator.CreateTasks(
+                Task.Quest, Task.SequenceNumber, Task.QuestSequence, Task.QuestStep);
+            questController.TaskQueue.EnqueueAll(retryTasks);
+            return ETaskResult.TaskComplete;
         }
 
         public override bool ShouldInterruptOnDamage() => false;

--- a/Questionable/Controller/Steps/Interactions/SinglePlayerDuty.cs
+++ b/Questionable/Controller/Steps/Interactions/SinglePlayerDuty.cs
@@ -52,8 +52,7 @@ internal static class SinglePlayerDuty
         IObjectTable objectTable,
         ICondition condition,
         IClientState clientState,
-        QuestFunctions questFunctions,
-        RetryTracker retryTracker) : ITaskFactory
+        QuestFunctions questFunctions) : ITaskFactory
     {
         public IEnumerable<ITask> CreateAllTasks(Quest quest, QuestSequence sequence, QuestStep step)
         {

--- a/Questionable/Controller/Steps/Interactions/SinglePlayerDuty.cs
+++ b/Questionable/Controller/Steps/Interactions/SinglePlayerDuty.cs
@@ -12,6 +12,7 @@ using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using Questionable.Controller;
 using Questionable.Controller.Steps;
+using Questionable.Controller.Utils;
 using Questionable.Controller.Steps.Common;
 using Questionable.Controller.Steps.Shared;
 using Questionable.Data;
@@ -78,7 +79,9 @@ internal static class SinglePlayerDuty
                     tId = cfcData.TerritoryId;
                 }
 
-                byte sequenceBeforeEntering = questFunctions.GetQuestProgressInfo(quest.Id)?.Sequence ?? 0;
+                QuestProgressInfo? progressBeforeEntering = questFunctions.GetQuestProgressInfo(quest.Id);
+                byte sequenceBeforeEntering = progressBeforeEntering?.Sequence ?? 0;
+                IReadOnlyList<byte>? variablesBeforeEntering = progressBeforeEntering?.Variables.ToArray();
 
                 yield return new Mount.UnmountTask();
                 if (tId == SpecialTerritories.Patisserie)
@@ -127,7 +130,7 @@ internal static class SinglePlayerDuty
                 yield return new WaitSinglePlayerDuty(cfcId);
                 yield return new DisableAi();
                 yield return new CheckSinglePlayerDutyOutcome(
-                    quest, sequence, (byte)sequence.Sequence, step, sequenceBeforeEntering);
+                    quest, sequence, (byte)sequence.Sequence, step, sequenceBeforeEntering, variablesBeforeEntering);
             }
         }
 
@@ -330,7 +333,8 @@ internal static class SinglePlayerDuty
         QuestSequence QuestSequence,
         byte SequenceNumber,
         QuestStep QuestStep,
-        byte SequenceBeforeEntering) : ITask
+        byte SequenceBeforeEntering,
+        IReadOnlyList<byte>? VariablesBeforeEntering) : ITask
     {
         public override string ToString() => "CheckSinglePlayerDutyOutcome";
     }
@@ -360,9 +364,34 @@ internal static class SinglePlayerDuty
             QuestProgressInfo? progress = questFunctions.GetQuestProgressInfo(Task.Quest.Id);
             byte dutyIndex = Task.QuestStep.SinglePlayerDutyIndex;
 
-            if (progress == null || progress.Sequence > Task.SequenceBeforeEntering)
+            if (progress == null)
             {
-                pluginLog.Information($"[SinglePlayerDuty] Duty succeeded (sequence {Task.SequenceBeforeEntering} -> {progress?.Sequence.ToString() ?? "complete"})");
+                pluginLog.Information("[SinglePlayerDuty] Duty succeeded (quest completed)");
+                retryTracker.Reset(Task.Quest.Id, dutyIndex);
+                return ETaskResult.TaskComplete;
+            }
+
+            if (progress.Sequence > Task.SequenceBeforeEntering)
+            {
+                pluginLog.Information($"[SinglePlayerDuty] Duty succeeded (sequence {Task.SequenceBeforeEntering} -> {progress.Sequence})");
+                retryTracker.Reset(Task.Quest.Id, dutyIndex);
+                return ETaskResult.TaskComplete;
+            }
+
+            bool hasCompletionFlags = QuestWorkUtils.HasCompletionFlags(Task.QuestStep.CompletionQuestVariablesFlags);
+            if (hasCompletionFlags)
+            {
+                if (QuestWorkUtils.MatchesQuestWork(Task.QuestStep.CompletionQuestVariablesFlags, progress))
+                {
+                    pluginLog.Information("[SinglePlayerDuty] Duty succeeded (completion flags matched)");
+                    retryTracker.Reset(Task.Quest.Id, dutyIndex);
+                    return ETaskResult.TaskComplete;
+                }
+            }
+            else if (Task.VariablesBeforeEntering != null &&
+                     !progress.Variables.SequenceEqual(Task.VariablesBeforeEntering))
+            {
+                pluginLog.Information("[SinglePlayerDuty] Duty succeeded (quest variables changed)");
                 retryTracker.Reset(Task.Quest.Id, dutyIndex);
                 return ETaskResult.TaskComplete;
             }

--- a/Questionable/Controller/Steps/Interactions/SinglePlayerDuty.cs
+++ b/Questionable/Controller/Steps/Interactions/SinglePlayerDuty.cs
@@ -209,6 +209,7 @@ internal static class SinglePlayerDuty
 
     internal sealed record WaitSinglePlayerDuty(uint ContentFinderConditionId) : ITask
     {
+        public bool IgnoreDeath => true;
         public override string ToString() => $"Wait(BossMod, left instance {ContentFinderConditionId})";
     }
 
@@ -340,7 +341,8 @@ internal static class SinglePlayerDuty
         QuestController questController,
         TaskCreator taskCreator,
         RetryTracker retryTracker,
-        Configuration configuration) : TaskExecutor<CheckSinglePlayerDutyOutcome>
+        Configuration configuration,
+        IPluginLog pluginLog) : TaskExecutor<CheckSinglePlayerDutyOutcome>
     {
         private DateTime _checkAt = DateTime.MinValue;
 
@@ -360,6 +362,7 @@ internal static class SinglePlayerDuty
 
             if (progress == null || progress.Sequence > Task.SequenceBeforeEntering)
             {
+                pluginLog.Information($"[SinglePlayerDuty] Duty succeeded (sequence {Task.SequenceBeforeEntering} -> {progress?.Sequence.ToString() ?? "complete"})");
                 retryTracker.Reset(Task.Quest.Id, dutyIndex);
                 return ETaskResult.TaskComplete;
             }
@@ -367,13 +370,17 @@ internal static class SinglePlayerDuty
             int retriesUsed = retryTracker.GetCount(Task.Quest.Id, dutyIndex);
             int maxRetries = configuration.SinglePlayerDuties.MaxRetries;
 
+            pluginLog.Information($"[SinglePlayerDuty] Duty failed (sequence unchanged at {Task.SequenceBeforeEntering}), retries used: {retriesUsed}, max: {maxRetries}");
+
             if (maxRetries == 0 || (maxRetries > 0 && retriesUsed >= maxRetries))
             {
+                pluginLog.Information("[SinglePlayerDuty] Retry limit reached or retries disabled, stopping automation");
                 questController.TaskQueue.EnqueueAll([new WaitAtEnd.EndAutomation()]);
                 return ETaskResult.TaskComplete;
             }
 
             retryTracker.Increment(Task.Quest.Id, dutyIndex);
+            pluginLog.Information($"[SinglePlayerDuty] Retrying duty (attempt {retriesUsed + 1})");
             IReadOnlyList<ITask> retryTasks = taskCreator.CreateTasks(
                 Task.Quest, Task.SequenceNumber, Task.QuestSequence, Task.QuestStep);
             questController.TaskQueue.EnqueueAll(retryTasks);

--- a/Questionable/QuestionablePlugin.cs
+++ b/Questionable/QuestionablePlugin.cs
@@ -241,6 +241,7 @@ public sealed class QuestionablePlugin : IDalamudPlugin
             .AddTaskFactoryAndExecutor<TurnInDelivery.Task, TurnInDelivery.Factory,
                 TurnInDelivery.SatisfactionSupplyTurnIn>();
 
+        serviceCollection.AddSingleton<SinglePlayerDuty.RetryTracker>();
         serviceCollection.AddTaskFactory<SinglePlayerDuty.Factory>();
         serviceCollection
             .AddTaskExecutor<SinglePlayerDuty.StartSinglePlayerDuty, SinglePlayerDuty.StartSinglePlayerDutyExecutor>();
@@ -251,6 +252,7 @@ public sealed class QuestionablePlugin : IDalamudPlugin
             .AddTaskExecutor<SinglePlayerDuty.WaitSinglePlayerDuty, SinglePlayerDuty.WaitSinglePlayerDutyExecutor>();
         serviceCollection.AddTaskExecutor<SinglePlayerDuty.DisableAi, SinglePlayerDuty.DisableAiExecutor>();
         serviceCollection.AddTaskExecutor<SinglePlayerDuty.SetTarget, SinglePlayerDuty.SetTargetExecutor>();
+        serviceCollection.AddTaskExecutor<SinglePlayerDuty.CheckSinglePlayerDutyOutcome, SinglePlayerDuty.CheckSinglePlayerDutyOutcomeExecutor>();
 
         serviceCollection.AddTaskExecutor<WaitCondition.Task, WaitCondition.WaitConditionExecutor>();
         serviceCollection.AddTaskExecutor<WaitNavmesh.Task, WaitNavmesh.Executor>();

--- a/Questionable/Windows/ConfigComponents/SinglePlayerDutyConfigComponent.cs
+++ b/Questionable/Windows/ConfigComponents/SinglePlayerDutyConfigComponent.cs
@@ -256,23 +256,21 @@ internal sealed class SinglePlayerDutyConfigComponent
                 ImGui.TextUnformatted("Work in Progress:");
                 ImGui.BulletText("Will always use BossMod for combat (ignoring the configured combat module).");
                 ImGui.BulletText("Only a small subset of quest battles have been tested - most of which are in the MSQ.");
-                ImGui.BulletText("When retrying a failed battle, it will always start at 'Normal' difficulty.");
                 ImGui.BulletText("Please don't enable this option when using a BossMod fork (such as Reborn);\nwith the missing combat module configuration, it is unlikely to be compatible.");
             }
 
-#if false
             using (ImRaii.Disabled(!runSoloInstancesWithBossMod))
             {
                 ImGui.Spacing();
-                int retryDifficulty = Configuration.SinglePlayerDuties.RetryDifficulty;
-                if (ImGui.Combo("Difficulty when retrying a quest battle", ref retryDifficulty, _retryDifficulties,
-                        _retryDifficulties.Length))
+                int retryDifficulty = (int)Configuration.SinglePlayerDuties.RetryDifficulty;
+                if (ImGui.Combo("Difficulty when retrying a failed quest battle", ref retryDifficulty,
+                        _retryDifficulties, _retryDifficulties.Length))
                 {
-                    Configuration.SinglePlayerDuties.RetryDifficulty = (byte)retryDifficulty;
+                    Configuration.SinglePlayerDuties.RetryDifficulty = (EQuestBattleDifficulty)retryDifficulty;
                     Save();
                 }
+                ImGuiComponents.HelpMarker("Not all quest battles offer Easy or Very Easy difficulty.");
             }
-#endif
         }
 
         ImGui.Separator();

--- a/Questionable/Windows/ConfigComponents/SinglePlayerDutyConfigComponent.cs
+++ b/Questionable/Windows/ConfigComponents/SinglePlayerDutyConfigComponent.cs
@@ -289,7 +289,7 @@ internal sealed class SinglePlayerDutyConfigComponent
                 if (retryNTimes)
                 {
                     ImGui.SameLine();
-                    ImGui.SetNextItemWidth(60f);
+                    ImGui.SetNextItemWidth(240f);
                     int n = Math.Max(1, maxRetries);
                     if (ImGui.InputInt("##retryCount", ref n, 1))
                     {

--- a/Questionable/Windows/ConfigComponents/SinglePlayerDutyConfigComponent.cs
+++ b/Questionable/Windows/ConfigComponents/SinglePlayerDutyConfigComponent.cs
@@ -46,9 +46,7 @@ internal sealed class SinglePlayerDutyConfigComponent
         (Job.BLM, "Magical Ranged Role Quests")
     ];
 
-#if false
     private readonly string[] _retryDifficulties = ["Normal", "Easy", "Very Easy"];
-#endif
 
     private readonly TerritoryData _territoryData = territoryData;
     private readonly QuestRegistry _questRegistry = questRegistry;
@@ -266,7 +264,7 @@ internal sealed class SinglePlayerDutyConfigComponent
                 if (ImGui.Combo("Difficulty when retrying a failed quest battle", ref retryDifficulty,
                         _retryDifficulties, _retryDifficulties.Length))
                 {
-                    Configuration.SinglePlayerDuties.RetryDifficulty = (EQuestBattleDifficulty)retryDifficulty;
+                    Configuration.SinglePlayerDuties.RetryDifficulty = (Configuration.EQuestBattleDifficulty)retryDifficulty;
                     Save();
                 }
                 ImGuiComponents.HelpMarker("Not all quest battles offer Easy or Very Easy difficulty.");

--- a/Questionable/Windows/ConfigComponents/SinglePlayerDutyConfigComponent.cs
+++ b/Questionable/Windows/ConfigComponents/SinglePlayerDutyConfigComponent.cs
@@ -270,6 +270,49 @@ internal sealed class SinglePlayerDutyConfigComponent
                     Save();
                 }
                 ImGuiComponents.HelpMarker("Not all quest battles offer Easy or Very Easy difficulty.");
+
+                ImGui.Spacing();
+
+                int maxRetries = Configuration.SinglePlayerDuties.MaxRetries;
+
+                bool doNotRetry = maxRetries == 0;
+                if (ImGui.Checkbox("Do not retry failed quest battles", ref doNotRetry) && doNotRetry)
+                {
+                    Configuration.SinglePlayerDuties.MaxRetries = 0;
+                    Save();
+                }
+
+                bool retryNTimes = maxRetries > 0;
+                if (ImGui.Checkbox("Retry##retryNTimes", ref retryNTimes))
+                {
+                    Configuration.SinglePlayerDuties.MaxRetries = retryNTimes ? 1 : 0;
+                    Save();
+                }
+                if (retryNTimes)
+                {
+                    ImGui.SameLine();
+                    ImGui.SetNextItemWidth(60f);
+                    int n = Math.Max(1, maxRetries);
+                    if (ImGui.InputInt("##retryCount", ref n, 1))
+                    {
+                        Configuration.SinglePlayerDuties.MaxRetries = Math.Max(1, n);
+                        Save();
+                    }
+                    ImGui.SameLine();
+                    ImGui.TextUnformatted("time(s)");
+                }
+
+                bool retryIndefinitely = maxRetries == -1;
+                if (ImGui.Checkbox("Retry indefinitely", ref retryIndefinitely))
+                {
+                    Configuration.SinglePlayerDuties.MaxRetries = retryIndefinitely ? -1 : 0;
+                    Save();
+                }
+                if (retryIndefinitely)
+                {
+                    ImGui.SameLine();
+                    ImGuiComponents.HelpMarker("Warning: Your gear may break if you retry endlessly!");
+                }
             }
         }
 


### PR DESCRIPTION
* Adds a Retry Difficulty drop-down to Quest Battles config.
* Adds Checkboxes for retry attempts: `Don't Retry` (current behavior), `Retry N times`, `Retry Indefinitely` to Quest Battles config
* Does not visually update difficulty selection on duty pop-up but correctly enters desired difficulty if available.
* Takes a snapshot of both the quest sequence and quest variables to see if there's a change when the duty ends implying success/failure.
* Player death was preventing the actual check for duties so this adds an `IgnoreDeath` task. `WaitSinglePlayerDuty` declares `IgnoreDeath = true`; the `QuestController` checks this on both the current task and remaining queued tasks — so when `Unconscious` fires, if `WaitSinglePlayerDuty` is anywhere in the pipeline, the HP = 0 stop is skipped and automation survives to let `CheckSinglePlayerDutyOutcome` run.
*  Non-death failures (escort killed, objective failed, etc.) should "just work"
* The `RetryTracker` is a singleton that lives for the plugin session. On crash or restart it resets to 0. 
* If player restarts/disconnects/crashes, etc., while in a duty, the game no longer offers difficulty options so the plugin uses Normal until failure/difficulty options are unlocked again. 
* Tested thoroughly on the quest/Single Player Duty "The Ultimate Weapon" which has a death wall making it easier to force retries/deaths to confirm The Echo buff was present on non-Normal difficulties when selected from the Quest Battles config.
* When running Single Player Duties in New Game+, difficulty is available on the first attempt; the plugin chooses the configured difficulty. 
* Actively testing on more duties but wanted to share what I had!
* Additionally tested duties:
  * The Hand of Thal (L20 GLA quest, died and got to select difficulty)
  * The Rematch (L30 GLA quest, died and got to select difficulty) 