### PR TITLE
start of refactor questcontroller

### DIFF
--- a/Questionable/Controller/QuestController.cs
+++ b/Questionable/Controller/QuestController.cs
@@ -50,7 +50,6 @@ internal sealed class QuestController : MiniTaskController<QuestController>
         Simulated
     }
 
-    private const char ClipboardSeparator = ';';
     private readonly AlliedSocietyQuestFunctions _alliedSocietyQuestFunctions;
     private readonly IChatGui _chatGui;
     private readonly IClientState _clientState;
@@ -70,6 +69,7 @@ internal sealed class QuestController : MiniTaskController<QuestController>
     private readonly QuestData _questData;
     private readonly QuestFunctions _questFunctions;
     private readonly QuestRegistry _questRegistry;
+    private readonly QuestPriorityManager _priorityManager;
     private readonly SinglePlayerDutyConfigComponent _singlePlayerDutyConfigComponent;
     private readonly TaskCreator _taskCreator;
     private readonly IToastGui _toastGui;
@@ -108,6 +108,7 @@ internal sealed class QuestController : MiniTaskController<QuestController>
         ILogger<QuestController> logger,
         HighlightObject highlightObject,
         QuestRegistry questRegistry,
+        QuestPriorityManager priorityManager,
         QuestData questData,
         IKeyState keyState,
         IChatGui chatGui,
@@ -131,6 +132,7 @@ internal sealed class QuestController : MiniTaskController<QuestController>
         _combatController = combatController;
         _gatheringController = gatheringController;
         _questRegistry = questRegistry;
+        _priorityManager = priorityManager;
         _questData = questData;
         _keyState = keyState;
         _chatGui = chatGui;
@@ -192,7 +194,7 @@ internal sealed class QuestController : MiniTaskController<QuestController>
     /// </summary>
     public QuestProgress? PendingQuest { get; private set; }
 
-    public List<Quest> ManualPriorityQuests { get; } = [];
+    public QuestPriorityManager PriorityManager => _priorityManager;
 
     public bool StopAfterCurrentQuest { get; set; }
     public bool StopBeforeTeleport { get; set; }
@@ -496,7 +498,7 @@ internal sealed class QuestController : MiniTaskController<QuestController>
             {
                 (ElementId? currentQuestId, currentSequence, MainScenarioQuestState msqState) = _questFunctions.GetCurrentQuest(allowNewMsq: AutomationType != EAutomationType.SingleQuestB);
                 (ElementId, byte)? priorityQuestOption =
-                    ManualPriorityQuests
+                    _priorityManager.Quests
                         .Where(x => _questFunctions.IsReadyToAcceptQuest(x.Id) || _questFunctions.IsQuestAccepted(x.Id))
                         .Select(x => (x.Id, _questFunctions.GetQuestProgressInfo(x.Id)?.Sequence ?? 0))
                         .FirstOrDefault();
@@ -1086,7 +1088,7 @@ internal sealed class QuestController : MiniTaskController<QuestController>
         if (type != ECurrentQuestType.Normal || !currentQuest.Quest.Root.Interruptible || currentQuest.Sequence == 0)
             return false;
 
-        if (ManualPriorityQuests.Contains(currentQuest.Quest))
+        if (_priorityManager.Contains(currentQuest.Quest))
             return false;
 
         // "ifrit bleeds, we can kill it" isn't listed as priority quest, as we accept it during the MSQ 'Moving On'
@@ -1130,51 +1132,6 @@ internal sealed class QuestController : MiniTaskController<QuestController>
         }
 
         return false;
