### PR TITLE
1128 1129 1130 Shadows Uncast

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/Unlocks/Dungeons/1128_Shadows Uncast (Maelstrom).json
+++ b/QuestPaths/2.x - A Realm Reborn/Unlocks/Dungeons/1128_Shadows Uncast (Maelstrom).json
@@ -37,6 +37,16 @@
       "Sequence": 1,
       "Steps": [
         {
+          "Position": {
+            "X": 175.38486,
+            "Y": 222.54001,
+            "Z": 353.219
+          },
+          "TerritoryId": 155,
+          "InteractionType": "WalkTo",
+          "SkipConditions": {"StepIf": {"QuestsCompleted": [979]}}
+        },
+        {
           "DataId": 1006382,
           "Position": {
             "X": 165.20935,

--- a/QuestPaths/2.x - A Realm Reborn/Unlocks/Dungeons/1129_Shadows Uncast (Twin Adder).json
+++ b/QuestPaths/2.x - A Realm Reborn/Unlocks/Dungeons/1129_Shadows Uncast (Twin Adder).json
@@ -27,6 +27,16 @@
       "Sequence": 1,
       "Steps": [
         {
+          "Position": {
+            "X": 175.38486,
+            "Y": 222.54001,
+            "Z": 353.219
+          },
+          "TerritoryId": 155,
+          "InteractionType": "WalkTo",
+          "SkipConditions": {"StepIf": {"QuestsCompleted": [979]}}
+        },
+        {
           "DataId": 1006382,
           "Position": {
             "X": 165.20935,

--- a/QuestPaths/2.x - A Realm Reborn/Unlocks/Dungeons/1130_Shadows Uncast (Immortal Flames).json
+++ b/QuestPaths/2.x - A Realm Reborn/Unlocks/Dungeons/1130_Shadows Uncast (Immortal Flames).json
@@ -27,6 +27,16 @@
       "Sequence": 1,
       "Steps": [
         {
+          "Position": {
+            "X": 175.38486,
+            "Y": 222.54001,
+            "Z": 353.219
+          },
+          "TerritoryId": 155,
+          "InteractionType": "WalkTo",
+          "SkipConditions": {"StepIf": {"QuestsCompleted": [979]}}
+        },
+        {
           "DataId": 1006382,
           "Position": {
             "X": 165.20935,


### PR DESCRIPTION
Added WalkTo step before picking up the regular quest

"Mount": false was skipping the teleport, causing pathing to fail. This also allows you to fly to outside the building first, then walk in (much faster)