### PR TITLE
1709 Legacy of Allag - Added aetheryte unlock to skip step conditions.

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/Alliance Raid Quests/1709_Legacy of Allag.json
+++ b/QuestPaths/2.x - A Realm Reborn/Alliance Raid Quests/1709_Legacy of Allag.json
@@ -83,6 +83,7 @@
             },
             "StepIf": {
               "InTerritory": [180],
+              "AetheryteUnlocked": "Outer La Noscea - Camp Overlook",
               "CompletionQuestVariablesFlags": [null,null,null,null,null,128]
             }
           }


### PR DESCRIPTION
Without this, if you already had the aetheryte unlocked QST was flying to a point in Mor Dhona and getting stuck. (It stayed in Mor Dhona due to skipping the Aetheryte teleport to Upper La Noscea)

Even though MSQ does not go to Outer La Noscea, some job quests do (e.g. PLD, SCH), so this is an entirely feasible situation through normal automation.