### PR TITLE
add coffers and quest battles

### DIFF
--- a/Questionable/Controller/Steps/Shared/RedeemRewardItems.cs
+++ b/Questionable/Controller/Steps/Shared/RedeemRewardItems.cs
@@ -3,40 +3,85 @@ using System.Collections.Generic;
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Plugin.Services;
 using FFXIVClientStructs.FFXIV.Client.Game;
+using Lumina.Excel.Sheets;
 using Questionable.Data;
 using Questionable.Functions;
 using Questionable.Model;
 using Questionable.Model.Questing;
+using Quest = Questionable.Model.Quest;
 namespace Questionable.Controller.Steps.Shared;
 
 internal static class RedeemRewardItems
 {
-    internal sealed class Factory(QuestData questData) : ITaskFactory
+    internal sealed class Factory(QuestData questData, IDataManager dataManager) : ITaskFactory
     {
         public IEnumerable<ITask> CreateAllTasks(Quest quest, QuestSequence sequence, QuestStep step)
         {
             if (step.InteractionType != EInteractionType.AcceptQuest)
                 return [];
 
-            List<ITask> tasks = [];
-            unsafe
-            {
-                InventoryManager* inventoryManager = InventoryManager.Instance();
-                if (inventoryManager == null)
-                    return tasks;
+            return CreateRedeemTasks(questData, dataManager);
+        }
+    }
 
-                foreach (ItemReward itemReward in questData.RedeemableItems)
+    internal static List<ITask> CreateRedeemTasks(QuestData questData, IDataManager dataManager)
+    {
+        List<ITask> tasks = [];
+        HashSet<uint> seenItemIds = [];
+        unsafe
+        {
+            InventoryManager* inventoryManager = InventoryManager.Instance();
+            if (inventoryManager == null)
+                return tasks;
+
+            void TryAdd(ItemReward itemReward)
+            {
+                if (!seenItemIds.Add(itemReward.ItemId))
+                    return;
+
+                if (inventoryManager->GetInventoryItemCount(itemReward.ItemId) > 0 &&
+                    !itemReward.IsUnlocked())
+                    tasks.Add(new Task(itemReward));
+            }
+
+            foreach (ItemReward itemReward in questData.RedeemableItems)
+                TryAdd(itemReward);
+
+            HashSet<uint> inventoryItemIds = [];
+            for (InventoryType inventoryType = InventoryType.Inventory1;
+                 inventoryType <= InventoryType.Inventory4;
+                 ++inventoryType)
+            {
+                InventoryContainer* container = inventoryManager->GetInventoryContainer(inventoryType);
+                if (container == null)
+                    continue;
+
+                for (int i = 0; i < container->Size; ++i)
                 {
-                    if (inventoryManager->GetInventoryItemCount(itemReward.ItemId) > 0 &&
-                        !itemReward.IsUnlocked())
-                    {
-                        tasks.Add(new Task(itemReward));
-                    }
+                    InventoryItem* slot = container->GetInventorySlot(i);
+                    if (slot == null || slot->ItemId == 0)
+                        continue;
+
+                    inventoryItemIds.Add(slot->ItemId);
                 }
             }
 
-            return tasks;
+            foreach (uint itemId in inventoryItemIds)
+            {
+                if (seenItemIds.Contains(itemId))
+                    continue;
+
+                Item? item = dataManager.GetExcelSheet<Item>()?.GetRow(itemId);
+                if (item == null)
+                    continue;
+
+                ItemReward? redeemable = ItemReward.CreateFromItem(item.Value, new QuestId(0));
+                if (redeemable != null)
+                    TryAdd(redeemable);
+            }
         }
+
+        return tasks;
     }
 
     internal sealed record Task(ItemReward ItemReward) : ITask
@@ -57,6 +102,9 @@ internal static class RedeemRewardItems
             if (condition[ConditionFlag.Mounted])
                 return false;
 
+            if (Task.ItemReward.Type is EItemRewardType.Coffer && GameFunctions.GetFreeInventorySlots() < 1)
+                return false;
+
             TimeSpan castTime = Task.ItemReward.CastTime;
             if (castTime < MinimumCastTime)
                 castTime = MinimumCastTime;
@@ -69,6 +117,9 @@ internal static class RedeemRewardItems
 
         public override ETaskResult Update()
         {
+            if (Task.ItemReward.Type is EItemRewardType.Coffer && GameFunctions.GetFreeInventorySlots() < 1)
+                return ETaskResult.StillRunning;
+
             if (condition[ConditionFlag.Casting])
                 return ETaskResult.StillRunning;
 

--- a/Questionable/Controller/Steps/Shared/WaitAtEnd.cs
+++ b/Questionable/Controller/Steps/Shared/WaitAtEnd.cs
@@ -23,7 +23,9 @@ internal static class WaitAtEnd
         ICondition condition,
         AutoDutyIpc autoDutyIpc,
         BossModIpc bossModIpc,
-        RedoUtil redoUtil)
+        RedoUtil redoUtil,
+        QuestData questData,
+        IDataManager dataManager)
         : ITaskFactory
     {
         public IEnumerable<ITask> CreateAllTasks(Quest quest, QuestSequence sequence, QuestStep step)
@@ -128,10 +130,10 @@ internal static class WaitAtEnd
                     {
                         WaitQuestCompleted complete = new(step.TurnInQuestId ?? quest.Id);
                         WaitDelay delay = new();
+                        List<ITask> tasks = [complete, delay, ..RedeemRewardItems.CreateRedeemTasks(questData, dataManager)];
                         if (step.TurnInQuestId != null)
-                            return [complete, delay, Next(quest, sequence)];
-                        else
-                            return [complete, delay];
+                            tasks.Add(Next(quest, sequence));
+                        return tasks;
                     }
 
                 case EInteractionType.Interact:

--- a/Questionable/External/BossModIpc.cs
+++ b/Questionable/External/BossModIpc.cs
@@ -39,8 +39,11 @@ internal sealed class BossModIpc
     private readonly ICallGateSubscriber<string, string?> _getPreset = pluginInterface.GetIpcSubscriber<string, string?>($"{PluginName}.Presets.Get");
     private readonly ICallGateSubscriber<string, bool> _setPreset = pluginInterface.GetIpcSubscriber<string, bool>($"{PluginName}.Presets.SetActive");
     private readonly ICallGateSubscriber<string, bool> _deletePreset = pluginInterface.GetIpcSubscriber<string, bool>($"{PluginName}.Presets.Delete");
+    private readonly ICallGateSubscriber<IReadOnlyList<string>, bool, IReadOnlyList<string>> _configuration =
+        pluginInterface.GetIpcSubscriber<IReadOnlyList<string>, bool, IReadOnlyList<string>>($"{PluginName}.Configuration");
 
     private bool _soloDutyZoneConfigured;
+    private bool _enableQuestBattlesOverridden;
 
     public bool IsSupported() => IpcInvoke.SafeFunc(() => _getPreset.HasFunction, false);
 
@@ -75,7 +78,7 @@ internal sealed class BossModIpc
 
     public void SetPresetForSoloDuty(EPreset preset)
     {
-        ConfigureZoneForQuestBattle(true);
+        ConfigureZoneForQuestBattle();
         SetActivePreset(preset);
     }
 
@@ -113,26 +116,51 @@ internal sealed class BossModIpc
         ClearActivePresets();
     }
 
-    private void ConfigureZoneForQuestBattle(bool enable)
+    private void ConfigureZoneForQuestBattle()
     {
-        commandManager.ProcessCommand(enable
-            ? "/vbm cfg ZoneModuleConfig EnableQuestBattles true"
-            : "/vbm cfg ZoneModuleConfig EnableQuestBattles false");
-        if (enable)
+        if (!_soloDutyZoneConfigured)
         {
             commandManager.ProcessCommand("/vbm cfg Autorotation ClearPresetOnCombatEnd false");
             _soloDutyZoneConfigured = true;
         }
+
+        bool? enableQuestBattles = TryGetEnableQuestBattles();
+        if (enableQuestBattles is not true)
+            SetEnableQuestBattles(true);
+        _enableQuestBattlesOverridden = enableQuestBattles == false;
     }
 
     private void ReleaseSoloDutyZone()
     {
-        if (!_soloDutyZoneConfigured)
-            return;
+        if (_enableQuestBattlesOverridden)
+        {
+            SetEnableQuestBattles(false);
+            _enableQuestBattlesOverridden = false;
+        }
 
-        commandManager.ProcessCommand("/vbm cfg ZoneModuleConfig EnableQuestBattles false");
         _soloDutyZoneConfigured = false;
     }
+
+    private bool? TryGetEnableQuestBattles()
+    {
+        if (!_configuration.HasFunction)
+            return null;
+
+        return IpcInvoke.SafeFunc(() =>
+        {
+            IReadOnlyList<string> result = _configuration.InvokeFunc(
+                ["cfg", "ZoneModuleConfig", "EnableQuestBattles"], false);
+            if (result.Count == 0)
+                return (bool?)null;
+
+            return bool.TryParse(result[0], out bool value) ? value : null;
+        }, null);
+    }
+
+    private void SetEnableQuestBattles(bool enabled) =>
+        commandManager.ProcessCommand(enabled
+            ? "/vbm cfg ZoneModuleConfig EnableQuestBattles true"
+            : "/vbm cfg ZoneModuleConfig EnableQuestBattles false");
 
     public bool IsConfiguredToRunSoloInstance(ElementId questId, SinglePlayerDutyOptions? dutyOptions)
     {

--- a/Questionable/Model/ItemReward.cs
+++ b/Questionable/Model/ItemReward.cs
@@ -11,7 +11,9 @@ public enum EItemRewardType
     Minion,
     OrchestrionRoll,
     TripleTriadCard,
-    FashionAccessory
+    FashionAccessory,
+    Coffer,
+    UnlockLink,
 }
 
 public sealed class ItemRewardDetails(Item item, ElementId elementId)
@@ -29,8 +31,14 @@ public abstract record ItemReward(ItemRewardDetails Item)
     public ElementId ElementId => Item.ElementId;
     public TimeSpan CastTime => Item.CastTime;
     public abstract EItemRewardType Type { get; }
+    internal static bool IsValidCoffer(Item item) =>
+        item.ItemAction.RowId is 1085 or 388 or 367 && item.ItemUICategory.RowId is 61;
+
     internal static ItemReward? CreateFromItem(Item item, ElementId elementId)
     {
+        if (IsValidCoffer(item))
+            return new CofferReward(new(item, elementId));
+
         if (item.ItemAction.Value is { } itemAction &&
             itemAction.Action.Value is { } action)
         {
@@ -48,7 +56,11 @@ public abstract record ItemReward(ItemRewardDetails Item)
 
             if (action.RowId is 3357)
                 return new TripleTriadCardReward(new(item, elementId), (ushort)item.AdditionalData.RowId);
+
+            if (action.RowId is 2633)
+                return new UnlockLinkReward(new(item, elementId), (ushort)item.ItemAction.Value.Data[0]);
         }
+
         return null;
     }
     public abstract bool IsUnlocked();
@@ -93,4 +105,18 @@ public sealed record FashionAccessoryReward(ItemRewardDetails Item, uint Accesso
     public override EItemRewardType Type => EItemRewardType.FashionAccessory;
 
     public override unsafe bool IsUnlocked() => PlayerState.Instance()->IsOrnamentUnlocked(AccessoryId);
+}
+
+public sealed record CofferReward(ItemRewardDetails Item) : ItemReward(Item)
+{
+    public override EItemRewardType Type => EItemRewardType.Coffer;
+
+    public override bool IsUnlocked() => false;
+}
+
+public sealed record UnlockLinkReward(ItemRewardDetails Item, ushort UnlockLinkId) : ItemReward(Item)
+{
+    public override EItemRewardType Type => EItemRewardType.UnlockLink;
+
+    public override unsafe bool IsUnlocked() => UIState.Instance()->IsUnlockLinkUnlocked(UnlockLinkId);
 }


### PR DESCRIPTION
Make it so that it opens ALL coffers/mounts/minions/.. so all rewards after a quest. 
it still has the fallback of nextquest as before.

update the bossmod IPC so that it doesnt actually touch the `EnableQuestBattles ` setting, but overrides it if needed and reverts it back to what it was. so it doest not hard disable it anymore after a quest battle as before.