-    }
-
-    public void ImportQuestPriority(List<ElementId> questElements)
-    {
-        foreach (ElementId elementId in questElements)
-        {
-            if (_questRegistry.TryGetQuest(elementId, out Quest? quest) && !ManualPriorityQuests.Contains(quest))
-                ManualPriorityQuests.Add(quest);
-        }
-    }
-    public string ExportQuestPriority() => string.Join(ClipboardSeparator, ManualPriorityQuests.Select(x => x.Id.ToString()));
-
-    public void ClearQuestPriority() => ManualPriorityQuests.Clear();
-
-    public bool AddQuestPriority(ElementId elementId)
-    {
-        if (_questRegistry.TryGetQuest(elementId, out Quest? quest) && !ManualPriorityQuests.Contains(quest))
-        {
-            ManualPriorityQuests.Add(quest);
-        }
-
-        return true;
-    }
-
-    public bool RemoveQuestPriority(ElementId elementId)
-    {
-        if (_questRegistry.TryGetQuest(elementId, out Quest? quest) && ManualPriorityQuests.Contains(quest))
-            ManualPriorityQuests.Remove(quest);
-        return true;
-    }
-
-    public bool InsertQuestPriority(int index, ElementId elementId)
-    {
-        try
-        {
-            if (_questRegistry.TryGetQuest(elementId, out Quest? quest) && !ManualPriorityQuests.Contains(quest))
-                ManualPriorityQuests.Insert(index, quest);
-            return true;
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e, "Failed to insert quest in priority list");
-            _chatGui.PrintError("Failed to insert quest in priority list, please check /xllog for details.", CommandHandler.MessageTag, CommandHandler.TagColor);
-            return false;
-        }
     }
 
     public bool WasLastTaskUpdateWithin(TimeSpan timeSpan)

--- a/Questionable/Controller/QuestController.cs
+++ b/Questionable/Controller/QuestController.cs
@@ -70,6 +70,7 @@ internal sealed class QuestController : MiniTaskController<QuestController>
     private readonly QuestFunctions _questFunctions;
     private readonly QuestRegistry _questRegistry;
     private readonly QuestPriorityManager _priorityManager;
+    private readonly QuestProgressTracker _tracker;
     private readonly SinglePlayerDutyConfigComponent _singlePlayerDutyConfigComponent;
     private readonly TaskCreator _taskCreator;
     private readonly IToastGui _toastGui;
@@ -109,6 +110,7 @@ internal sealed class QuestController : MiniTaskController<QuestController>
         HighlightObject highlightObject,
         QuestRegistry questRegistry,
         QuestPriorityManager priorityManager,
+        QuestProgressTracker tracker,
         QuestData questData,
         IKeyState keyState,
         IChatGui chatGui,
@@ -133,6 +135,7 @@ internal sealed class QuestController : MiniTaskController<QuestController>
         _gatheringController = gatheringController;
         _questRegistry = questRegistry;
         _priorityManager = priorityManager;
+        _tracker = tracker;
         _questData = questData;
         _keyState = keyState;
         _chatGui = chatGui;
@@ -165,34 +168,42 @@ internal sealed class QuestController : MiniTaskController<QuestController>
         }
     }
 
-    public (QuestProgress Progress, ECurrentQuestType Type)? CurrentQuestDetails
+    public (QuestProgress Progress, ECurrentQuestType Type)? CurrentQuestDetails => _tracker.CurrentQuestDetails;
+
+    public QuestProgress? CurrentQuest => _tracker.CurrentQuest;
+
+    public QuestProgress? StartedQuest
     {
-        get
-        {
-            if (SimulatedQuest != null)
-                return (SimulatedQuest, ECurrentQuestType.Simulated);
-            else if (NextQuest != null && _questFunctions.IsReadyToAcceptQuest(NextQuest.Quest.Id))
-                return (NextQuest, ECurrentQuestType.Next);
-            else if (GatheringQuest != null)
-                return (GatheringQuest, ECurrentQuestType.Gathering);
-            else if (StartedQuest != null)
-                return (StartedQuest, ECurrentQuestType.Normal);
-            else
-                return null;
-        }
+        get => _tracker.StartedQuest;
+        private set => _tracker.StartedQuest = value;
     }
 
-    public QuestProgress? CurrentQuest => CurrentQuestDetails?.Progress;
+    public QuestProgress? SimulatedQuest
+    {
+        get => _tracker.SimulatedQuest;
+        private set => _tracker.SimulatedQuest = value;
+    }
 
-    public QuestProgress? StartedQuest { get; private set; }
-    public QuestProgress? SimulatedQuest { get; private set; }
-    public QuestProgress? NextQuest { get; private set; }
-    public QuestProgress? GatheringQuest { get; private set; }
+    public QuestProgress? NextQuest
+    {
+        get => _tracker.NextQuest;
+        private set => _tracker.NextQuest = value;
+    }
+
+    public QuestProgress? GatheringQuest
+    {
+        get => _tracker.GatheringQuest;
+        private set => _tracker.GatheringQuest = value;
+    }
 
     /// <summary>
     ///     Used when accepting leves, as there's a small delay
     /// </summary>
