### PR TITLE
Presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,13 @@
 - Revert change to 406 On to the Drydocks -alydev
 - Add missing amaljaa mount def -alydev
+- BossMod presets — We now only  
+- -turn off our own presets ("Questionable" and "Questionable – Quest Battles"). - KAge
+- Removed an old, outdated BossMod helper — It was silently changing two BossMod settings and only changing one back,
+  leaving the other stuck. - Kage
+- Always switch off BossMod's old AI mode (/vbmai off) — Whenever we set one of our presets or end combat, we make sure
+  the deprecated "vbmai" auto-pilot is turned off. This prevents the old AI and the new preset from running at the same
+  time and stepping on each other. - Kage
+- YesAlready now gets turned back on properly — Before, if you closed Questionable while it had paused YesAlready,
+  YesAlready would stay paused forever. Now it gets re-enabled on shutdown. - Kage
+- Stopping mid-cutscene during a solo duty cleans up properly — If you hit Stop during a duty cutscene, BossMod's AI and
+  our preset both shut down now (previously the AI could be left running). - Kage

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup Condition="$(MSBuildProjectName) != 'GatheringPathRenderer'">
-        <Version>15.286.0.3</Version>
+        <Version>15.286.0.4</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Questionable/Controller/CombatModules/BossModModule.cs
+++ b/Questionable/Controller/CombatModules/BossModModule.cs
@@ -38,7 +38,7 @@ internal sealed class BossModModule
     {
         try
         {
-            bossModIpc.ClearPreset();
+            bossModIpc.Cleanup();
             return true;
         }
         catch (IpcError e)

--- a/Questionable/Controller/CombatModules/BossModModule.cs
+++ b/Questionable/Controller/CombatModules/BossModModule.cs
@@ -11,28 +11,25 @@ internal sealed class BossModModule
     BossModIpc bossModIpc,
     Configuration configuration) : ICombatModule, IDisposable
 {
-    private readonly BossModIpc _bossModIpc = bossModIpc;
-    private readonly Configuration _configuration = configuration;
-    private readonly ILogger<BossModModule> _logger = logger;
 
     public bool CanHandleFight(CombatController.CombatData combatData)
     {
-        if (_configuration.General.CombatModule != Configuration.ECombatModule.BossMod)
+        if (configuration.General.CombatModule != Configuration.ECombatModule.BossMod)
             return false;
 
-        return _bossModIpc.IsSupported();
+        return bossModIpc.IsSupported();
     }
 
     public bool Start(CombatController.CombatData combatData)
     {
         try
         {
-            _bossModIpc.SetPreset(BossModIpc.EPreset.Overworld);
+            bossModIpc.SetPreset(BossModIpc.EPreset.Overworld);
             return true;
         }
         catch (IpcError e)
         {
-            _logger.LogWarning(e, "Could not start combat");
+            logger.LogWarning(e, "Could not start combat");
             return false;
         }
     }
@@ -41,12 +38,12 @@ internal sealed class BossModModule
     {
         try
         {
-            _bossModIpc.ClearPreset();
+            bossModIpc.ClearPreset();
             return true;
         }
         catch (IpcError e)
         {
-            _logger.LogWarning(e, "Could not turn off combat");
+            logger.LogWarning(e, "Could not turn off combat");
             return false;
         }
     }

--- a/Questionable/Controller/CombatModules/ItemUseModule.cs
+++ b/Questionable/Controller/CombatModules/ItemUseModule.cs
@@ -15,9 +15,6 @@ namespace Questionable.Controller.CombatModules;
 
 internal sealed class ItemUseModule(IServiceProvider serviceProvider, ICondition condition, ILogger<ItemUseModule> logger) : ICombatModule
 {
-    private readonly ICondition _condition = condition;
-    private readonly ILogger<ItemUseModule> _logger = logger;
-    private readonly IServiceProvider _serviceProvider = serviceProvider;
     private CombatController.CombatData? _combatData;
     private DateTime _continueAt;
 
@@ -29,10 +26,10 @@ internal sealed class ItemUseModule(IServiceProvider serviceProvider, ICondition
         if (combatData.CombatItemUse == null)
             return false;
 
-        _delegate = _serviceProvider.GetRequiredService<IEnumerable<ICombatModule>>()
+        _delegate = serviceProvider.GetRequiredService<IEnumerable<ICombatModule>>()
             .Where(x => x is not ItemUseModule)
             .FirstOrDefault(x => x.CanHandleFight(combatData));
-        _logger.LogInformation("ItemUse delegate: {Delegate}", _delegate?.GetType().Name);
+        logger.LogInformation("ItemUse delegate: {Delegate}", _delegate?.GetType().Name);
         return _delegate != null;
     }
 
@@ -100,7 +97,7 @@ internal sealed class ItemUseModule(IServiceProvider serviceProvider, ICondition
                     _delegate.Stop();
                     unsafe
                     {
-                        _logger.LogInformation("Using item {ItemId}", _combatData.CombatItemUse.ItemId);
+                        logger.LogInformation("Using item {ItemId}", _combatData.CombatItemUse.ItemId);
                         AgentInventoryContext.Instance()->UseItem(_combatData.CombatItemUse.ItemId);
                     }
 
@@ -109,7 +106,7 @@ internal sealed class ItemUseModule(IServiceProvider serviceProvider, ICondition
                 else
                     _delegate.Update(nextTarget);
             }
-            else if (_condition[ConditionFlag.Casting])
+            else if (condition[ConditionFlag.Casting])
             {
                 // do nothing
                 DateTime alternativeContinueAt = DateTime.Now.AddSeconds(0.5);

--- a/Questionable/Controller/CombatModules/Mount128Module.cs
+++ b/Questionable/Controller/CombatModules/Mount128Module.cs
@@ -11,9 +11,7 @@ internal sealed class Mount128Module(GameFunctions gameFunctions) : ICombatModul
     public const ushort MountId = 128;
     private readonly EAction[] _actions = [EAction.MagitekThunder, EAction.MagitekPulse];
 
-    private readonly GameFunctions _gameFunctions = gameFunctions;
-
-    public bool CanHandleFight(CombatController.CombatData combatData) => _gameFunctions.GetMountId() == MountId;
+    public bool CanHandleFight(CombatController.CombatData combatData) => gameFunctions.GetMountId() == MountId;
 
     public bool Start(CombatController.CombatData combatData) => true;
 
@@ -23,7 +21,7 @@ internal sealed class Mount128Module(GameFunctions gameFunctions) : ICombatModul
     {
         foreach (EAction action in _actions)
         {
-            if (_gameFunctions.UseAction(gameObject, action, false))
+            if (gameFunctions.UseAction(gameObject, action, false))
                 return;
         }
     }

--- a/Questionable/Controller/CombatModules/Mount147Module.cs
+++ b/Questionable/Controller/CombatModules/Mount147Module.cs
@@ -11,9 +11,7 @@ internal sealed class Mount147Module(GameFunctions gameFunctions) : ICombatModul
     public const ushort MountId = 147;
     private readonly EAction[] _actions = [EAction.Trample];
 
-    private readonly GameFunctions _gameFunctions = gameFunctions;
-
-    public bool CanHandleFight(CombatController.CombatData combatData) => _gameFunctions.GetMountId() == MountId;
+    public bool CanHandleFight(CombatController.CombatData combatData) => gameFunctions.GetMountId() == MountId;
 
     public bool Start(CombatController.CombatData combatData) => true;
 
@@ -23,7 +21,7 @@ internal sealed class Mount147Module(GameFunctions gameFunctions) : ICombatModul
     {
         foreach (EAction action in _actions)
         {
-            if (_gameFunctions.UseAction(gameObject, action, false))
+            if (gameFunctions.UseAction(gameObject, action, false))
                 return;
         }
     }

--- a/Questionable/Controller/CombatModules/RotationSolverRebornModule.cs
+++ b/Questionable/Controller/CombatModules/RotationSolverRebornModule.cs
@@ -15,13 +15,11 @@ internal sealed class RotationSolverRebornModule
 {
     private readonly ICallGateSubscriber<StateCommandType, object> _changeOperationMode =
         pluginInterface.GetIpcSubscriber<StateCommandType, object>("RotationSolverReborn.ChangeOperatingMode");
-    private readonly Configuration _configuration = configuration;
-    private readonly ILogger<RotationSolverRebornModule> _logger = logger;
     private readonly ICallGateSubscriber<string, object> _test = pluginInterface.GetIpcSubscriber<string, object>("RotationSolverReborn.Test");
 
     public bool CanHandleFight(CombatController.CombatData combatData)
     {
-        if (_configuration.General.CombatModule != Configuration.ECombatModule.RotationSolverReborn)
+        if (configuration.General.CombatModule != Configuration.ECombatModule.RotationSolverReborn)
             return false;
 
         try
@@ -44,7 +42,7 @@ internal sealed class RotationSolverRebornModule
         }
         catch (IpcError e)
         {
-            _logger.LogWarning(e, "Could not start combat");
+            logger.LogWarning(e, "Could not start combat");
             return false;
         }
     }
@@ -61,7 +59,7 @@ internal sealed class RotationSolverRebornModule
         }
         catch (IpcError e)
         {
-            _logger.LogWarning(e, "Could not turn off combat");
+            logger.LogWarning(e, "Could not turn off combat");
             return false;
         }
     }

--- a/Questionable/Controller/Steps/Interactions/SinglePlayerDuty.cs
+++ b/Questionable/Controller/Steps/Interactions/SinglePlayerDuty.cs
@@ -182,7 +182,7 @@ internal static class SinglePlayerDuty
     {
         protected override bool Start()
         {
-            bossModIpc.EnableAi(Task.Passive);
+            bossModIpc.SetPreset(Task.Passive ? BossModIpc.EPreset.Overworld : BossModIpc.EPreset.QuestBattle);
             return true;
         }
 
@@ -237,7 +237,7 @@ internal static class SinglePlayerDuty
                 : ETaskResult.StillRunning;
         }
 
-        public void StopNow() => bossModIpc.DisableAi();
+        public void StopNow() => bossModIpc.Cleanup();
 
         public override bool ShouldInterruptOnDamage() => false;
         protected override bool Start() => true;
@@ -254,7 +254,7 @@ internal static class SinglePlayerDuty
     {
         protected override bool Start()
         {
-            bossModIpc.DisableAi();
+            bossModIpc.ClearPreset();
             return true;
         }
 

--- a/Questionable/External/ArtisanIpc.cs
+++ b/Questionable/External/ArtisanIpc.cs
@@ -13,20 +13,19 @@ internal sealed class ArtisanIpc(IDalamudPluginInterface pluginInterface, ILogge
     private readonly ICallGateSubscriber<bool> _getEnduranceStatus = pluginInterface.GetIpcSubscriber<bool>("Artisan.GetEnduranceStatus");
     private readonly ICallGateSubscriber<bool> _isListRunning = pluginInterface.GetIpcSubscriber<bool>("Artisan.IsListRunning");
     private readonly ICallGateSubscriber<int, object> _startListById = pluginInterface.GetIpcSubscriber<int, object>("Artisan.StartListById");
-    private readonly ILogger<ArtisanIpc> _logger = logger;
 
     public bool CraftItem(ushort recipeId, int quantity)
     {
         try
         {
-            _logger.LogInformation("Attempting to craft {Quantity} items with recipe {RecipeId} with Artisan", quantity,
+            logger.LogInformation("Attempting to craft {Quantity} items with recipe {RecipeId} with Artisan", quantity,
                 recipeId);
             _craftItem.InvokeAction(recipeId, quantity);
             return true;
         }
         catch (IpcError e)
         {
-            _logger.LogError(e, "Unable to craft items");
+            logger.LogError(e, "Unable to craft items");
             return false;
         }
     }
@@ -35,26 +34,23 @@ internal sealed class ArtisanIpc(IDalamudPluginInterface pluginInterface, ILogge
     {
         try
         {
-            _logger.LogInformation("Attempting to craft list {ListId} with Artisan", listId);
+            logger.LogInformation("Attempting to craft list {ListId} with Artisan", listId);
             _startListById.InvokeAction(listId);
             return true;
         }
         catch (IpcError e)
         {
-            _logger.LogError(e, "Unable to craft items");
+            logger.LogError(e, "Unable to craft items");
             return false;
         }
         catch (Exception e)
         {
-            _logger.LogInformation(e, "CraftList failed");
+            logger.LogInformation(e, "CraftList failed");
             return false;
         }
     }
 
-    public bool CraftList(ElementId questId)
-    {
-        return CraftList(questId.Value.ToInt() + 65536);
-    }
+    public bool CraftList(ElementId questId) => CraftList(questId.Value.ToInt() + 65536);
 
     public bool IsCrafting()
     {
@@ -64,7 +60,7 @@ internal sealed class ArtisanIpc(IDalamudPluginInterface pluginInterface, ILogge
         }
         catch (IpcError e)
         {
-            _logger.LogError(e, "Unable to check for Artisanstatus");
+            logger.LogError(e, "Unable to check for Artisanstatus");
             return false;
         }
     }

--- a/Questionable/External/AutoDutyIpc.cs
+++ b/Questionable/External/AutoDutyIpc.cs
@@ -21,28 +21,25 @@ internal sealed class AutoDutyIpc
         UnsyncRegular = 2
     }
 
-    private readonly Configuration _configuration = configuration;
     private readonly ICallGateSubscriber<uint, bool> _contentHasPath = pluginInterface.GetIpcSubscriber<uint, bool>("AutoDuty.ContentHasPath");
     private readonly ICallGateSubscriber<bool> _isStopped = pluginInterface.GetIpcSubscriber<bool>("AutoDuty.IsStopped");
-    private readonly ILogger<AutoDutyIpc> _logger = logger;
     private readonly ICallGateSubscriber<uint, int, bool, object> _run = pluginInterface.GetIpcSubscriber<uint, int, bool, object>("AutoDuty.Run");
     private readonly ICallGateSubscriber<string, string, object> _setConfig = pluginInterface.GetIpcSubscriber<string, string, object>("AutoDuty.SetConfig");
     private readonly ICallGateSubscriber<object> _stop = pluginInterface.GetIpcSubscriber<object>("AutoDuty.Stop");
-    private readonly TerritoryData _territoryData = territoryData;
 
     public bool IsConfiguredToRunContent(DutyOptions? dutyOptions)
     {
         if (dutyOptions == null || dutyOptions.ContentFinderConditionId == 0)
             return false;
 
-        if (!_configuration.Duties.RunInstancedContentWithAutoDuty)
+        if (!configuration.Duties.RunInstancedContentWithAutoDuty)
             return false;
 
-        if (_configuration.Duties.BlacklistedDutyCfcIds.Contains(dutyOptions.ContentFinderConditionId))
+        if (configuration.Duties.BlacklistedDutyCfcIds.Contains(dutyOptions.ContentFinderConditionId))
             return false;
 
-        if (_configuration.Duties.WhitelistedDutyCfcIds.Contains(dutyOptions.ContentFinderConditionId) &&
-            _territoryData.TryGetContentFinderCondition(dutyOptions.ContentFinderConditionId, out TerritoryData.ContentFinderConditionData? _))
+        if (configuration.Duties.WhitelistedDutyCfcIds.Contains(dutyOptions.ContentFinderConditionId) &&
+            territoryData.TryGetContentFinderCondition(dutyOptions.ContentFinderConditionId, out TerritoryData.ContentFinderConditionData? _))
         {
             return true;
         }
@@ -52,16 +49,16 @@ internal sealed class AutoDutyIpc
 
     public bool HasPath(uint cfcId)
     {
-        if (!_territoryData.TryGetContentFinderCondition(cfcId, out TerritoryData.ContentFinderConditionData? cfcData))
+        if (!territoryData.TryGetContentFinderCondition(cfcId, out TerritoryData.ContentFinderConditionData? cfcData))
             return false;
 
         return IpcInvoke.SafeFunc(() => _contentHasPath.InvokeFunc(cfcData.TerritoryId), false,
-            _logger, "Unable to query AutoDuty for path in territory {TerritoryType}", cfcData.TerritoryId);
+            logger, "Unable to query AutoDuty for path in territory {TerritoryType}", cfcData.TerritoryId);
     }
 
     public void StartInstance(uint cfcId, DutyMode dutyMode)
     {
-        if (!_territoryData.TryGetContentFinderCondition(cfcId, out TerritoryData.ContentFinderConditionData? cfcData))
+        if (!territoryData.TryGetContentFinderCondition(cfcId, out TerritoryData.ContentFinderConditionData? cfcData))
             throw new TaskException($"Unknown ContentFinderConditionId {cfcId}");
 
         try
@@ -74,7 +71,7 @@ internal sealed class AutoDutyIpc
                 var _ => throw new ArgumentOutOfRangeException(nameof(dutyMode), dutyMode, null)
             });
 
-            _run.InvokeAction(cfcData.TerritoryId, 1, !_configuration.Advanced.DisableAutoDutyBareMode);
+            _run.InvokeAction(cfcData.TerritoryId, 1, !configuration.Advanced.DisableAutoDutyBareMode);
         }
         catch (IpcError e)
         {
@@ -88,7 +85,7 @@ internal sealed class AutoDutyIpc
     {
         try
         {
-            _logger.LogInformation("Calling AutoDuty.Stop");
+            logger.LogInformation("Calling AutoDuty.Stop");
             _stop.InvokeAction();
         }
         catch (IpcError e)

--- a/Questionable/External/AutomatonIpc.cs
+++ b/Questionable/External/AutomatonIpc.cs
@@ -8,7 +8,6 @@ internal sealed class AutomatonIpc
 {
     private readonly ICallGateSubscriber<string, bool> _isTweakEnabled;
     private readonly ILogger<AutomatonIpc> _logger;
-    private bool _loggedIpcError;
 
     public AutomatonIpc(IDalamudPluginInterface pluginInterface, ILogger<AutomatonIpc> logger)
     {
@@ -27,9 +26,9 @@ internal sealed class AutomatonIpc
             }
             catch (IpcError e)
             {
-                if (!_loggedIpcError)
+                if (!field)
                 {
-                    _loggedIpcError = true;
+                    field = true;
                     _logger.LogWarning(e, "Could not query automaton for tweak status, probably not installed");
                 }
 

--- a/Questionable/External/BossModIpc.cs
+++ b/Questionable/External/BossModIpc.cs
@@ -5,7 +5,6 @@ using System.IO;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Ipc;
 using Dalamud.Plugin.Services;
-using ECommons.DalamudServices;
 using Questionable.Data;
 using Questionable.Model.Questing;
 namespace Questionable.External;
@@ -14,8 +13,8 @@ internal sealed class BossModIpc
 (
     IDalamudPluginInterface pluginInterface,
     Configuration configuration,
-    ICommandManager commandManager,
-    TerritoryData territoryData)
+    TerritoryData territoryData,
+    ICommandManager commandManager)
 {
     public enum EPreset
     {
@@ -33,13 +32,11 @@ internal sealed class BossModIpc
         { EPreset.NormalMovement, new("Questionable - Normal Movement", "NormalMovement") }
     }.AsReadOnly();
     private readonly ICallGateSubscriber<bool> _clearPreset = pluginInterface.GetIpcSubscriber<bool>($"{PluginName}.Presets.ClearActive");
-    private readonly ICommandManager _commandManager = commandManager;
 
-    private readonly Configuration _configuration = configuration;
     private readonly ICallGateSubscriber<string, bool, bool> _createPreset = pluginInterface.GetIpcSubscriber<string, bool, bool>($"{PluginName}.Presets.Create");
+    private readonly ICallGateSubscriber<string?> _getActivePreset = pluginInterface.GetIpcSubscriber<string?>($"{PluginName}.Presets.GetActive");
     private readonly ICallGateSubscriber<string, string?> _getPreset = pluginInterface.GetIpcSubscriber<string, string?>($"{PluginName}.Presets.Get");
     private readonly ICallGateSubscriber<string, bool> _setPreset = pluginInterface.GetIpcSubscriber<string, bool>($"{PluginName}.Presets.SetActive");
-    private readonly TerritoryData _territoryData = territoryData;
 
     public bool IsSupported() => IpcInvoke.SafeFunc(() => _getPreset.HasFunction, false);
 
@@ -49,25 +46,29 @@ internal sealed class BossModIpc
         if (_getPreset.InvokeFunc(definition.Name) == null)
             _createPreset.InvokeFunc(definition.Content, true);
 
+        commandManager.ProcessCommand("/vbmai off");
         _setPreset.InvokeFunc(definition.Name);
     }
 
-    public void ClearPreset() => _clearPreset.InvokeFunc();
-
-    // TODO this should use your actual rotation plugin, not always vbm
-    public void EnableAi(bool passive)
+    public void ClearPreset()
     {
-        //_commandManager.ProcessCommand("/vbmai on");
-        _commandManager.ProcessCommand("/vbm cfg ZoneModuleConfig EnableQuestBattles true");
-        _commandManager.ProcessCommand("/vbm cfg Autorotation ClearPresetOnCombatEnd false");
-        Svc.Log.Debug($"Enabling preset {(passive ? "Overworld" : "QuestBattle")}");
-        SetPreset(passive ? EPreset.Overworld : EPreset.QuestBattle);
+        string? activePreset = _getActivePreset.InvokeFunc();
+        if (activePreset == null)
+            return;
+
+        foreach (PresetDefinition definition in PresetDefinitions.Values)
+        {
+            if (definition.Name.Equals(activePreset, StringComparison.Ordinal))
+            {
+                _clearPreset.InvokeFunc();
+                return;
+            }
+        }
     }
 
-    public void DisableAi()
+    public void Cleanup()
     {
-        _commandManager.ProcessCommand("/vbmai off");
-        _commandManager.ProcessCommand("/vbm cfg ZoneModuleConfig EnableQuestBattles false");
+        commandManager.ProcessCommand("/vbmai off");
         ClearPreset();
     }
 
@@ -76,17 +77,17 @@ internal sealed class BossModIpc
         if (!IsSupported())
             return false;
 
-        if (!_configuration.SinglePlayerDuties.RunSoloInstancesWithBossMod)
+        if (!configuration.SinglePlayerDuties.RunSoloInstancesWithBossMod)
             return false;
 
         dutyOptions ??= new();
-        if (!_territoryData.TryGetContentFinderConditionForSoloInstance(questId, dutyOptions.Index, out TerritoryData.ContentFinderConditionData? cfcData))
+        if (!territoryData.TryGetContentFinderConditionForSoloInstance(questId, dutyOptions.Index, out TerritoryData.ContentFinderConditionData? cfcData))
             return false;
 
-        if (_configuration.SinglePlayerDuties.BlacklistedSinglePlayerDutyCfcIds.Contains(cfcData.ContentFinderConditionId))
+        if (configuration.SinglePlayerDuties.BlacklistedSinglePlayerDutyCfcIds.Contains(cfcData.ContentFinderConditionId))
             return false;
 
-        if (_configuration.SinglePlayerDuties.WhitelistedSinglePlayerDutyCfcIds.Contains(cfcData.ContentFinderConditionId))
+        if (configuration.SinglePlayerDuties.WhitelistedSinglePlayerDutyCfcIds.Contains(cfcData.ContentFinderConditionId))
             return true;
 
         return dutyOptions.Enabled;

--- a/Questionable/External/IPCUtils.cs
+++ b/Questionable/External/IPCUtils.cs
@@ -2,8 +2,8 @@
 using ECommons.DalamudServices;
 using ECommons.EzIpcManager;
 using ECommons.Reflection;
-
 namespace Questionable.External;
+
 internal interface IPCUtils
 {
     internal sealed class IPCSubscriber_Common

--- a/Questionable/External/LifestreamIpc.cs
+++ b/Questionable/External/LifestreamIpc.cs
@@ -17,19 +17,18 @@ internal sealed class LifestreamIpc(IDalamudPluginInterface pluginInterface, ILo
         pluginInterface.GetIpcSubscriber<bool>("Lifestream.AethernetTeleportToFirmament");
     private readonly ICallGateSubscriber<bool> _isBusy =
         pluginInterface.GetIpcSubscriber<bool>("Lifestream.IsBusy");
-    private readonly ILogger<LifestreamIpc> _logger = logger;
 
     public bool IsBusy => IpcInvoke.SafeFunc(() => _isBusy.InvokeFunc(), false);
 
     public bool Teleport(string destination)
     {
-        _logger.LogInformation("Teleporting to vague string '{Destination}'", destination);
+        logger.LogInformation("Teleporting to vague string '{Destination}'", destination);
         return _aethernetTeleport.InvokeFunc(destination);
     }
 
     public bool Teleport(EAetheryteLocation aetheryteLocation)
     {
-        _logger.LogInformation("Teleporting to '{Name}'", aetheryteLocation);
+        logger.LogInformation("Teleporting to '{Name}'", aetheryteLocation);
         return aetheryteLocation switch
         {
             EAetheryteLocation.IshgardFirmament => _aethernetTeleportToFirmament.InvokeFunc(),

--- a/Questionable/External/NavmeshIpc.cs
+++ b/Questionable/External/NavmeshIpc.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Ipc;
 using Dalamud.Plugin.Ipc.Exceptions;
-using ECommons.DalamudServices;
 using Microsoft.Extensions.Logging;
 namespace Questionable.External;
 
@@ -15,7 +14,6 @@ internal sealed class NavmeshIpc(IDalamudPluginInterface pluginInterface, ILogge
 {
     private readonly ICallGateSubscriber<float> _buildProgress = pluginInterface.GetIpcSubscriber<float>("vnavmesh.Nav.BuildProgress");
     private readonly ICallGateSubscriber<bool> _isNavReady = pluginInterface.GetIpcSubscriber<bool>("vnavmesh.Nav.IsReady");
-    private readonly ILogger<NavmeshIpc> _logger = logger;
     private readonly ICallGateSubscriber<Vector3, Vector3, bool, CancellationToken, Task<List<Vector3>>> _navPathfind =
         pluginInterface.GetIpcSubscriber<Vector3, Vector3, bool, CancellationToken, Task<List<Vector3>>>(
             "vnavmesh.Nav.PathfindCancelable");
@@ -51,7 +49,7 @@ internal sealed class NavmeshIpc(IDalamudPluginInterface pluginInterface, ILogge
         IpcInvoke.SafeFunc(() => _simpleMovePathfindInProgress.InvokeFunc(), false);
 
     public void Stop() =>
-        IpcInvoke.SafeAction(() => _pathStop.InvokeAction(), _logger,
+        IpcInvoke.SafeAction(() => _pathStop.InvokeAction(), logger,
             "Could not stop navigating via navmesh {Version}", Version);
 
     public Task<List<Vector3>> Pathfind(Vector3 localPlayerPosition, Vector3 targetPosition, bool fly,
@@ -64,7 +62,7 @@ internal sealed class NavmeshIpc(IDalamudPluginInterface pluginInterface, ILogge
         }
         catch (IpcNotReadyError e)
         {
-            _logger.LogWarning(e, "Could not pathfind via navmesh {Version}", Version);
+            logger.LogWarning(e, "Could not pathfind via navmesh {Version}", Version);
             return Task.FromException<List<Vector3>>(e);
         }
     }
@@ -72,19 +70,19 @@ internal sealed class NavmeshIpc(IDalamudPluginInterface pluginInterface, ILogge
     public void MoveTo(List<Vector3> position, bool fly)
     {
         Stop();
-        IpcInvoke.SafeAction(() => _pathMoveTo.InvokeAction(position, fly), _logger,
+        IpcInvoke.SafeAction(() => _pathMoveTo.InvokeAction(position, fly), logger,
             "Could not move via navmesh {Version}", Version);
     }
 
     public Vector3? GetPointOnFloor(Vector3 position, bool unlandable) =>
-        IpcInvoke.SafeFunc(() => _queryPointOnFloor.InvokeFunc(position, unlandable, 0.2f), (Vector3?)null);
+        IpcInvoke.SafeFunc(() => _queryPointOnFloor.InvokeFunc(position, unlandable, 0.2f), null);
 
     public bool SimplePathfindAndMoveTo(Vector3 destination, bool fly)
     {
         if (!IsReady)
             return false;
         return IpcInvoke.SafeFunc(() => _simpleMovePathfindAndMoveTo.InvokeFunc(destination, fly), false,
-            _logger, "Could not SimplePathfindAndMoveTo {Version}", Version);
+            logger, "Could not SimplePathfindAndMoveTo {Version}", Version);
     }
 
     public bool SimplePathfindAndMoveCloseTo(Vector3 destination, bool fly, float range)
@@ -92,7 +90,7 @@ internal sealed class NavmeshIpc(IDalamudPluginInterface pluginInterface, ILogge
         if (!IsReady)
             return false;
         return IpcInvoke.SafeFunc(() => _simpleMovePathfindAndMoveCloseTo.InvokeFunc(destination, fly, range), false,
-            _logger, "Could not SimplePathfindAndMoveCloseTo {Version}", Version);
+            logger, "Could not SimplePathfindAndMoveCloseTo {Version}", Version);
     }
 
     public List<Vector3> GetWaypoints()

--- a/Questionable/External/StylistIpc.cs
+++ b/Questionable/External/StylistIpc.cs
@@ -21,7 +21,7 @@ internal sealed class StylistIpc
 
     public static bool IsInstalled => IPCSubscriber_Common.IsInstalled("Stylist");
 
-    public bool IsBusy => IsInstalled ? _isBusy.InvokeFunc() : true;
+    public bool IsBusy => !IsInstalled || _isBusy.InvokeFunc();
 
     public void UpdateGearset()
     {

--- a/Questionable/External/YesAlreadyIpc.cs
+++ b/Questionable/External/YesAlreadyIpc.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using Dalamud.Plugin.Services;
-using ECommons.DalamudServices;
 using ECommons.EzIpcManager;
-using ECommons.Reflection;
 using Microsoft.Extensions.Logging;
 using Questionable.Controller;
 using Questionable.Data;
@@ -44,6 +42,12 @@ internal sealed class YesAlreadyIpc : IDisposable
     public void Dispose()
     {
         _framework.Update -= OnUpdate;
+        if (IPCSubscriber_Common.IsInstalled("YesAlready") && _wasEnabled && !IsPluginEnabled())
+        {
+            _logger.LogDebug("Re-enabling YesAlready on dispose");
+            SetPluginEnabled(true);
+        }
+
         IPCSubscriber_Common.DisposeAll(_disposalTokens);
     }
 


### PR DESCRIPTION
- BossMod presets — We now only turn off our own presets ("Questionable" and "Questionable – Quest Battles"). Before, we could accidentally wipe out a preset you'd manually picked.
- Removed an old, outdated BossMod helper — It was silently changing two BossMod settings and only changing one back, leaving the other stuck. That whole helper is gone now.
- Always switch off BossMod's old AI mode (/vbmai off) — Whenever we set one of our presets or end combat, we make sure the deprecated "vbmai" auto-pilot is turned off. This prevents the old AI and the new preset from running at the same time and stepping on each other.
- YesAlready now gets turned back on properly — Before, if you closed Questionable while it had paused YesAlready, YesAlready would stay paused forever. Now it gets re-enabled on shutdown.
- Stopping mid-cutscene during a solo duty cleans up properly — If you hit Stop during a duty cutscene, BossMod's AI and our preset both shut down now (previously the AI could be left running).