### PR TITLE
bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,2 @@
-- Icon in Journal Progress to show when quest is in Priority Quests -wah
-  - Priority Quests icon changed from Exclamation to ExclamationCircle -alydev
-- Standardised 'Priority Quests' name -alydev
-- Click NoQuestPath journal progress entry to travel to issuer -alydev
-- Dependencies tab sections can now be minimised -alydev
-- Testing refactor -Kage, alydev
-- Add split pathing. so the plugin doesnt have to update anytime there is a path update - Kage
-  - Loading local paths after downloaded bundle paths -alydev
-- Add Death handling. Now it will retry 5 times before it needs manual intervention. - Kage
-- Fix list quests not selecting the correct response - Kage 
-- Fix Icon - Kage
+- Fix emote step not always going through - Kage
+- various backend fixes - Kage

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup Condition="$(MSBuildProjectName) != 'GatheringPathRenderer'">
-        <Version>15.285.1.3</Version>
+        <Version>15.285.1.4</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Questionable/Controller/Steps/Interactions/Dive.cs
+++ b/Questionable/Controller/Steps/Interactions/Dive.cs
@@ -12,7 +12,8 @@ namespace Questionable.Controller.Steps.Interactions;
 
 internal static class Dive
 {
-    private static DiveDelegate DiveFunc = Marshal.GetDelegateForFunctionPointer<DiveDelegate>(Svc.SigScanner.ScanText("48 89 5C 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 48 8B 1D ?? ?? ?? ?? 48 8D 54 24"));
+    private static DiveDelegate? _diveFunc;
+    private static DiveDelegate DiveFunc => _diveFunc ??= Marshal.GetDelegateForFunctionPointer<DiveDelegate>(Svc.SigScanner.ScanText("48 89 5C 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 48 8B 1D ?? ?? ?? ?? 48 8D 54 24"));
     public static unsafe void ExecuteDive() => DiveFunc(Control.Instance());
     private static unsafe void Dismount() => ActionManager.Instance()->UseAction(ActionType.GeneralAction, 23);
     private unsafe delegate byte DiveDelegate(void* control);

--- a/Questionable/Controller/Steps/Interactions/Emote.cs
+++ b/Questionable/Controller/Steps/Interactions/Emote.cs
@@ -45,10 +45,20 @@ internal static class Emote
     internal sealed class UseOnObjectExecutor(ChatFunctions chatFunctions)
         : AbstractDelayedTaskExecutor<UseOnObject>
     {
+        private bool _emoteFired;
+
         protected override bool StartInternal()
         {
-            chatFunctions.UseEmote(Task.DataId, Task.Emote);
+            _emoteFired = chatFunctions.UseEmote(Task.DataId, Task.Emote);
             return true;
+        }
+
+        protected override ETaskResult UpdateInternal()
+        {
+            if (!_emoteFired)
+                return ETaskResult.RetryStep;
+
+            return ETaskResult.TaskComplete;
         }
 
         public override bool ShouldInterruptOnDamage() => true;

--- a/Questionable/Controller/Steps/Interactions/EquipRecommended.cs
+++ b/Questionable/Controller/Steps/Interactions/EquipRecommended.cs
@@ -76,7 +76,7 @@ internal static class EquipRecommended
 
                     if (!_checkedOrTriggeredEquipmentUpdate)
                     {
-                        if (!IsAllRecommendeGearEquipped())
+                    if (!IsAllRecommendedGearEquipped())
                         {
                             chatGui.Print("Equipping recommended gear.", CommandHandler.MessageTag, CommandHandler.TagColor);
                             recommendedEquipModule->EquipRecommendedGear();
@@ -105,13 +105,12 @@ internal static class EquipRecommended
             return DateTime.Now >= _continueAt ? ETaskResult.TaskComplete : ETaskResult.StillRunning;
         }
 
-        private bool IsAllRecommendeGearEquipped()
+        private bool IsAllRecommendedGearEquipped()
         {
             RecommendEquipModule* recommendedEquipModule = RecommendEquipModule.Instance();
             InventoryManager* inventoryManager = InventoryManager.Instance();
             InventoryContainer* equippedItems =
                 inventoryManager->GetInventoryContainer(InventoryType.EquippedItems);
-            bool isAllEquipped = true;
             foreach (Pointer<InventoryItem> recommendedItemPtr in recommendedEquipModule->RecommendedItems)
             {
                 InventoryItem* recommendedItem = recommendedItemPtr.Value;
@@ -130,10 +129,10 @@ internal static class EquipRecommended
                 }
 
                 if (!isEquipped)
-                    isAllEquipped = false;
+                    return false;
             }
 
-            return isAllEquipped;
+            return true;
         }
 
         public override bool ShouldInterruptOnDamage() => true;

--- a/Questionable/Controller/Steps/Interactions/UnequipItem.cs
+++ b/Questionable/Controller/Steps/Interactions/UnequipItem.cs
@@ -135,12 +135,8 @@ internal static class UnequipItem
                 }
             }
 