-    public QuestProgress? PendingQuest { get; private set; }
+    public QuestProgress? PendingQuest
+    {
+        get => _tracker.PendingQuest;
+        private set => _tracker.PendingQuest = value;
+    }
 
     public QuestPriorityManager PriorityManager => _priorityManager;
 
@@ -237,11 +248,7 @@ internal sealed class QuestController : MiniTaskController<QuestController>
 
     private void ResetInternalState()
     {
-        StartedQuest = null;
-        NextQuest = null;
-        GatheringQuest = null;
-        PendingQuest = null;
-        SimulatedQuest = null;
+        _tracker.Reset();
         _safeAnimationEnd = DateTime.MinValue;
 
         DebugState = null;
@@ -667,24 +674,7 @@ internal sealed class QuestController : MiniTaskController<QuestController>
         }
     }
 
-    public (QuestSequence? Sequence, QuestStep? Step, bool createTasks) GetNextStep()
-    {
-        if (CurrentQuest == null)
-            return (null, null, false);
-
-        Quest q = CurrentQuest.Quest;
-        QuestSequence? seq = q.FindSequence(CurrentQuest.Sequence);
-        if (seq == null)
-            return (null, null, true);
-
-        if (seq.Steps.Count == 0)
-            return (seq, null, true);
-
-        if (CurrentQuest.Step >= seq.Steps.Count)
-            return (null, null, false);
-
-        return (seq, seq.Steps[CurrentQuest.Step], true);
-    }
+    public (QuestSequence? Sequence, QuestStep? Step, bool createTasks) GetNextStep() => _tracker.GetNextStep();
 
     public void IncreaseStepCount(ElementId? questId, int? sequence, bool shouldContinue = false)
     {
@@ -827,55 +817,19 @@ internal sealed class QuestController : MiniTaskController<QuestController>
             Stop(label);
     }
 
-    public void SimulateQuest(IQuestInfo? questInfo, byte sequence, int step)
-    {
-        if (questInfo is not null && _questRegistry.TryGetQuest(questInfo.QuestId, out Quest? quest))
-            SimulateQuest(quest, sequence, step);
-    }
+    public void SimulateQuest(IQuestInfo? questInfo, byte sequence, int step) =>
+        _tracker.SimulateQuest(questInfo, sequence, step);
 
-    public void SimulateQuest(Quest? quest, byte sequence, int step)
-    {
-        _highlightObject.SetHighlight([]);
-        _logger.LogInformation("SimulateQuest: {QuestId}", quest?.Id);
-        if (quest != null)
-            SimulatedQuest = new(quest, sequence, step);
-        else
-            SimulatedQuest = null;
-    }
+    public void SimulateQuest(Quest? quest, byte sequence, int step) =>
+        _tracker.SimulateQuest(quest, sequence, step);
 
-    public void StopSimulate()
-    {
-        _highlightObject.SetHighlight([]);
-        _logger.LogInformation("StopSimulate");
-        SimulatedQuest = null;
-    }
+    public void StopSimulate() => _tracker.StopSimulate();
 
-    public void SetNextQuest(Quest? quest)
-    {
-        _highlightObject.SetHighlight([]);
-        _logger.LogInformation("NextQuest: {QuestId}", quest?.Id);
-        if (quest != null)
-            NextQuest = new(quest);
-        else
-            NextQuest = null;
-    }
+    public void SetNextQuest(Quest? quest) => _tracker.SetNextQuest(quest);
 
-    public void SetGatheringQuest(Quest? quest)
-    {
-        _highlightObject.SetHighlight([]);
-        _logger.LogInformation("GatheringQuest: {QuestId}", quest?.Id);
-        if (quest != null)
-            GatheringQuest = new(quest);
-        else
-            GatheringQuest = null;
-    }
+    public void SetGatheringQuest(Quest? quest) => _tracker.SetGatheringQuest(quest);
 
