### PR TITLE
Allied society

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,4 @@
-- Fix quests not being detected - Kage
+- Allied Society batching — Accept, do objectives, and turn in tribe dailies in batch (priority list controls accept; Ixal
+excluded). If you manually take all available dailies today, objectives/turn-in batch without priority. - Kage 
+- Mount dailies — Dismount tribe quest mount after objectives; fly back on your normal mount. - Kage
+- Fixes — Active quest detection, batch accept/turn-in reliability, dialogue selection, Yok Huy accept step. - Kage

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup Condition="$(MSBuildProjectName) != 'GatheringPathRenderer'">
-        <Version>15.286.0.11</Version>
+        <Version>15.286.0.12</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Questionable/Controller/GameUi/DialogueChoiceHandler.cs
+++ b/Questionable/Controller/GameUi/DialogueChoiceHandler.cs
@@ -192,8 +192,19 @@ internal sealed class DialogueChoiceHandler : IDisposable
         // this is 'Daily Quests' for tribal quests, but not set for normal selections
         string? title = AtkValueAdapter.ReadString(addonSelectIconString->AtkValues[0]);
 
+        if (_questController.TryGetActiveInteractQuest(out Quest? interactQuest, out _) &&
+            (actualPrompt == null || title != null))
+        {
+            _logger.LogInformation("Checking if active interact quest {Name} is on the list",
+                interactQuest.Info.Name);
+            if (CheckQuestSelection(addonSelectIconString, interactQuest, answers))
+                return;
+        }
+
+        bool batchInteractInProgress = _questController.TryGetActiveInteractQuest(out _, out _);
+
         QuestController.QuestProgress? currentQuest = _questController.StartedQuest;
-        if (currentQuest != null && (actualPrompt == null || title != null))
+        if (!batchInteractInProgress && currentQuest != null && (actualPrompt == null || title != null))
         {
             _logger.LogInformation("Checking if current quest {Name} is on the list", currentQuest.Quest.Info.Name);
             if (CheckQuestSelection(addonSelectIconString, currentQuest.Quest, answers))
@@ -211,7 +222,7 @@ internal sealed class DialogueChoiceHandler : IDisposable
         }
 
         QuestController.QuestProgress? nextQuest = _questController.NextQuest;
