### PR TITLE
3096 - TP to Dawn Thrown if Dhoro Iloh is not unlocked

### DIFF
--- a/QuestPaths/4.x - Stormblood/Allied Societies/Namazu/Story/3096_Something Fishy This Way Comes.json
+++ b/QuestPaths/4.x - Stormblood/Allied Societies/Namazu/Story/3096_Something Fishy This Way Comes.json
@@ -1,7 +1,10 @@
 ﻿{
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "Censored",
-  "LastChecked": {"Username": "Iskierka", "Date": "2026-06-27"},
+  "LastChecked": {
+    "Username": "Iskierka",
+    "Date": "2026-06-27"
+  },
   "QuestSequence": [
     {
       "Sequence": 0,
@@ -109,7 +112,6 @@
           },
           "TerritoryId": 622,
           "InteractionType": "Interact",
-          "Fly": true,
           "AetheryteShortcut": "Azim Steppe - Dawn Throne",
           "DialogueChoices": [
             {
@@ -118,6 +120,22 @@
               "Yes": true
             }
           ]
+        },
+        {
+          "DataId": 128,
+          "Position": {
+            "X": -750.19824,
+            "Y": 128.82487,
+            "Z": 117.04963
+          },
+          "TerritoryId": 622,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "SkipConditions": {
+            "StepIf": {
+              "AetheryteUnlocked": "Azim Steppe - Dhoro Iloh"
+            }
+          }
         }
       ]
     },

--- a/QuestPaths/4.x - Stormblood/Allied Societies/Namazu/Story/3096_Something Fishy This Way Comes.json
+++ b/QuestPaths/4.x - Stormblood/Allied Societies/Namazu/Story/3096_Something Fishy This Way Comes.json
@@ -82,6 +82,25 @@
       "Sequence": 4,
       "Steps": [
         {
+          "Position": {
+            "X": -627.83246,
+            "Y": 40.01948,
+            "Z": 100.20593
+          },
+          "TerritoryId": 622,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "AetheryteShortcut": "Azim Steppe - Dhoro Iloh",
+          "SkipConditions": {
+            "AetheryteShortcutIf": {
+              "AetheryteLocked": "Azim Steppe - Dhoro Iloh"
+            },
+            "StepIf": {
+              "AetheryteLocked": "Azim Steppe - Dhoro Iloh"
+            }
+          }
+        },
+        {
           "DataId": 1025697,
           "Position": {
             "X": -627.83246,
@@ -91,7 +110,7 @@
           "TerritoryId": 622,
           "InteractionType": "Interact",
           "Fly": true,
-          "AetheryteShortcut": "Azim Steppe - Dhoro Iloh",
+          "AetheryteShortcut": "Azim Steppe - Dawn Throne",
           "DialogueChoices": [
             {
               "Type": "YesNo",

--- a/QuestPaths/4.x - Stormblood/Allied Societies/Namazu/Story/3097_One Size Fits All.json
+++ b/QuestPaths/4.x - Stormblood/Allied Societies/Namazu/Story/3097_One Size Fits All.json
@@ -92,6 +92,7 @@
             "Z": 90.92847
           },
           "TerritoryId": 622,
+          "AetheryteShortcut": "Azim Steppe - Dhoro Iloh",
           "InteractionType": "CompleteQuest"
         }
       ]


### PR DESCRIPTION
Introduces an optional step to teleport to Dawn Throne instead of Dhoro Iloh if it is not yet unlocked. Also adds a step to unlock it. I believe this is the intended way to do it if flying is not yet unlocked, since the quest requires you to talk to the NPC which will take you up there.

I had not unlocked Dhoro Iloh yet and was receiving this message:

[QST v15.303.0.17] Could not complete 'UseAetheryte(AzimSteppeDhoroIloh)': Aetheryte is not unlocked. Please check /xllog for more details.