-    public void SetPendingQuest(QuestProgress? quest)
-    {
-        _highlightObject.SetHighlight([]);
-        _logger.LogInformation("PendingQuest: {QuestId}", quest?.Quest.Id);
-        PendingQuest = quest;
-    }
+    public void SetPendingQuest(QuestProgress? quest) => _tracker.SetPendingQuest(quest);
 
     protected override void UpdateCurrentTask()
     {

--- a/Questionable/Controller/QuestPriorityManager.cs
+++ b/Questionable/Controller/QuestPriorityManager.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dalamud.Plugin.Services;
+using Microsoft.Extensions.Logging;
+using Questionable.Model.Questing;
+using Quest = Questionable.Model.Quest;
+
+namespace Questionable.Controller;
+
+/// <summary>
+///     Holds and mutates the user's manually-prioritised quest list. Extracted from
+///     <see cref="QuestController"/> so the list logic lives in one focused, testable place.
+/// </summary>
+internal sealed class QuestPriorityManager(
+    QuestRegistry questRegistry,
+    ILogger<QuestPriorityManager> logger,
+    IChatGui chatGui)
+{
+    private const char ClipboardSeparator = ';';
+    private readonly List<Quest> _quests = [];
+
+    public IReadOnlyList<Quest> Quests => _quests;
+    public int Count => _quests.Count;
+    public bool IsEmpty => _quests.Count == 0;
+
+    public bool Contains(Quest quest) => _quests.Contains(quest);
+
+    public bool Add(Quest quest)
+    {
+        if (_quests.Contains(quest))
+            return false;
+
+        _quests.Add(quest);
+        return true;
+    }
+
+    public bool Add(ElementId elementId)
+    {
+        if (questRegistry.TryGetQuest(elementId, out Quest? quest) && !_quests.Contains(quest))
+            _quests.Add(quest);
+
+        return true;
+    }
+
+    public bool Insert(int index, ElementId elementId)
+    {
+        try
+        {
+            if (questRegistry.TryGetQuest(elementId, out Quest? quest) && !_quests.Contains(quest))
+                _quests.Insert(index, quest);
+            return true;
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "Failed to insert quest in priority list");
+            chatGui.PrintError("Failed to insert quest in priority list, please check /xllog for details.",
+                CommandHandler.MessageTag, CommandHandler.TagColor);
+            return false;
+        }
+    }
+
+    public bool Remove(Quest quest) => _quests.Remove(quest);
+
+    public bool Remove(ElementId elementId)
+    {
+        if (questRegistry.TryGetQuest(elementId, out Quest? quest))
+            _quests.Remove(quest);
+
+        return true;
+    }
+
+    /// <summary>Moves the quest at <paramref name="oldIndex"/> to <paramref name="newIndex"/> (used by drag-drop).</summary>
+    public void Move(int oldIndex, int newIndex)
+    {
+        if (oldIndex < 0 || oldIndex >= _quests.Count || newIndex < 0 || newIndex >= _quests.Count)
+            return;
+
+        Quest quest = _quests[oldIndex];
+        _quests.RemoveAt(oldIndex);
+        _quests.Insert(newIndex, quest);
+    }
+
+    public void RemoveCompleted(Func<ElementId, bool> isComplete) => _quests.RemoveAll(q => isComplete(q.Id));
+
+    public void Clear() => _quests.Clear();
+
+    public void Import(IEnumerable<ElementId> questElements)
+    {
+        foreach (ElementId elementId in questElements)
+        {
+            if (questRegistry.TryGetQuest(elementId, out Quest? quest) && !_quests.Contains(quest))
+                _quests.Add(quest);
+        }
+    }
+
+    public string Export() => string.Join(ClipboardSeparator, _quests.Select(x => x.Id.ToString()));
+}

