### PR TITLE
Various quest fixes and additions

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/Alliance Raid Quests/1709_Legacy of Allag.json
+++ b/QuestPaths/2.x - A Realm Reborn/Alliance Raid Quests/1709_Legacy of Allag.json
@@ -83,6 +83,7 @@
             },
             "StepIf": {
               "InTerritory": [180],
+              "AetheryteUnlocked": "Outer La Noscea - Camp Overlook",
               "CompletionQuestVariablesFlags": [null,null,null,null,null,128]
             }
           }

--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/577_My First Alembic.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/577_My First Alembic.json
@@ -77,7 +77,7 @@
         },
         {
           "InteractionType": "Craft",
-          "TerritoryId": 419,
+          "TerritoryId": 131,
           "ItemId": 5487,
           "ItemCount": 1,
           "SkipConditions": {

--- a/QuestPaths/2.x - A Realm Reborn/Unlocks/Leves/220_Leves of Bentbranch.json
+++ b/QuestPaths/2.x - A Realm Reborn/Unlocks/Leves/220_Leves of Bentbranch.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "Comment": "!!! Requires manual acceptance and running of Trial Leve !!!",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "$": "Switch to combat job",
+          "InteractionType": "SwitchClass",
+          "TargetClass": "ConfiguredCombatJob",
+          "TerritoryId": 132
+        },
+        {
+          "DataId": 1000101,
+          "Position": {
+            "X": 25.04,
+            "Y": -8.01103,
+            "Z": 108.11
+          },
+          "TerritoryId": 132,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Gridania",
+          "SkipConditions": {
+            "AetheryteShortcutIf": { "InSameTerritory": true }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Comment": "Accept Trial Leve",
+          "$": "Leve: Too Close to Home",
+          "DataId": 1000105,
+          "Position": {
+            "X": 55.005,
+            "Y": -6.00002,
+            "Z": 40.8088
+          },
+          "TerritoryId": 148,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Central Shroud - Bentbranch Meadows",
+          "SkipConditions": {
+            "AetheryteShortcutIf": { "InSameTerritory": true }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": -135.631,
+            "Y": 0.64121413,
+            "Z": -110.114
+          },
+          "TerritoryId": 148,
+          "InteractionType": "Instruction",
+          "Comment": "Complete the Trial Levequest\nComplete manually or can use Battlevest"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1000105,
+          "Position": {
+            "X": 55.005,
+            "Y": -6.00002,
+            "Z": 40.8088
+          },
+          "TerritoryId": 148,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Unlocks/Leves/687_Leves of Horizon.json
+++ b/QuestPaths/2.x - A Realm Reborn/Unlocks/Leves/687_Leves of Horizon.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "Comment": "!!! Requires manual acceptance and running of Trial Leve !!!",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "$": "Switch to combat job",
+          "InteractionType": "SwitchClass",
+          "TargetClass": "ConfiguredCombatJob",
+          "TerritoryId": 130
+        },
+        {
+          "DataId": 1001794,
+          "Position": {
+            "X": 42.0224,
+            "Y": 8.00998,
+            "Z": -107.562
+          },
+          "TerritoryId": 130,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Ul'dah",
+          "AethernetShortcut": [
+            "[Ul'dah] Aetheryte Plaza",
+            "[Ul'dah] Adventurers' Guild"
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": { "InTerritory": [130] },
+            "AethernetShortcutIf": { "InSameTerritory": true }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Comment": "Accept Trial Leve",
+          "$": "Leve: What Peistes Crave",
+          "DataId": 1001796,
+          "Position": {
+            "X": 85.1833,
+            "Y": 46.0034,
+            "Z": -245.824
+          },
+          "TerritoryId": 140,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Western Thanalan - Horizon",
+          "SkipConditions": {
+            "AetheryteShortcutIf": { "InSameTerritory": true }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": -146.04796,
+            "Y": 15.468151,
+            "Z": -259.95544
+          },
+          "TerritoryId": 140,
+          "InteractionType": "Instruction",
+          "Comment": "Complete the Trial Levequest\nComplete manually or can use Battlevest"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1001796,
+          "Position": {
+            "X": 85.1833,
+            "Y": 46.0034,
+            "Z": -245.824
+          },
+          "TerritoryId": 140,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/2.x - A Realm Reborn/Unlocks/Leves/693_Leves of Swiftperch.json
+++ b/QuestPaths/2.x - A Realm Reborn/Unlocks/Leves/693_Leves of Swiftperch.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "Comment": "!!! Requires manual acceptance and running of Trial Leve !!!",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "$": "Switch to combat job",
+          "InteractionType": "SwitchClass",
+          "TargetClass": "ConfiguredCombatJob",
+          "TerritoryId": 128
+        },
+        {
+          "DataId": 1000970,
+          "Position": {
+            "X": -12.3446,
+            "Y": 39.9939,
+            "Z": -12.131
+          },
+          "TerritoryId": 128,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Limsa Lominsa",
+          "AethernetShortcut": [
+            "[Limsa Lominsa] Aetheryte Plaza",
+            "[Limsa Lominsa] The Aftcastle"
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": { "InSameTerritory": true, "InTerritory": [129] },
+            "AethernetShortcutIf": { "InSameTerritory": true }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Comment": "Accept Trial Leve",
+          "$": "Leve: Grabbing Crabs",
+          "DataId": 1001788,
+          "Position": {
+            "X": 669.201,
+            "Y": 9.15361,
+            "Z": 513.02
+          },
+          "TerritoryId": 138,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Western La Noscea - Swiftperch",
+          "SkipConditions": {
+            "AetheryteShortcutIf": { "InSameTerritory": true }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": 614.62415,
+            "Y": 8.027198,
+            "Z": 480.9083
+          },
+          "TerritoryId": 138,
+          "InteractionType": "Instruction",
+          "Comment": "Complete the Trial Levequest\nComplete manually or can use Battlevest"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1001788,
+          "Position": {
+            "X": 669.201,
+            "Y": 9.15361,
+            "Z": 513.02
+          },
+          "TerritoryId": 138,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/3.x - Heavensward/Unlocks/Misc/2096_Beloved of the Builder.json
+++ b/QuestPaths/3.x - Heavensward/Unlocks/Misc/2096_Beloved of the Builder.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "ShermTank",
+  "$": "Unlocks Specialist crafters",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "$": "Need to be on a crafter class for this quest",
+          "InteractionType": "SwitchClass",
+          "TargetClass": "ConfiguredCraftingJob",
+          "TerritoryId": 156
+        },
+        {
+          "DataId": 1013395,
+          "Position": {
+            "X": 45.632,
+            "Y": 31.1797,
+            "Z": -732.891
+          },
+          "TerritoryId": 156,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Mor Dhona",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1012179,
+          "Position": {
+            "X": 173.835,
+            "Y": -12.5461,
+            "Z": -25.3606
+          },
+          "TerritoryId": 419,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Ishgard",
+          "AethernetShortcut": [
+            "[Ishgard] Aetheryte Plaza",
+            "[Ishgard] Athenaeum Astrologicum"
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "InTerritory": [418,419]
+            },
+            "AethernetShortcutIf": {
+              "InSameTerritory": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/6.x - Endwalker/Custom Deliveries/Ameliance/4525_A Gift from House Leveilleur.json
+++ b/QuestPaths/6.x - Endwalker/Custom Deliveries/Ameliance/4525_A Gift from House Leveilleur.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Anonymous",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1042647,
+          "Position": {
+            "X": 225.686,
+            "Y": 24.9427,
+            "Z": -204.978
+          },
+          "TerritoryId": 962,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Old Sharlayan",
+          "AethernetShortcut": [
+            "[Old Sharlayan] Aetheryte Plaza",
+            "[Old Sharlayan] The Leveilleur Estate"
+          ],
+          "SkipConditions": {
+            "AetheryteShortcutIf": { "InTerritory": [962] },
+            "AethernetShortcutIf": { "InSameTerritory": true }
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1042772,
+          "Position": {
+            "X": 232.349,
+            "Y": 24.9422,
+            "Z": -187.12
+          },
+          "TerritoryId": 962,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Fixed 1709 [Legacy of Allag](https://ffxiv.consolegameswiki.com/wiki/Legacy_of_Allag)
  * Added aetheryte unlock to skip step conditions.
  * Without this, if you already had the aetheryte unlocked QST was flying to a point in Mor Dhona and getting stuck. (It stayed in Mor Dhona due to skipping the Aetheryte teleport to Upper La Noscea)
* Fixed 577 [My First Alembic](https://ffxiv.consolegameswiki.com/wiki/My_First_Alembic)
  * TerritoryId 419 was inducing a teleport to Ishgard, which is both unnecessary and (if this quest is being done during ARR) potentially impossible
* Added 4525 [A Gift from House Leveilleur](https://ffxiv.consolegameswiki.com/wiki/A_Gift_from_House_Leveilleur)
  * This is the "capstone" quest for Ameliance's Custom Deliveries
* Added 2096 [Beloved of the Builder](https://ffxiv.consolegameswiki.com/wiki/Beloved_of_the_Builder)
  * This is the quest that unlocks Crafter Specialists
* Added 220 [Leves of Bentbranch](https://ffxiv.consolegameswiki.com/wiki/Leves_of_Bentbranch), 687 [Leves of Horizon](https://ffxiv.consolegameswiki.com/wiki/Leves_of_Horizon), 693 [Leves of Swiftperch](https://ffxiv.consolegameswiki.com/wiki/Leves_of_Swiftperch)
  * These quests unlock Levequests
    * Useful if someone wants to grind out Grand Company leves for seals prior to Expert Delivery being unlocked.
  * _**Manual interaction is still required**_ to accept and perform Leve, but everything else is automated. Left a note as such in the "Comment" field.
  * I wasn't able to find these Leves in Questionable's journal, so I presume Leves are handled differently than the usual quest handler?
    * In conjunction with Battlevest, I was able to _fully_ automate this quest, but that still required me hitting the "start" button in Battlevest at the leve acceptance screen; is there a way we can hook that into Questionable?