-            //int result = inventoryManager->MoveItemSlot(sourceInventoryType, sourceSlot,
-            //    InventoryType.EquippedItems, targetSlot, true);
-            //logger.LogInformation("MoveItemSlot result: {Result}", result);
-            return;
-
-            throw new TaskException($"Could not unequip item {Task.ItemId}.");
+            // TODO: Implement actual unequip logic (MoveItemSlot to armory chest)
+            logger.LogWarning("Unequip not yet implemented for item {ItemId}", Task.ItemId);
         }
 
         private static List<ushort>? GetEquipSlot(Item? item)

--- a/Questionable/Functions/ChatFunctions.cs
+++ b/Questionable/Functions/ChatFunctions.cs
@@ -38,14 +38,18 @@ internal sealed class ChatFunctions
         Chat.ExecuteCommand(command);
     }
 
-    public void UseEmote(uint dataId, EEmote emote)
+    public bool UseEmote(uint dataId, EEmote emote)
     {
         IGameObject? gameObject = _gameFunctions.FindObjectByDataId(dataId);
         if (gameObject != null)
         {
             _targetManager.Target = gameObject;
             ExecuteCommand($"{_emoteCommands[emote]} motion");
+            return true;
         }
+
+        _logger.LogWarning("Could not find object with DataId {DataId} for emote {Emote}", dataId, emote);
+        return false;
     }
 
     public void UseEmote(EEmote emote) => ExecuteCommand($"{_emoteCommands[emote]} motion");

--- a/Questionable/Functions/GameFunctions.cs
+++ b/Questionable/Functions/GameFunctions.cs
@@ -269,8 +269,6 @@ internal sealed unsafe class GameFunctions
         if (localPlayer == null)
             return false;
 
-        BattleChara* battleChara = (BattleChara*)localPlayer.Address;
-        StatusManager* statusManager = battleChara->GetStatusManager();
         if (HasStatus(1151) ||
             HasStatus(1945)) // hoofing it
         {
@@ -511,13 +509,8 @@ internal sealed unsafe class GameFunctions
     {
         if (obj == null)
             return 0;
-        if (obj.GetType().GetProperty("BaseId") is { } baseIdProp)
-            return (uint)baseIdProp.GetValue(obj)!;
 
-        if (obj.GetType().GetProperty("DataId") is { } dataIdProp)
-            return (uint)dataIdProp.GetValue(obj)!;
-
-        return 0;
+        return obj.BaseId;
     }
 
     /// <summary>


### PR DESCRIPTION
Bug fixes:
•  Emote step silent failure — UseEmote now returns success/failure, and UseOnObjectExecutor retries the step if the NPC wasn't found instead of falsely completing
•  Black Wolf's Ultimatum teleport loop — Fixed "Never": true skip condition causing infinite Ul'dah teleport loop

Code fixes:
•  Dive.cs — Lazy-initialized the sig scan delegate to prevent class load crash on stale signatures
•  EquipRecommended.cs — Fixed IsAllRecommendeGearEquipped typo and added early exit on first unequipped item
•  UnequipItem.cs — Replaced unreachable throw after return with a TODO warning log
•  GameFunctions.cs — Removed unused statusManager variable, replaced reflection-based GetBaseID with direct obj.BaseId access