--- a/Questionable/Controller/QuestProgressTracker.cs
+++ b/Questionable/Controller/QuestProgressTracker.cs
@@ -1,0 +1,129 @@
+using Microsoft.Extensions.Logging;
+using Questionable.Controller.Utils;
+using Questionable.Functions;
+using Questionable.Model;
+using Questionable.Model.Questing;
+using Quest = Questionable.Model.Quest;
+
+namespace Questionable.Controller;
+
+/// <summary>
+///     Tracks which quest is currently being worked on. There are up to five quest "slots"
+///     (started / simulated / next / gathering / pending); this class owns those slots, the rules
+///     that pick the currently-active one, and the setters that mutate them. Extracted from
+///     <see cref="QuestController"/>.
+/// </summary>
+internal sealed class QuestProgressTracker(
+    QuestFunctions questFunctions,
+    QuestRegistry questRegistry,
+    HighlightObject highlightObject,
+    ILogger<QuestProgressTracker> logger)
+{
+    public QuestController.QuestProgress? StartedQuest { get; set; }
+    public QuestController.QuestProgress? SimulatedQuest { get; set; }
+    public QuestController.QuestProgress? NextQuest { get; set; }
+    public QuestController.QuestProgress? GatheringQuest { get; set; }
+
+    /// <summary>
+    ///     Used when accepting leves, as there's a small delay.
+    /// </summary>
+    public QuestController.QuestProgress? PendingQuest { get; set; }
+
+    public (QuestController.QuestProgress Progress, QuestController.ECurrentQuestType Type)? CurrentQuestDetails
+    {
+        get
+        {
+            if (SimulatedQuest != null)
+                return (SimulatedQuest, QuestController.ECurrentQuestType.Simulated);
+            else if (NextQuest != null && questFunctions.IsReadyToAcceptQuest(NextQuest.Quest.Id))
+                return (NextQuest, QuestController.ECurrentQuestType.Next);
+            else if (GatheringQuest != null)
+                return (GatheringQuest, QuestController.ECurrentQuestType.Gathering);
+            else if (StartedQuest != null)
+                return (StartedQuest, QuestController.ECurrentQuestType.Normal);
+            else
+                return null;
+        }
+    }
+
+    public QuestController.QuestProgress? CurrentQuest => CurrentQuestDetails?.Progress;
+
+    /// <summary>Clears every quest slot.</summary>
+    public void Reset()
+    {
+        StartedQuest = null;
+        NextQuest = null;
+        GatheringQuest = null;
+        PendingQuest = null;
+        SimulatedQuest = null;
+    }
+
+    public void SimulateQuest(IQuestInfo? questInfo, byte sequence, int step)
+    {
+        if (questInfo is not null && questRegistry.TryGetQuest(questInfo.QuestId, out Quest? quest))
+            SimulateQuest(quest, sequence, step);
+    }
+
+    public void SimulateQuest(Quest? quest, byte sequence, int step)
+    {
+        highlightObject.SetHighlight([]);
+        logger.LogInformation("SimulateQuest: {QuestId}", quest?.Id);
+        if (quest != null)
+            SimulatedQuest = new(quest, sequence, step);
+        else
+            SimulatedQuest = null;
+    }
+
+    public void StopSimulate()
+    {
+        highlightObject.SetHighlight([]);
+        logger.LogInformation("StopSimulate");
+        SimulatedQuest = null;
+    }
+
+    public void SetNextQuest(Quest? quest)
+    {
+        highlightObject.SetHighlight([]);
+        logger.LogInformation("NextQuest: {QuestId}", quest?.Id);
+        if (quest != null)
+            NextQuest = new(quest);
+        else
+            NextQuest = null;
+    }
+
+    public void SetGatheringQuest(Quest? quest)
+    {
+        highlightObject.SetHighlight([]);
+        logger.LogInformation("GatheringQuest: {QuestId}", quest?.Id);
+        if (quest != null)
+            GatheringQuest = new(quest);
+        else
+            GatheringQuest = null;
+    }
+
+    public void SetPendingQuest(QuestController.QuestProgress? quest)
+    {
+        highlightObject.SetHighlight([]);
+        logger.LogInformation("PendingQuest: {QuestId}", quest?.Quest.Id);
+        PendingQuest = quest;
+    }
+
+    public (QuestSequence? Sequence, QuestStep? Step, bool createTasks) GetNextStep()
+    {
+        if (CurrentQuest == null)
+            return (null, null, false);
+
+        Quest q = CurrentQuest.Quest;
+        QuestSequence? seq = q.FindSequence(CurrentQuest.Sequence);
+        if (seq == null)
+            return (null, null, true);
+
+        if (seq.Steps.Count == 0)
+            return (seq, null, true);
+
+        if (CurrentQuest.Step >= seq.Steps.Count)
+            return (null, null, false);
+
+        return (seq, seq.Steps[CurrentQuest.Step], true);
+    }
+}

