### PR TITLE
Check item quality before skipping the craft step

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/ARM/279_Showing Your Steel.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/ARM/279_Showing Your Steel.json
@@ -39,6 +39,7 @@
           "TerritoryId": 128,
           "ItemId": 5058,
           "ItemCount": 1,
+          "ItemQuality": "HQ",
           "SkipConditions": {
             "StepIf": {
               "Item": {

--- a/QuestPaths/2.x - A Realm Reborn/Class Quests/BSM/297_True as Steel.json
+++ b/QuestPaths/2.x - A Realm Reborn/Class Quests/BSM/297_True as Steel.json
@@ -39,6 +39,7 @@
           "TerritoryId": 128,
           "ItemId": 5058,
           "ItemCount": 1,
+          "ItemQuality": "HQ",
           "SkipConditions": {
             "StepIf": {
               "Item": {

--- a/Questionable/Controller/Steps/Shared/SkipCondition.cs
+++ b/Questionable/Controller/Steps/Shared/SkipCondition.cs
@@ -266,8 +266,20 @@ internal static class SkipCondition
                 return false;
 
             InventoryManager* inventoryManager = InventoryManager.Instance();
-            int itemCount = inventoryManager->GetInventoryItemCount(step.ItemId.Value, false, false)
-                            + inventoryManager->GetInventoryItemCount(step.ItemId.Value, true, false);
+            int itemCount = 0;
+            switch (step.ItemQuality)
+            {
+                case EItemQuality.NQ:
+                    itemCount = inventoryManager->GetInventoryItemCount(step.ItemId.Value, false, false);
+                    break;
+                case EItemQuality.HQ:
+                    itemCount = inventoryManager->GetInventoryItemCount(step.ItemId.Value, true, false);
+                    break;
+                case EItemQuality.Any:
+                    itemCount = inventoryManager->GetInventoryItemCount(step.ItemId.Value, false, false)
+                                + inventoryManager->GetInventoryItemCount(step.ItemId.Value, true, false);
+                    break;
+            }
 
             if (itemCount == 0 && skipConditions.Item is { NotInInventory: true })
             {

--- a/Questionable/Controller/Steps/Shared/SkipCondition.cs
+++ b/Questionable/Controller/Steps/Shared/SkipCondition.cs
@@ -270,14 +270,14 @@ internal static class SkipCondition
             switch (step.ItemQuality)
             {
                 case EItemQuality.NQ:
-                    itemCount = inventoryManager->GetInventoryItemCount(step.ItemId.Value, false, false);
+                    itemCount = inventoryManager->GetInventoryItemCount(step.ItemId.Value, isHq:false, checkEquipped:false);
                     break;
                 case EItemQuality.HQ:
-                    itemCount = inventoryManager->GetInventoryItemCount(step.ItemId.Value, true, false);
+                    itemCount = inventoryManager->GetInventoryItemCount(step.ItemId.Value, isHq:true, checkEquipped:false);
                     break;
                 case EItemQuality.Any:
-                    itemCount = inventoryManager->GetInventoryItemCount(step.ItemId.Value, false, false)
-                                + inventoryManager->GetInventoryItemCount(step.ItemId.Value, true, false);
+                    itemCount = inventoryManager->GetInventoryItemCount(step.ItemId.Value, isHq:false, checkEquipped:false)
+                                + inventoryManager->GetInventoryItemCount(step.ItemId.Value, isHq:true, checkEquipped:false);
                     break;
             }
 


### PR DESCRIPTION
Update the item SkipCondition to check for the item's quality before deciding to skip.
Update the BSM and ARM class quests for Steel Ingots to require an HQ item.

Unfortunately, Artisan will still skip the craft if you have an NQ Steel Ingot in your inventory. Artisan has no way to specify that the item must be HQ. I disabled my own "skip crafting items you already have enough of", but it still skipped. Perhaps there is a setting in QST that I couldn't find that could be temporarily disabled if we need an HQ craft and detect that we don't yet have it.

Without this fix, I was stuck standing at the quest NPC because it was trying to hand in an NQ ingot instead of the required HQ one.

This doesn't really change much; this situation will still stall. But at least it is more correct than it was, and QST can support it as soon as Artisan does.