-        if (nextQuest != null && (actualPrompt == null || title != null))
+        if (!batchInteractInProgress && nextQuest != null && (actualPrompt == null || title != null))
         {
             _logger.LogInformation("Checking if next quest {Name} is on the list", nextQuest.Quest.Info.Name);
             if (CheckQuestSelection(addonSelectIconString, nextQuest.Quest, answers))
@@ -245,10 +256,17 @@ internal sealed class DialogueChoiceHandler : IDisposable
     {
         List<DialogueChoiceInfo> dialogueChoices = [];
 
+        if (_questController.TryGetActiveInteractQuest(out Quest? interactQuest,
+                out QuestStep? interactStep))
+        {
+            dialogueChoices.AddRange(interactStep.DialogueChoices
+                .Select(x => new DialogueChoiceInfo(interactQuest, x)));
+        }
+
         QuestController.QuestProgress? currentQuest = _questController.SimulatedQuest ??
                                                       _questController.GatheringQuest ??
                                                       _questController.StartedQuest;
-        if (currentQuest != null)
+        if (currentQuest != null && interactQuest == null)
         {
             Quest quest = currentQuest.Quest;
             bool isTaxiStandUnlock = false;

--- a/Questionable/Controller/GameUi/YesNoChoiceHandler.cs
+++ b/Questionable/Controller/GameUi/YesNoChoiceHandler.cs
@@ -164,6 +164,12 @@ internal sealed class YesNoChoiceHandler : IDisposable
             return;
         }
 
+        if (_questController.TryGetActiveInteractQuest(out Quest? interactQuest,
+                out QuestStep? interactStep) &&
+            HandleDefaultYesNo(addonSelectYesno, interactQuest, interactStep,
+                interactStep.DialogueChoices, actualPrompt))
+            return;
+
         QuestController.QuestProgress? currentQuest = _questController.StartedQuest;
         if (currentQuest != null && CheckQuestYesNo(addonSelectYesno, currentQuest, actualPrompt, checkAllSteps))
             return;

--- a/Questionable/Controller/QuestController.cs
+++ b/Questionable/Controller/QuestController.cs
@@ -565,15 +565,14 @@ internal sealed class QuestController : MiniTaskController<QuestController>
             else
             {
                 (ElementId? currentQuestId, currentSequence, MainScenarioQuestState msqState) = _questFunctions.GetCurrentQuest(allowNewMsq: AutomationType != EAutomationType.SingleQuestB);
-                (ElementId, byte)? priorityQuestOption =
-                    _priorityManager.Quests
-                        .Where(x => _questFunctions.IsReadyToAcceptQuest(x.Id) || _questFunctions.IsQuestAccepted(x.Id))
-                        .Select(x => (x.Id, _questFunctions.GetQuestProgressInfo(x.Id)?.Sequence ?? 0))
-                        .FirstOrDefault();
-                if (priorityQuestOption is { Item1: not null } priorityQuest)
+                if (!HasPendingAlliedSocietyBatchAcceptTasks())
                 {
-                    currentQuestId = priorityQuest.Item1;
-                    currentSequence = priorityQuest.Item2;
+                    (ElementId QuestId, byte Sequence)? priorityQuest = _questFunctions.GetPriorityQuestToRun(_priorityManager.Quests);
+                    if (priorityQuest != null)
+                    {
+                        currentQuestId = priorityQuest.Value.QuestId;
+                        currentSequence = priorityQuest.Value.Sequence;
+                    }
                 }
 
                 if (currentQuestId == null || currentQuestId.Value == 0)
@@ -638,6 +637,9 @@ internal sealed class QuestController : MiniTaskController<QuestController>
 #endif
 
                         if (AutomationType == EAutomationType.Manual)
+                            return;
+
+                        if (HasPendingAlliedSocietyBatchAcceptTasks())
                             return;
 
                         unsafe
@@ -707,6 +709,15 @@ internal sealed class QuestController : MiniTaskController<QuestController>
 
             if (questToRun.Sequence != currentSequence)
             {
+                if (HasPendingAlliedSocietyBatchTasks())
+                    return;
+
+                if (currentSequence == 255 &&
+                    _questFunctions.ShouldDeferAlliedSocietyTurnIn(questToRun.Quest, _priorityManager.Quests))
+                {
+                    return;
+                }
+
                 _highlightObject.SetHighlight([]);
                 questToRun.SetSequence(currentSequence);
                 CheckNextTasks(
@@ -923,6 +934,41 @@ internal sealed class QuestController : MiniTaskController<QuestController>
         }
         else
             Stop(label);
+    }
+
+    /// <summary>
+    ///     True while sibling allied-society accept tasks are still queued. Prevents advancing to
+    ///     sequence 1 after the first daily is accepted, which would otherwise clear the queue.
+    /// </summary>
+    private bool HasPendingAlliedSocietyBatchAcceptTasks() => HasPendingAlliedSocietyBatchInteractTasks(isComplete: false);
+
+    /// <summary>
+    ///     True while sibling allied-society turn-in tasks are still queued.
+    /// </summary>
+    private bool HasPendingAlliedSocietyBatchCompleteTasks() => HasPendingAlliedSocietyBatchInteractTasks(isComplete: true);
+
+    private bool HasPendingAlliedSocietyBatchTasks() =>
+        HasPendingAlliedSocietyBatchAcceptTasks() || HasPendingAlliedSocietyBatchCompleteTasks();
+
+    private bool HasPendingAlliedSocietyBatchInteractTasks(bool isComplete)
+    {
+        if (CurrentQuest == null)
+            return false;
+
+        ElementId currentQuestId = CurrentQuest.Quest.Id;
+        EInteractionType interactionType = isComplete ? EInteractionType.CompleteQuest : EInteractionType.AcceptQuest;
+        IEnumerable<ITask> pending = _taskQueue.CurrentTaskExecutor?.CurrentTask is { } current
+            ? [current, .._taskQueue.RemainingTasks]
+            : _taskQueue.RemainingTasks;
+
+        return pending.Any(task => task switch
+        {
+            Interact.Task { InteractionType: var type, Quest: { } quest } when type == interactionType =>
+                quest.Id != currentQuestId,
+            WaitAtEnd.WaitQuestAccepted accept when !isComplete => accept.ElementId != currentQuestId,
+            WaitAtEnd.WaitQuestCompleted complete when isComplete => complete.ElementId != currentQuestId,
+            _ => false
+        });
     }
 
     /// <summary>
@@ -1197,6 +1243,39 @@ internal sealed class QuestController : MiniTaskController<QuestController>
             return false;
         }
     }
+
+    /// <summary>
+    ///     Returns the quest being accepted or turned in when the current task is an AcceptQuest or
+    ///     CompleteQuest interact, including allied-society batch tasks for quests other than
+    ///     <see cref="StartedQuest"/>.
+    /// </summary>
+    public bool TryGetActiveInteractQuest([NotNullWhen(true)] out Quest? quest, [NotNullWhen(true)] out QuestStep? step)
+    {
+        if (_taskQueue.CurrentTaskExecutor?.CurrentTask is Interact.Task
+            {
+                InteractionType: EInteractionType.AcceptQuest or EInteractionType.CompleteQuest,
+                Quest: { } activeQuest
+            } task)
+        {
+            byte sequence = task.InteractionType == EInteractionType.AcceptQuest ? (byte)0 : (byte)255;
+            step = activeQuest.FindSequence(sequence)?.Steps
+                .FirstOrDefault(s => s.InteractionType == task.InteractionType);
+            if (step != null)
+            {
+                quest = activeQuest;
+                return true;
+            }
+        }
+
+        quest = null;
+        step = null;
+        return false;
+    }
+
+    public bool TryGetActiveInteractAcceptQuest([NotNullWhen(true)] out Quest? quest,
+        [NotNullWhen(true)] out QuestStep? acceptStep) =>
+        TryGetActiveInteractQuest(out quest, out acceptStep) &&
+        _taskQueue.CurrentTaskExecutor?.CurrentTask is Interact.Task { InteractionType: EInteractionType.AcceptQuest };
 
     public void Skip(ElementId elementId, byte currentQuestSequence)
     {

--- a/Questionable/Controller/QuestPriorityManager.cs
+++ b/Questionable/Controller/QuestPriorityManager.cs
@@ -24,7 +24,9 @@ internal sealed class QuestPriorityManager(
     public int Count => _quests.Count;
     public bool IsEmpty => _quests.Count == 0;
 
-    public bool Contains(Quest quest) => _quests.Contains(quest);
+    public bool Contains(Quest quest) => _quests.Any(q => q.Id == quest.Id);
+
+    public bool Contains(ElementId elementId) => _quests.Any(q => q.Id == elementId);
 
     public bool Add(Quest quest)
     {

--- a/Questionable/Controller/Steps/QuestCleanUp.cs
+++ b/Questionable/Controller/Steps/QuestCleanUp.cs
@@ -1,76 +1,48 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using Microsoft.Extensions.Logging;
 using Questionable.Controller.Steps.Common;
-using Questionable.Controller.Steps.Shared;
 using Questionable.Data;
 using Questionable.Functions;
 using Questionable.Model;
-using Questionable.Model.Common;
 using Questionable.Model.Questing;
 using Questionable.Utils;
 namespace Questionable.Controller.Steps;
 
 internal static class QuestCleanUp
 {
-    internal sealed class CheckAlliedSocietyMount(GameFunctions gameFunctions, AetheryteData aetheryteData, AlliedSocietyData alliedSocietyData, ILogger<CheckAlliedSocietyMount> logger) : SimpleTaskFactory
+    internal sealed class CheckAlliedSocietyMount(
+        GameFunctions gameFunctions,
+        AlliedSocietyData alliedSocietyData,
+        ILogger<CheckAlliedSocietyMount> logger)
+        : SimpleTaskFactory
     {
         public override ITask? CreateTask(Quest quest, QuestSequence sequence, QuestStep step)
         {
             if (sequence.Sequence == 0)
                 return null;
 
-            // if you are on a allied society mount
-            if (gameFunctions.GetMountId() is { } mountId &&
-                alliedSocietyData.Mounts.TryGetValue(mountId, out AlliedSocietyMountConfiguration? mountConfiguration))
+            ushort? mountId = gameFunctions.GetMountId();
+            if (!alliedSocietyData.IsAlliedSocietyMount(mountId))
+                return null;
+
+            logger.LogInformation("On allied society mount {MountId}", mountId);
+
+            // oh boy we love one-off hacky fixes don't we folks
+            if (quest.Id.Value == 4349)
             {
-                logger.LogInformation("We are on a known allied society mount with id = {MountId}", mountId);
-
-                // oh boy we love one-off hacky fixes don't we folks
-                if (quest.Id.Value == 4349)
-                {
-                    logger.LogInformation("However, this UT sidequest happens to reuse this Moogle society mount.");
-                    logger.LogInformation("We do not question the almighty wisdom of game devs. Let's continue with this sidequest.");
-                    return null;
-                }
-
-                // it doesn't particularly matter if we teleport to the same aetheryte twice in the same quest step, as
-                // the second (normal) teleport instance should detect that we're within range and not do anything
-                EAetheryteLocation targetAetheryte = step.AetheryteShortcut ?? mountConfiguration.ClosestAetheryte;
-                AetheryteShortcut.Task teleportTask = new(null, quest.Id, targetAetheryte, aetheryteData.TerritoryIds[targetAetheryte]);
-
-                // turn-in step can never be done while mounted on an allied society mount
-                if (sequence.Sequence == 255)
-                {
-                    logger.LogInformation("Mount can't be used to finish quest, teleporting to {Aetheryte}", mountConfiguration.ClosestAetheryte);
-                    return teleportTask;
-                }
-
-                // if the quest uses no mount actions, that's not a mount quest
-                if (!quest.AllSteps().Any(x => (x.Step.Action is { } action && action.RequiresMount()) ||
-                    (x.Step.InteractionType == EInteractionType.Combat && x.Step.KillEnemyDataIds.Contains(8593))))
-                {
-                    logger.LogInformation("Quest doesn't use any mount actions, unmounting");
-                    return new Mount.UnmountTask();
-                }
-
-                // have any of the previous sequences interacted with the issuer?
-                List<QuestStep> previousSteps =
-                    quest.AllSequences()
-                        .Where(x => x.Sequence > 0 // quest accept doesn't ever put us into a mount
-                                    && x.Sequence < sequence.Sequence)
-                        .SelectMany(x => x.Steps)
-                        .ToList();
-                if (!previousSteps.Any(x => x.DataId != null && mountConfiguration.IssuerDataIds.Contains(x.DataId.Value)))
-                {
-                    // this quest hasn't given us a mount yet
-                    logger.LogInformation("Haven't talked to mount NPC for this allied society quest; {Aetheryte}", mountConfiguration.ClosestAetheryte);
-                    return teleportTask;
-                }
+                logger.LogInformation("However, this UT sidequest happens to reuse this Moogle society mount.");
+                logger.LogInformation("We do not question the almighty wisdom of game devs. Let's continue with this sidequest.");
+                return null;
             }
 
-            return null;
+            if (alliedSocietyData.ShouldRemainMountedForStep(step, mountId!.Value))
+                return null;
+
+            logger.LogInformation(
+                "Dismounting allied society mount {MountId} before {InteractionType} (sequence {Sequence})",
+                mountId, step.InteractionType, sequence.Sequence);
+            return new Mount.UnmountTask();
         }
     }
 

--- a/Questionable/Controller/Steps/Shared/AlliedSocietyBatch.cs
+++ b/Questionable/Controller/Steps/Shared/AlliedSocietyBatch.cs
@@ -1,0 +1,10 @@
+using Questionable.Model;
+using Quest = Questionable.Model.Quest;
+
+namespace Questionable.Controller.Steps.Shared;
+
+internal static class AlliedSocietyBatch
+{
+    internal static bool SupportsBatch(Quest quest) =>
+        quest.Info is { AlliedSociety: not (EAlliedSociety.None or EAlliedSociety.Ixal), IsRepeatable: true };
+}

--- a/Questionable/Controller/Steps/Shared/AlliedSocietyBatchAccept.cs
+++ b/Questionable/Controller/Steps/Shared/AlliedSocietyBatchAccept.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Questionable.Controller.Steps.Interactions;
+using Questionable.Functions;
+using Questionable.Model;
+using Questionable.Model.Questing;
+
+namespace Questionable.Controller.Steps.Shared;
+
+internal static class AlliedSocietyBatchAccept
+{
+    internal sealed class Factory(
+        QuestController questController,
+        QuestFunctions questFunctions,
+        ILogger<Factory> logger)
+        : ITaskFactory
+    {
+        public IEnumerable<ITask> CreateAllTasks(Quest quest, QuestSequence sequence, QuestStep step)
+        {
+            if (sequence.Sequence != 0 ||
+                step.InteractionType != EInteractionType.AcceptQuest ||
+                step.PickUpQuestId != null)
+            {
+                yield break;
+            }
+
+            if (!AlliedSocietyBatch.SupportsBatch(quest))
+                yield break;
+
+            if (!questController.PriorityManager.Contains(quest.Id))
+                yield break;
+
+            EAlliedSociety alliedSociety = quest.Info.AlliedSociety;
+            if (!QuestFunctions.IsAlliedSocietyBatchModeActive(questController.PriorityManager.Quests, alliedSociety))
+                yield break;
+
+            int batchCount = 0;
+            foreach (Quest siblingQuest in questController.PriorityManager.Quests
+                         .Where(AlliedSocietyBatch.SupportsBatch)
+                         .Where(q => q.Info.AlliedSociety == alliedSociety))
+            {
+                if (siblingQuest.Id == quest.Id || !questFunctions.IsReadyToAcceptQuest(siblingQuest.Id))
+                    continue;
+
+                QuestStep? acceptStep = FindAcceptQuestStep(siblingQuest);
+                if (acceptStep?.DataId == null)
+                    continue;
+
+                batchCount++;
+                logger.LogInformation("Batch-accepting allied society quest {QuestId} ({QuestName}) after {CurrentQuestId}",
+                    siblingQuest.Id, siblingQuest.Info.Name, quest.Id);
+
+                yield return new Interact.Task(
+                    acceptStep.DataId.Value,
+                    siblingQuest,
+                    EInteractionType.AcceptQuest,
+                    acceptStep.TargetTerritoryId != null);
+
+                yield return new WaitAtEnd.WaitQuestAccepted(siblingQuest.Id);
+                yield return new WaitAtEnd.WaitDelay();
+            }
+
+            if (batchCount > 0)
+                logger.LogInformation("Queued {Count} allied society batch accept(s) for {Society}", batchCount, alliedSociety);
+        }
+
+        private static QuestStep? FindAcceptQuestStep(Quest quest) =>
+            quest.FindSequence(0)?.Steps.FirstOrDefault(s => s.InteractionType == EInteractionType.AcceptQuest);
+    }
+}

--- a/Questionable/Controller/Steps/Shared/AlliedSocietyBatchComplete.cs
+++ b/Questionable/Controller/Steps/Shared/AlliedSocietyBatchComplete.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Questionable.Controller.Steps.Interactions;
+using Questionable.Functions;
+using Questionable.Model;
+using Questionable.Model.Questing;
+
+namespace Questionable.Controller.Steps.Shared;
+
+internal static class AlliedSocietyBatchComplete
+{
+    internal sealed class Factory(
+        QuestController questController,
+        QuestFunctions questFunctions,
+        Configuration configuration,
+        ILogger<Factory> logger)
+        : ITaskFactory
+    {
+        public IEnumerable<ITask> CreateAllTasks(Quest quest, QuestSequence sequence, QuestStep step)
+        {
+            if (sequence.Sequence != 255 ||
+                step.InteractionType != EInteractionType.CompleteQuest ||
+                step.TurnInQuestId != null ||
+                configuration.Advanced.PreventQuestCompletion)
+            {
+                yield break;
+            }
+
+            if (!AlliedSocietyBatch.SupportsBatch(quest))
+                yield break;
+
+            EAlliedSociety alliedSociety = quest.Info.AlliedSociety;
+            if (!questFunctions.IsAlliedSocietyBatchCoordinationActive(questController.PriorityManager.Quests, alliedSociety))
+                yield break;
+
+            int batchCount = 0;
+            foreach ((Quest siblingQuest, byte siblingSequence) in questFunctions.GetActiveAlliedSocietyBatch(
+                         questController.PriorityManager.Quests, alliedSociety))
+            {
+                if (siblingQuest.Id == quest.Id ||
+                    siblingSequence != 255 ||
+                    !questFunctions.IsAlliedSocietyDailyReadyToTurnIn(siblingQuest))
+                {
+                    continue;
+                }
+
+                QuestStep? completeStep = FindCompleteQuestStep(siblingQuest);
+                if (completeStep?.DataId == null)
+                    continue;
+
+                batchCount++;
+                logger.LogInformation("Batch-completing allied society quest {QuestId} ({QuestName}) after {CurrentQuestId}",
+                    siblingQuest.Id, siblingQuest.Info.Name, quest.Id);
+
+                yield return new Interact.Task(
+                    completeStep.DataId.Value,
+                    siblingQuest,
+                    EInteractionType.CompleteQuest,
+                    completeStep.TargetTerritoryId != null);
+
+                yield return new WaitAtEnd.WaitQuestCompleted(siblingQuest.Id);
+                yield return new WaitAtEnd.WaitDelay();
+            }
+
+            if (batchCount > 0)
+                logger.LogInformation("Queued {Count} allied society batch complete(s) for {Society}", batchCount, alliedSociety);
+        }
+
+        private static QuestStep? FindCompleteQuestStep(Quest quest) =>
+            quest.FindSequence(255)?.Steps.FirstOrDefault(s => s.InteractionType == EInteractionType.CompleteQuest);
+    }
+}

--- a/Questionable/Data/AlliedSocietyData.cs
+++ b/Questionable/Data/AlliedSocietyData.cs
@@ -32,10 +32,24 @@ internal sealed class AlliedSocietyData
             { 23, new([1008327, 1005848, 1005860], EAetheryteLocation.SouthernThanalanLittleAlaMhigo) } // amaljaa
         }.AsReadOnly();
 
-    public bool IsAlliedSocietyMount(ushort? mountId)
+    public bool IsAlliedSocietyMount(ushort? mountId) =>
+        mountId is { } id && Mounts.ContainsKey(id);
+
+    /// <summary>
+    ///     True while the current quest step should be performed on a tribe quest mount.
+    ///     Every other step dismounts so normal travel (mount roulette / flying) can be used.
+    /// </summary>
+    public bool ShouldRemainMountedForStep(QuestStep step, ushort mountId)
     {
-        if (mountId is { } && Mounts.TryGetValue(mountId.Value, out AlliedSocietyMountConfiguration? mountConfig) && mountConfig is { })
+        if (step.Action is { } action && action.RequiresMount())
             return true;
+
+        if (step.InteractionType == EInteractionType.Combat &&
+            (mountId == 147 || step.KillEnemyDataIds.Contains(8593)))
+        {
+            return true;
+        }
+
         return false;
     }
     public EAlliedSociety GetCommonAlliedSocietyTurnIn(ElementId elementId)

--- a/Questionable/Functions/QuestFunctions.cs
+++ b/Questionable/Functions/QuestFunctions.cs
@@ -17,6 +17,7 @@ using FFXIVClientStructs.FFXIV.Client.UI.Arrays;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using Lumina.Excel.Sheets;
 using Questionable.Controller;
+using Questionable.Controller.Steps.Shared;
 using Questionable.Data;
 using Questionable.Model;
 using Questionable.Model.Common;
@@ -363,8 +364,7 @@ internal sealed unsafe class QuestFunctions
     {
         BattleChara* battleChara = (BattleChara*)(objectTable[0]?.Address ?? 0);
         return battleChara != null &&
-               battleChara->Mount.MountId != 0 &&
-               alliedSocietyData.Mounts.ContainsKey(battleChara->Mount.MountId);
+               alliedSocietyData.IsAlliedSocietyMount(battleChara->Mount.MountId);
     }
 
     private bool IsReadyToCompleteQuest(Quest quest)
@@ -377,6 +377,90 @@ internal sealed unsafe class QuestFunctions
                 return toDoListNA->QuestTypeIcon[i] == 71025; // green checkmark quest icon
         }
         return false;
+    }
+
+    private bool HasIncompleteAlliedSocietyDailyObjectives(Quest quest, byte sequence) =>
+        sequence < 255 || !IsReadyToCompleteQuest(quest);
+
+    public bool IsAlliedSocietyDailyReadyToTurnIn(Quest quest) =>
+        GetQuestProgressInfo(quest.Id)?.Sequence == 255 && IsReadyToCompleteQuest(quest);
+
+    /// <summary>
+    ///     Accepted allied-society dailies for batch objectives and turn-in. Uses the priority list by default;
+    ///     if every daily available today is already accepted (manual pickup), includes all of them.
+    /// </summary>
+    public List<(Quest Quest, byte Sequence)> GetActiveAlliedSocietyBatch(IReadOnlyList<Quest> priorityQuests,
+        EAlliedSociety society)
+    {
+        List<(Quest Quest, byte Sequence)> priorityBatch = GetAcceptedAlliedSocietyDailies(priorityQuests, society);
+
+        List<QuestId> availableToday = alliedSocietyQuestFunctions.GetAvailableAlliedSocietyQuests(society);
+        if (availableToday.Count >= 2 && availableToday.All(id => IsQuestAccepted(id)))
+        {
+            List<(Quest Quest, byte Sequence)> fullBatch =
+                GetAcceptedAlliedSocietyDailiesByIds(availableToday, priorityQuests, society);
+            if (fullBatch.Count >= 2)
+                return fullBatch;
+        }
+
+        return priorityBatch;
+    }
+
+    /// <summary>
+    ///     True while any accepted allied-society daily in the batch still has objectives to finish.
+    /// </summary>
+    public bool ShouldDeferAlliedSocietyTurnIn(Quest quest, IReadOnlyList<Quest> priorityQuests)
+    {
+        if (!AlliedSocietyBatch.SupportsBatch(quest) ||
+            !IsAlliedSocietyBatchCoordinationActive(priorityQuests, quest.Info.AlliedSociety))
+        {
+            return false;
+        }
+
+        List<(Quest Quest, byte Sequence)> batch = GetActiveAlliedSocietyBatch(priorityQuests, quest.Info.AlliedSociety);
+        return batch.Count >= 2 &&
+               batch.Any(x => HasIncompleteAlliedSocietyDailyObjectives(x.Quest, x.Sequence));
+    }
+
+    private (ElementId QuestId, byte Sequence)? GetActiveAlliedSocietyBatchQuestToRun(
+        IReadOnlyList<Quest> priorityQuests)
+    {
+        foreach (EAlliedSociety society in GetAlliedSocietyBatchCoordinationSocieties(priorityQuests))
+        {
+            List<(Quest Quest, byte Sequence)> batch = GetActiveAlliedSocietyBatch(priorityQuests, society);
+            if (batch.Count < 2)
+                continue;
+
+            foreach ((Quest batchQuest, byte batchSequence) in batch)
+            {
+                if (HasIncompleteAlliedSocietyDailyObjectives(batchQuest, batchSequence))
+                    return (batchQuest.Id, batchSequence);
+            }
+
+            return (batch[0].Quest.Id, 255);
+        }
+
+        return null;
+    }
+
+    private IEnumerable<EAlliedSociety> GetAlliedSocietyBatchCoordinationSocieties(
+        IReadOnlyList<Quest> priorityQuests)
+    {
+        HashSet<EAlliedSociety> societies = priorityQuests
+            .Where(AlliedSocietyBatch.SupportsBatch)
+            .Select(q => q.Info.AlliedSociety)
+            .ToHashSet();
+
+        foreach (EAlliedSociety society in Enum.GetValues<EAlliedSociety>())
+        {
+            if (society is EAlliedSociety.None or EAlliedSociety.Ixal)
+                continue;
+
+            if (IsManuallyAcceptedFullAlliedSocietyBatch(society))
+                societies.Add(society);
+        }
+
+        return societies;
     }
 
     private bool IsInteractSequence(ElementId questId, byte sequenceNo, uint[] dataIds)
@@ -404,6 +488,106 @@ internal sealed unsafe class QuestFunctions
         else
             return null;
     }
+
+    /// <summary>
+    ///     Picks which priority-list quest to run. For allied-society dailies (except Ixal), finishes
+    ///     objectives on every accepted quest in the batch before turning any in.
+    /// </summary>
+    public (ElementId QuestId, byte Sequence)? GetPriorityQuestToRun(IReadOnlyList<Quest> priorityQuests)
+    {
+        foreach (Quest quest in priorityQuests)
+        {
+            if (IsReadyToAcceptQuest(quest.Id))
+                return (quest.Id, 0);
+        }
+
+        (ElementId QuestId, byte Sequence)? batchQuest = GetActiveAlliedSocietyBatchQuestToRun(priorityQuests);
+        if (batchQuest != null)
+            return batchQuest;
+
+        foreach (Quest quest in priorityQuests)
+        {
+            if (!IsQuestAccepted(quest.Id))
+                continue;
+
+            byte sequence = GetQuestProgressInfo(quest.Id)?.Sequence ?? 0;
+            return (quest.Id, sequence);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     Batch objectives and turn-in: active when the tribe is on the priority list, or every daily
+    ///     available today was accepted manually.
+    /// </summary>
+    public bool IsAlliedSocietyBatchCoordinationActive(IReadOnlyList<Quest> priorityQuests, EAlliedSociety society) =>
+        IsAlliedSocietyBatchModeActive(priorityQuests, society) ||
+        IsManuallyAcceptedFullAlliedSocietyBatch(society);
+
+    /// <summary>
+    ///     Batch accept only: requires at least one daily from the tribe on the priority list.
+    /// </summary>
+    public static bool IsAlliedSocietyBatchModeActive(IReadOnlyList<Quest> priorityQuests, EAlliedSociety society) =>
+        priorityQuests.Any(q => AlliedSocietyBatch.SupportsBatch(q) && q.Info.AlliedSociety == society);
+
+    private bool IsManuallyAcceptedFullAlliedSocietyBatch(EAlliedSociety society)
+    {
+        List<QuestId> availableToday = alliedSocietyQuestFunctions.GetAvailableAlliedSocietyQuests(society);
+        return availableToday.Count >= 2 && availableToday.All(id => IsQuestAccepted(id));
+    }
+
+    public List<(Quest Quest, byte Sequence)> GetAcceptedAlliedSocietyDailies(IReadOnlyList<Quest> priorityQuests,
+        EAlliedSociety society)
+    {
+        List<(Quest Quest, byte Sequence)> batch = [];
+        foreach (Quest quest in priorityQuests)
+        {
+            if (!AlliedSocietyBatch.SupportsBatch(quest) || quest.Info.AlliedSociety != society || !IsQuestAccepted(quest.Id))
+                continue;
+
+            batch.Add((quest, GetQuestProgressInfo(quest.Id)?.Sequence ?? 0));
+        }
+
+        return batch;
+    }
+
+    private List<(Quest Quest, byte Sequence)> GetAcceptedAlliedSocietyDailiesByIds(
+        IEnumerable<QuestId> questIds,
+        IReadOnlyList<Quest> priorityQuests,
+        EAlliedSociety society)
+    {
+        List<(Quest Quest, byte Sequence)> batch = [];
+        foreach (QuestId questId in questIds)
+        {
+            if (!IsQuestAccepted(questId) || !questRegistry.TryGetQuest(questId, out Quest? quest))
+                continue;
+
+            if (!AlliedSocietyBatch.SupportsBatch(quest) || quest.Info.AlliedSociety != society)
+                continue;
+
+            batch.Add((quest, GetQuestProgressInfo(questId)?.Sequence ?? 0));
+        }
+
+        return OrderAlliedSocietyBatch(batch, priorityQuests);
+    }
+
+    private static List<(Quest Quest, byte Sequence)> OrderAlliedSocietyBatch(
+        List<(Quest Quest, byte Sequence)> batch,
+        IReadOnlyList<Quest> priorityQuests) =>
+        batch
+            .OrderBy(x =>
+            {
+                for (int i = 0; i < priorityQuests.Count; ++i)
+                {
+                    if (priorityQuests[i].Id == x.Quest.Id)
+                        return i;
+                }
+
+                return int.MaxValue;
+            })
+            .ThenBy(x => x.Quest.Id.Value)
+            .ToList();
 
     public List<PriorityQuestInfo> GetNextPriorityQuestsThatCanBeAccepted()
     {

--- a/Questionable/QuestionablePlugin.cs
+++ b/Questionable/QuestionablePlugin.cs
@@ -257,6 +257,8 @@ public sealed class QuestionablePlugin : IDalamudPlugin
         serviceCollection.AddTaskExecutor<WaitCondition.Task, WaitCondition.WaitConditionExecutor>();
         serviceCollection.AddTaskExecutor<WaitNavmesh.Task, WaitNavmesh.Executor>();
         serviceCollection.AddTaskFactory<WaitAtEnd.Factory>();
+        serviceCollection.AddTaskFactory<AlliedSocietyBatchAccept.Factory>();
+        serviceCollection.AddTaskFactory<AlliedSocietyBatchComplete.Factory>();
         serviceCollection.AddTaskExecutor<WaitAtEnd.WaitDelay, WaitAtEnd.WaitDelayExecutor>();
         serviceCollection.AddTaskExecutor<WaitAtEnd.WaitNextStepOrSequence, WaitAtEnd.WaitNextStepOrSequenceExecutor>();
         serviceCollection.AddTaskExecutor<WaitAtEnd.WaitForCompletionFlags, WaitAtEnd.WaitForCompletionFlagsExecutor>();


### PR DESCRIPTION
- Allied Society batching — Accept, do objectives, and turn in tribe dailies in batch (priority list controls accept; Ixal
excluded). If you manually take all available dailies today, objectives/turn-in batch without priority. - Kage 
- Mount dailies — Dismount tribe quest mount after objectives; fly back on your normal mount. - Kage
- Fixes — Active quest detection, batch accept/turn-in reliability, dialogue selection, Yok Huy accept step. - Kage