--- a/Questionable/External/QuestionableIpc.cs
+++ b/Questionable/External/QuestionableIpc.cs
@@ -267,14 +267,14 @@ internal sealed class QuestionableIpc : IDisposable
     {
         _logger.LogDebug($"ImportQuestPriority({encodedQuestPriority})");
         List<ElementId> questElements = PriorityWindow.DecodeQuestPriority(encodedQuestPriority);
-        _questController.ImportQuestPriority(questElements);
+        _questController.PriorityManager.Import(questElements);
         return true;
     }
 
     private bool ClearQuestPriority()
     {
         _logger.LogDebug("ClearQuestPriority()");
-        _questController.ClearQuestPriority();
+        _questController.PriorityManager.Clear();
         return true;
     }
 
@@ -284,7 +284,7 @@ internal sealed class QuestionableIpc : IDisposable
         if (ElementId.TryFromString(questId, out ElementId? elementId) && elementId != null &&
             _questRegistry.IsKnownQuest(elementId))
         {
-            return _questController.AddQuestPriority(elementId);
+            return _questController.PriorityManager.Add(elementId);
         }
 
         return true;
@@ -296,7 +296,7 @@ internal sealed class QuestionableIpc : IDisposable
         if (ElementId.TryFromString(questId, out ElementId? elementId) && elementId != null &&
             _questRegistry.IsKnownQuest(elementId))
         {
-            return _questController.InsertQuestPriority(index, elementId);
+            return _questController.PriorityManager.Insert(index, elementId);
         }
 
         return true;

--- a/Questionable/QuestionablePlugin.cs
+++ b/Questionable/QuestionablePlugin.cs
@@ -278,6 +278,7 @@ public sealed class QuestionablePlugin : IDalamudPlugin
         serviceCollection.AddSingleton<MovementOverrideController>();
         serviceCollection.AddSingleton<GatheringPointRegistry>();
         serviceCollection.AddSingleton<QuestRegistry>();
+        serviceCollection.AddSingleton<QuestPriorityManager>();
         serviceCollection.AddSingleton<QuestController>();
         serviceCollection.AddSingleton<CombatController>();
         serviceCollection.AddSingleton<GatheringController>();

--- a/Questionable/QuestionablePlugin.cs
+++ b/Questionable/QuestionablePlugin.cs
@@ -279,6 +279,7 @@ public sealed class QuestionablePlugin : IDalamudPlugin
         serviceCollection.AddSingleton<GatheringPointRegistry>();
         serviceCollection.AddSingleton<QuestRegistry>();
         serviceCollection.AddSingleton<QuestPriorityManager>();
+        serviceCollection.AddSingleton<QuestProgressTracker>();
         serviceCollection.AddSingleton<QuestController>();
         serviceCollection.AddSingleton<CombatController>();
         serviceCollection.AddSingleton<GatheringController>();

--- a/Questionable/Windows/JournalComponents/AlliedSocietyJournalComponent.cs
+++ b/Questionable/Windows/JournalComponents/AlliedSocietyJournalComponent.cs
@@ -159,7 +159,7 @@ internal sealed class AlliedSocietyJournalComponent
         if (_uiUtils.ChecklistItem(checklistItem, color, icon))
             _questTooltipComponent.Draw(questInfo);
         if (addPending && (color.Equals(ImGuiColors.DalamudRed) || color.Equals(ImGuiColors.DPSRed)))
-            _questController.AddQuestPriority(questInfo.QuestId);
+            _questController.PriorityManager.Add(questInfo.QuestId);
 
         _questJournalUtils.ShowContextMenu(questInfo, quest, nameof(AlliedSocietyJournalComponent));
     }

--- a/Questionable/Windows/JournalComponents/QuestJournalUtils.cs
+++ b/Questionable/Windows/JournalComponents/QuestJournalUtils.cs
@@ -37,7 +37,7 @@ internal sealed class QuestJournalUtils
         using (ImRaii.Disabled(quest == null))
         {
             if (ImGui.MenuItem("Add to Priority Quests") && quest != null)
-                _questController.AddQuestPriority(quest.Id);
+                _questController.PriorityManager.Add(quest.Id);
         }
 
         using (ImRaii.Disabled(!_questFunctions.IsReadyToAcceptQuest(questInfo.QuestId)))
