### PR TITLE
577 My First Alembic

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/Alliance Raid Quests/1709_Legacy of Allag.json
+++ b/QuestPaths/2.x - A Realm Reborn/Alliance Raid Quests/1709_Legacy of Allag.json
@@ -83,6 +83,7 @@
             },
             "StepIf": {
               "InTerritory": [180],
+              "AetheryteUnlocked": "Outer La Noscea - Camp Overlook",
               "CompletionQuestVariablesFlags": [null,null,null,null,null,128]
             }
           }

--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/577_My First Alembic.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/577_My First Alembic.json
@@ -77,7 +77,7 @@
         },
         {
           "InteractionType": "Craft",
-          "TerritoryId": 419,
+          "TerritoryId": 131,
           "ItemId": 5487,
           "ItemCount": 1,
           "SkipConditions": {


### PR DESCRIPTION
Fixed 577 My First Alembic

This territory id was inducing a teleport to Ishgard, which isn't necessary. Fixed it to be Ul'dah.