### PR TITLE
Fix ALC class quests teleporting to Ishgard to craft

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/578_The Second Principle.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/578_The Second Principle.json
@@ -36,7 +36,7 @@
       "Steps": [
         {
           "InteractionType": "Craft",
-          "TerritoryId": 419,
+          "TerritoryId": 131,
           "ItemId": 4564,
           "ItemCount": 3,
           "SkipConditions": {

--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/580_All of Your Beeswax.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/580_All of Your Beeswax.json
@@ -36,7 +36,7 @@
       "Steps": [
         {
           "InteractionType": "Craft",
-          "TerritoryId": 419,
+          "TerritoryId": 131,
           "ItemId": 5515,
           "ItemCount": 12,
           "SkipConditions": {

--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/581_For Fair Love.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/581_For Fair Love.json
@@ -36,7 +36,7 @@
       "Steps": [
         {
           "InteractionType": "Craft",
-          "TerritoryId": 419,
+          "TerritoryId": 131,
           "ItemId": 4597,
           "ItemCount": 1,
           "SkipConditions": {
@@ -49,7 +49,7 @@
         },
         {
           "InteractionType": "Craft",
-          "TerritoryId": 419,
+          "TerritoryId": 131,
           "ItemId": 4595,
           "ItemCount": 1,
           "SkipConditions": {

--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/582_The Arcanist's Tome.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/582_The Arcanist's Tome.json
@@ -36,7 +36,7 @@
       "Steps": [
         {
           "InteractionType": "Craft",
-          "TerritoryId": 419,
+          "TerritoryId": 131,
           "ItemId": 2149,
           "ItemCount": 1,
           "SkipConditions": {

--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/583_Practical Alchemy.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/583_Practical Alchemy.json
@@ -36,7 +36,7 @@
       "Steps": [
         {
           "InteractionType": "Craft",
-          "TerritoryId": 419,
+          "TerritoryId": 131,
           "ItemId": 5522,
           "ItemCount": 1,
           "SkipConditions": {

--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/584_Baleful Brews.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/584_Baleful Brews.json
@@ -36,7 +36,7 @@
       "Steps": [
         {
           "InteractionType": "Craft",
-          "TerritoryId": 419,
+          "TerritoryId": 131,
           "ItemId": 4575,
           "ItemCount": 3,
           "SkipConditions": {

--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/647_Cease and Assist.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/647_Cease and Assist.json
@@ -66,7 +66,7 @@
       "Steps": [
         {
           "InteractionType": "Craft",
-          "TerritoryId": 419,
+          "TerritoryId": 131,
           "ItemId": 4556,
           "ItemCount": 1,
           "SkipConditions": {

--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/648_Might Made Right.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/648_Might Made Right.json
@@ -36,7 +36,7 @@
       "Steps": [
         {
           "InteractionType": "Craft",
-          "TerritoryId": 419,
+          "TerritoryId": 131,
           "ItemId": 4599,
           "ItemCount": 3,
           "SkipConditions": {

--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/649_Ultimate Alchemy.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/649_Ultimate Alchemy.json
@@ -36,7 +36,7 @@
       "Steps": [
         {
           "InteractionType": "Craft",
-          "TerritoryId": 419,
+          "TerritoryId": 131,
           "ItemId": 4607,
           "ItemCount": 1,
           "SkipConditions": {
@@ -49,7 +49,7 @@
         },
         {
           "InteractionType": "Craft",
-          "TerritoryId": 419,
+          "TerritoryId": 131,
           "ItemId": 4608,
           "ItemCount": 1,
           "SkipConditions": {
@@ -62,7 +62,7 @@
         },
         {
           "InteractionType": "Craft",
-          "TerritoryId": 419,
+          "TerritoryId": 131,
           "ItemId": 4606,
           "ItemCount": 1,
           "SkipConditions": {

--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/650_Momentary Miracle.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/ALC/650_Momentary Miracle.json
@@ -94,7 +94,7 @@
       "Steps": [
         {
           "InteractionType": "Craft",
-          "TerritoryId": 419,
+          "TerritoryId": 131,
           "ItemId": 1987,
           "ItemCount": 1,
           "SkipConditions": {


### PR DESCRIPTION
The Alchemist class quests have their Craft steps tagged `TerritoryId: 419` (The Pillars), so Questionable teleports to Foundation and crosses Ishgard before crafting, then heads back to Ul'dah for the turn-in. These quests are all in Ul'dah and crafting works anywhere, so I changed them to `131` (Ul'dah), matching `577 My First Alembic` which was already correct. Fixes 13 craft steps across 10 files.

Edit: FYI and thank you, I just went through all crafters class quests and this is the only issue I encountered. Huge help.