@@ -98,13 +98,13 @@ internal sealed class QuestJournalUtils
         if (ImGui.MenuItem("Add all to Priority Quests"))
         {
             foreach (IQuestInfo quest in quests)
-                _questController.AddQuestPriority(quest.QuestId);
+                _questController.PriorityManager.Add(quest.QuestId);
         }
 
         if (ImGui.MenuItem("Remove all from Priority Quests"))
         {
             foreach (IQuestInfo quest in quests)
-                _questController.RemoveQuestPriority(quest.QuestId);
+                _questController.PriorityManager.Remove(quest.QuestId);
         }
     }
 }

--- a/Questionable/Windows/PriorityWindow.cs
+++ b/Questionable/Windows/PriorityWindow.cs
@@ -66,9 +66,9 @@ internal sealed class PriorityWindow : LWindow
         _questSelector.SuggestionPredicate = quest =>
             !quest.Info.IsMainScenarioQuest &&
             !questFunctions.IsQuestUnobtainable(quest.Id) &&
-            questController.ManualPriorityQuests.All(x => x.Id != quest.Id);
+            questController.PriorityManager.Quests.All(x => x.Id != quest.Id);
         _questSelector.DefaultPredicate = quest => questFunctions.IsQuestAccepted(quest.Id);
-        _questSelector.QuestSelected = quest => _questController.ManualPriorityQuests.Add(quest);
+        _questSelector.QuestSelected = quest => _questController.PriorityManager.Add(quest);
 
         Size = new Vector2(400, 400);
         SizeCondition = ImGuiCond.Once;
@@ -113,17 +113,17 @@ internal sealed class PriorityWindow : LWindow
             ImportFromClipboard(clipboardItems);
         ImGui.EndDisabled();
         ImGui.SameLine();
-        ImGui.BeginDisabled(_questController.ManualPriorityQuests.Count == 0);
+        ImGui.BeginDisabled(_questController.PriorityManager.IsEmpty);
         if (ImGuiComponents.IconButtonWithText(FontAwesomeIcon.Upload, "Export to Clipboard"))
             ExportToClipboard();
         if (ImGuiComponents.IconButtonWithText(FontAwesomeIcon.Check, "Remove finished Quests"))
-            _questController.ManualPriorityQuests.RemoveAll(q => _questFunctions.IsQuestComplete(q.Id));
+            _questController.PriorityManager.RemoveCompleted(_questFunctions.IsQuestComplete);
         ImGui.SameLine();
 
         using (ImRaii.Disabled(!ImGui.IsKeyDown(ImGuiKey.ModCtrl)))
         {
             if (ImGuiComponents.IconButtonWithText(FontAwesomeIcon.Trash, "Clear All"))
-                _questController.ClearQuestPriority();
+                _questController.PriorityManager.Clear();
         }
 
         if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
@@ -134,7 +134,7 @@ internal sealed class PriorityWindow : LWindow
 
     private void DrawQuestList()
     {
-        List<Quest> priorityQuests = _questController.ManualPriorityQuests;
+        List<Quest> priorityQuests = [.. _questController.PriorityManager.Quests];
         Quest? itemToRemove = null;
         Quest? itemToAdd = null;
         int indexToAdd = 0;
@@ -251,13 +251,10 @@ internal sealed class PriorityWindow : LWindow
         }
 
         if (itemToRemove != null)
-            priorityQuests.Remove(itemToRemove);
+            _questController.PriorityManager.Remove(itemToRemove);
 
         if (itemToAdd != null)
-        {
-            priorityQuests.Remove(itemToAdd);
-            priorityQuests.Insert(indexToAdd, itemToAdd);
-        }
+            _questController.PriorityManager.Move(priorityQuests.IndexOf(itemToAdd), indexToAdd);
     }
 
     private static List<ElementId> ParseClipboardItems()
@@ -303,7 +300,7 @@ internal sealed class PriorityWindow : LWindow
     public string EncodeQuestPriority()
     {
         return ClipboardPrefix + Convert.ToBase64String(Encoding.UTF8.GetBytes(
-            string.Join(ClipboardSeparator, _questController.ManualPriorityQuests.Select(x => x.Id.ToString()))));
+            string.Join(ClipboardSeparator, _questController.PriorityManager.Quests.Select(x => x.Id.ToString()))));
     }
 
     private void ExportToClipboard()
