### PR TITLE
Fix for path, added new gearset creation to some applicable quests, added western Upper La Noscea path to Reusable Paths

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/CUL/254_My First Skillet.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/CUL/254_My First Skillet.json
@@ -1,11 +1,29 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "Kiarra",
+  "LastChecked": {"Username": "ShermTank", "Date": "2026-06-18"},
   "Comment": "Crafted Item:\n 1x Maple Syrup\nWill buy from Jossy",
   "QuestSequence": [
     {
       "Sequence": 0,
       "Steps": [
+        {
+          "InteractionType": "EquipItem",
+          "ItemId": 2493,
+          "TerritoryId": 128
+        },
+        {
+          "InteractionType": "CreateGearset",
+          "TerritoryId": 128
+        },
+        {
+          "InteractionType": "EquipRecommended",
+          "TerritoryId": 128
+        },
+        {
+          "InteractionType": "UpdateGearset",
+          "TerritoryId": 128
+        },
         {
           "DataId": 1000947,
           "Position": {

--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/FSH/1107_Way of the Fisher.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/FSH/1107_Way of the Fisher.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "Cacahuetes",
+  "LastChecked": {"Username": "ShermTank", "Date": "2026-06-18"},
   "QuestSequence": [
     {
       "Sequence": 0,
@@ -32,9 +33,9 @@
       "Steps": [
         {
           "Position": {
-            "X": -168.20791,
-            "Y": 4.550005,
-            "Z": 167.85986
+            "X": -173.68744,
+            "Y": 4.250004,
+            "Z": 163.71857
           },
           "TerritoryId": 129,
           "InteractionType": "WalkTo"

--- a/QuestPaths/4.x - Stormblood/Class Quests/BLU/3193_Blue Leading the Blue.json
+++ b/QuestPaths/4.x - Stormblood/Class Quests/BLU/3193_Blue Leading the Blue.json
@@ -32,7 +32,15 @@
         },
         {
           "TerritoryId": 135,
+          "InteractionType": "CreateGearset"
+        },
+        {
+          "TerritoryId": 135,
           "InteractionType": "EquipRecommended"
+        },
+        {
+          "TerritoryId": 135,
+          "InteractionType": "UpdateGearset"
         },
         {
           "DataId": 1026932,

--- a/QuestPaths/4.x - Stormblood/Class Quests/RDM/2577_The Crimson Duelist.json
+++ b/QuestPaths/4.x - Stormblood/Class Quests/RDM/2577_The Crimson Duelist.json
@@ -20,6 +20,10 @@
           }
         },
         {
+          "TerritoryId": 141,
+          "InteractionType": "CreateGearset"
+        },
+        {
           "DataId": 1021438,
           "Position": {
             "X": -96.84906,
@@ -40,6 +44,10 @@
         {
           "TerritoryId": 141,
           "InteractionType": "EquipRecommended"
+        },
+        {
+          "TerritoryId": 141,
+          "InteractionType": "UpdateGearset"
         },
         {
           "DataId": 1021438,

--- a/QuestPaths/4.x - Stormblood/Class Quests/SAM/2560_Master Musosai.json
+++ b/QuestPaths/4.x - Stormblood/Class Quests/SAM/2560_Master Musosai.json
@@ -30,6 +30,10 @@
           }
         },
         {
+          "TerritoryId": 131,
+          "InteractionType": "CreateGearset"
+        },
+        {
           "Position": {
             "X": -89.28058,
             "Y": 2.150006,
@@ -50,6 +54,10 @@
         {
           "TerritoryId": 131,
           "InteractionType": "EquipRecommended"
+        },
+        {
+          "TerritoryId": 131,
+          "InteractionType": "UpdateGearset"
         },
         {
           "DataId": 1023637,

--- a/QuestPaths/5.x - Shadowbringers/Class Quests/DNC/3250_Gamboling for Gil.json
+++ b/QuestPaths/5.x - Shadowbringers/Class Quests/DNC/3250_Gamboling for Gil.json
@@ -7,6 +7,46 @@
       "Sequence": 0,
       "Steps": [
         {
+          "TerritoryId": 129,
+          "InteractionType": "EquipItem",
+          "ItemId": 27358,
+          "AetheryteShortcut": "Limsa Lominsa",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            },
+            "StepIf": {
+              "Item": {
+                "NotInInventory": true
+              }
+            }
+          }
+        },
+        {
+          "TerritoryId": 129,
+          "InteractionType": "CreateGearset"
+        },
+        {
+          "TerritoryId": 129,
+          "InteractionType": "UseItem",
+          "ItemId": 27267,
+          "SkipConditions": {
+            "StepIf": {
+              "Item": {
+                "NotInInventory": true
+              }
+            }
+          }
+        },
+        {
+          "TerritoryId": 129,
+          "InteractionType": "EquipRecommended"
+        },
+        {
+          "TerritoryId": 129,
+          "InteractionType": "UpdateGearset"
+        },
+        {
           "DataId": 1028724,
           "Position": {
             "X": -104.32593,
@@ -14,13 +54,7 @@
             "Z": 195.94104
           },
           "TerritoryId": 129,
-          "InteractionType": "AcceptQuest",
-          "AetheryteShortcut": "Limsa Lominsa",
-          "SkipConditions": {
-            "AetheryteShortcutIf": {
-              "InSameTerritory": true
-            }
-          }
+          "InteractionType": "AcceptQuest"
         }
       ]
     },

--- a/QuestPaths/5.x - Shadowbringers/Class Quests/GNB/3262_Hired Gunblades.json
+++ b/QuestPaths/5.x - Shadowbringers/Class Quests/GNB/3262_Hired Gunblades.json
@@ -20,6 +20,10 @@
           }
         },
         {
+          "TerritoryId": 152,
+          "InteractionType": "CreateGearset"
+        },
+        {
           "Position": {
             "X": -214.67926,
             "Y": 11.971041,
@@ -41,6 +45,10 @@
         {
           "TerritoryId": 152,
           "InteractionType": "EquipRecommended"
+        },
+        {
+          "TerritoryId": 152,
+          "InteractionType": "UpdateGearset"
         },
         {
           "DataId": 1029033,

--- a/QuestPaths/6.x - Endwalker/Class Quests/RPR/4074_The Harvest Begins.json
+++ b/QuestPaths/6.x - Endwalker/Class Quests/RPR/4074_The Harvest Begins.json
@@ -48,6 +48,10 @@
           }
         },
         {
+          "TerritoryId": 971,
+          "InteractionType": "CreateGearset"
+        },
+        {
           "Position": {
             "X": 0.13146536,
             "Y": 0.01480782,
@@ -67,6 +71,10 @@
         {
           "TerritoryId": 971,
           "InteractionType": "EquipRecommended"
+        },
+        {
+          "TerritoryId": 971,
+          "InteractionType": "UpdateGearset"
         },
         {
           "DataId": 1037014,

--- a/QuestPaths/6.x - Endwalker/Class Quests/SGE/4068_Sage's Focus.json
+++ b/QuestPaths/6.x - Endwalker/Class Quests/SGE/4068_Sage's Focus.json
@@ -40,8 +40,16 @@
           }
         },
         {
-          "TerritoryId": 131,
+          "TerritoryId": 134,
+          "InteractionType": "CreateGearset"
+        },
+        {
+          "TerritoryId": 134,
           "InteractionType": "EquipRecommended"
+        },
+        {
+          "TerritoryId": 134,
+          "InteractionType": "UpdateGearset"
         },
         {
           "DataId": 1039265,

--- a/QuestPaths/7.x - Dawntrail/Class Quests/PCT/4855_Mind over Manor.json
+++ b/QuestPaths/7.x - Dawntrail/Class Quests/PCT/4855_Mind over Manor.json
@@ -40,7 +40,15 @@
         },
         {
           "TerritoryId": 132,
+          "InteractionType": "CreateGearset"
+        },
+        {
+          "TerritoryId": 132,
           "InteractionType": "EquipRecommended"
+        },
+        {
+          "TerritoryId": 132,
+          "InteractionType": "UpdateGearset"
         },
         {
           "DataId": 1049795,

--- a/QuestPaths/7.x - Dawntrail/Class Quests/VPR/4849_Fangs of the Viper.json
+++ b/QuestPaths/7.x - Dawntrail/Class Quests/VPR/4849_Fangs of the Viper.json
@@ -47,7 +47,15 @@
         },
         {
           "TerritoryId": 131,
+          "InteractionType": "CreateGearset"
+        },
+        {
+          "TerritoryId": 131,
           "InteractionType": "EquipRecommended"
+        },
+        {
+          "TerritoryId": 131,
+          "InteractionType": "UpdateGearset"
         },
         {
           "DataId": 1046337,

--- a/QuestPaths/Reusable Paths.md
+++ b/QuestPaths/Reusable Paths.md
@@ -44,6 +44,30 @@ Horizon side of the gate:
 
 ```
 
+## Upper La Noscea
+
+Western Half of Upper La Noscea (via Western La Noscea)
+
+```json
+        {
+          "Position": {
+            "X": 407.71924,
+            "Y": 32.11566,
+            "Z": -14.989758
+          },
+          "TerritoryId": 138,
+          "TargetTerritoryId": 139,
+          "Fly": true,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Western La Noscea - Aleport",
+          "SkipConditions": {
+            "AetheryteShortcutIf": { "InTerritory": [139] },
+            "StepIf": { "InTerritory": [139] }
+          }
+        }
+```
+
+
 ## Mor Dhona
 
 ```json


### PR DESCRIPTION
* Fix for path in 1107 Way of the Fisher. Existing path was getting stuck in the... what is that, a fish farm? Now it paths around the pillar.
* added path for Aleport to Upper La Noscea (West) in Reusable Paths file
* Added gearset creation to CUL, BLU, RDM, SAM, DNC, GNB, SGE, RPR, VPR, PCT quests