@@ -313,7 +310,7 @@ internal sealed class PriorityWindow : LWindow
         _chatGui.Print("Copied quests to clipboard.", CommandHandler.MessageTag, CommandHandler.TagColor);
     }
 
-    private void ImportFromClipboard(List<ElementId> questElements) => _questController.ImportQuestPriority(questElements);
+    private void ImportFromClipboard(List<ElementId> questElements) => _questController.PriorityManager.Import(questElements);
 
     private void DrawPresets()
     {
@@ -362,7 +359,7 @@ internal sealed class PriorityWindow : LWindow
         bool nameEmpty = string.IsNullOrWhiteSpace(_presetName);
         bool nameIsBuiltIn = !nameEmpty && builtInPresets.ContainsKey(_presetName.Trim());
         bool nameExists = !nameEmpty && userPresets.ContainsKey(_presetName.Trim());
-        bool noQuests = _questController.ManualPriorityQuests.Count == 0;
+        bool noQuests = _questController.PriorityManager.IsEmpty;
 
         using (ImRaii.Disabled(nameEmpty || nameIsBuiltIn || noQuests || (nameExists && !ImGui.IsKeyDown(ImGuiKey.ModCtrl))))
         {
@@ -439,18 +436,18 @@ internal sealed class PriorityWindow : LWindow
 
     private void LoadPreset(string name)
     {
-        _questController.ClearQuestPriority();
+        _questController.PriorityManager.Clear();
 
         if (name == JobQuestsPresetName)
         {
-            _questController.ImportQuestPriority(GetCurrentJobQuests());
+            _questController.PriorityManager.Import(GetCurrentJobQuests());
             return;
         }
 
         Dictionary<string, List<ElementId>> builtInPresets = GetOrCreateBuiltInPresets();
         if (builtInPresets.TryGetValue(name, out List<ElementId>? questIds))
         {
-            _questController.ImportQuestPriority(questIds);
+            _questController.PriorityManager.Import(questIds);
         }
         else if (_configuration.Priority.Presets.TryGetValue(name, out List<string>? questIdStrings))
         {
@@ -461,13 +458,13 @@ internal sealed class PriorityWindow : LWindow
                     ids.Add(id);
             }
 
-            _questController.ImportQuestPriority(ids);
+            _questController.PriorityManager.Import(ids);
         }
     }
 
     private void SavePreset(string name)
     {
-        List<string> questIds = _questController.ManualPriorityQuests
+        List<string> questIds = _questController.PriorityManager.Quests
             .Select(q => q.Id.ToString())
             .ToList();
         _configuration.Priority.Presets[name] = questIds;

--- a/Questionable/Windows/QuestComponents/CreationUtilsComponent.cs
+++ b/Questionable/Windows/QuestComponents/CreationUtilsComponent.cs
@@ -150,7 +150,7 @@ internal sealed class CreationUtilsComponent
 
                                         if (ImGui.IsItemClicked())
                                         {
-                                            _questController.AddQuestPriority(quest.Id);
+                                            _questController.PriorityManager.Add(quest.Id);
                                             if (!_priorityWindow.IsOpen)
                                                 _priorityWindow.ToggleOrUncollapse();
                                             _priorityWindow.BringToFront();


### PR DESCRIPTION
### MERGE LAST

### New classes
- **`QuestPriorityManager`** — owns the manual-priority quest list and all operations on
  it (`Add`/`Insert`/`Remove`/`Move`/`RemoveCompleted`/`Clear`/`Import`/`Export`,
  read-only `Quests`)
- **`QuestProgressTracker`** — owns the five quest slots (`StartedQuest`,
  `SimulatedQuest`, `NextQuest`, `GatheringQuest`, `PendingQuest`), the
  `CurrentQuest` selection rules, the slot setters, `Reset()` and `GetNextStep()`

### QuestController
- Priority list + five slots moved out; `QuestController` now forwards to the two new
  classes via thin properties/delegators (~120 net lines lighter)
- Both new classes registered as singletons in `QuestionablePlugin`

### Call sites
- Old `QuestController` priority methods + `ManualPriorityQuests` replaced with
  `QuestController.PriorityManager.*` across IPC, journal components, and PriorityWindow
- `PriorityWindow` no longer mutates the live list in place — reordering goes through
  `PriorityManager.Move`, "Remove finished" through `RemoveCompleted(predicate)`