### PR TITLE
Add owner-scoped cooperative quest pause leases

### DIFF
--- a/Questionable/Controller/QuestController.cs
+++ b/Questionable/Controller/QuestController.cs
@@ -109,6 +109,7 @@ internal sealed class QuestController : MiniTaskController<QuestController>
     private readonly IToastGui _toastGui;
     private readonly ICommandManager _commandManager;
     private EAutomationType _automationType;
+    private readonly object _pauseRequestGate = new();
     private readonly HashSet<string> _pauseRequests = new(StringComparer.Ordinal);
     private bool _pauseEffective;
     private DateTime _lastAutoRefresh = DateTime.MinValue;
@@ -272,16 +273,32 @@ internal sealed class QuestController : MiniTaskController<QuestController>
     {
         if (string.IsNullOrWhiteSpace(owner))
             throw new ArgumentException("A pause-request owner is required.", nameof(owner));
-        if (paused)
-            _pauseRequests.Add(owner);
-        else
-            _pauseRequests.Remove(owner);
-        if (_pauseRequests.Count == 0)
-            _pauseEffective = false;
+        lock (_pauseRequestGate)
+        {
+            if (paused)
+                _pauseRequests.Add(owner);
+            else
+                _pauseRequests.Remove(owner);
+        }
     }
 
-    public bool IsPauseRequestEffective(string owner) =>
-        !string.IsNullOrWhiteSpace(owner) && _pauseRequests.Contains(owner) && _pauseEffective;
+    public bool IsPauseRequestEffective(string owner)
+    {
+        lock (_pauseRequestGate)
+            return !string.IsNullOrWhiteSpace(owner) && _pauseRequests.Contains(owner) && _pauseEffective;
+    }
+
+    private bool HasPauseRequests()
+    {
+        lock (_pauseRequestGate)
+            return _pauseRequests.Count > 0;
+    }
+
+    private void SetPauseEffective(bool effective)
+    {
+        lock (_pauseRequestGate)
+            _pauseEffective = effective;
+    }
     public TaskQueue TaskQueue => _taskQueue;
 
     public string? CurrentTaskState
@@ -357,12 +374,12 @@ internal sealed class QuestController : MiniTaskController<QuestController>
         if (IsQuestingStopped)
             return;
 
-        if (_pauseRequests.Count > 0 && _taskQueue.CurrentTaskExecutor == null)
+        if (HasPauseRequests() && _taskQueue.CurrentTaskExecutor == null)
         {
-            _pauseEffective = true;
+            SetPauseEffective(true);
             return;
         }
-        _pauseEffective = false;
+        SetPauseEffective(false);
 
         UpdateCurrentQuest();
 

--- a/Questionable/Controller/QuestController.cs
+++ b/Questionable/Controller/QuestController.cs
@@ -109,8 +109,9 @@ internal sealed class QuestController : MiniTaskController<QuestController>
     private readonly IToastGui _toastGui;
     private readonly ICommandManager _commandManager;
     private EAutomationType _automationType;
+    private static readonly TimeSpan PauseRequestLifetime = TimeSpan.FromMinutes(10);
     private readonly object _pauseRequestGate = new();
-    private readonly HashSet<string> _pauseRequests = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, DateTime> _pauseRequests = new(StringComparer.Ordinal);
     private bool _pauseEffective;
     private DateTime _lastAutoRefresh = DateTime.MinValue;
 
@@ -276,7 +277,7 @@ internal sealed class QuestController : MiniTaskController<QuestController>
         lock (_pauseRequestGate)
         {
             if (paused)
-                _pauseRequests.Add(owner);
+                _pauseRequests[owner] = DateTime.UtcNow.Add(PauseRequestLifetime);
             else
                 _pauseRequests.Remove(owner);
         }
@@ -285,13 +286,26 @@ internal sealed class QuestController : MiniTaskController<QuestController>
     public bool IsPauseRequestEffective(string owner)
     {
         lock (_pauseRequestGate)
-            return !string.IsNullOrWhiteSpace(owner) && _pauseRequests.Contains(owner) && _pauseEffective;
+        {
+            PruneExpiredPauseRequests();
+            return !string.IsNullOrWhiteSpace(owner) && _pauseRequests.ContainsKey(owner) && _pauseEffective;
+        }
     }
 
     private bool HasPauseRequests()
     {
         lock (_pauseRequestGate)
+        {
+            PruneExpiredPauseRequests();
             return _pauseRequests.Count > 0;
+        }
+    }
+
+    private void PruneExpiredPauseRequests()
+    {
+        var now = DateTime.UtcNow;
+        foreach (var owner in _pauseRequests.Where(request => request.Value <= now).Select(request => request.Key).ToArray())
+            _pauseRequests.Remove(owner);
     }
 
     private void SetPauseEffective(bool effective)

--- a/Questionable/Controller/QuestController.cs
+++ b/Questionable/Controller/QuestController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Collections.Generic;
 using System.Numerics;
 using System.Threading;
 using Dalamud.Game.ClientState.Conditions;
@@ -108,6 +109,8 @@ internal sealed class QuestController : MiniTaskController<QuestController>
     private readonly IToastGui _toastGui;
     private readonly ICommandManager _commandManager;
     private EAutomationType _automationType;
+    private readonly HashSet<string> _pauseRequests = new(StringComparer.Ordinal);
+    private bool _pauseEffective;
     private DateTime _lastAutoRefresh = DateTime.MinValue;
 
     /// <summary>True while recovering from the player's death (waiting for the return prompt / respawn).</summary>
@@ -265,6 +268,20 @@ internal sealed class QuestController : MiniTaskController<QuestController>
     public Func<bool>? IsQuestWindowOpenFunction { private get; set; } = () => true;
 
     public bool IsRunning => !_taskQueue.AllTasksComplete;
+    public void SetPauseRequest(string owner, bool paused)
+    {
+        if (string.IsNullOrWhiteSpace(owner))
+            throw new ArgumentException("A pause-request owner is required.", nameof(owner));
+        if (paused)
+            _pauseRequests.Add(owner);
+        else
+            _pauseRequests.Remove(owner);
+        if (_pauseRequests.Count == 0)
+            _pauseEffective = false;
+    }
+
+    public bool IsPauseRequestEffective(string owner) =>
+        !string.IsNullOrWhiteSpace(owner) && _pauseRequests.Contains(owner) && _pauseEffective;
     public TaskQueue TaskQueue => _taskQueue;
 
     public string? CurrentTaskState
@@ -339,6 +356,13 @@ internal sealed class QuestController : MiniTaskController<QuestController>
 
         if (IsQuestingStopped)
             return;
+
+        if (_pauseRequests.Count > 0 && _taskQueue.CurrentTaskExecutor == null)
+        {
+            _pauseEffective = true;
+            return;
+        }
+        _pauseEffective = false;
 
         UpdateCurrentQuest();
 

--- a/Questionable/External/QuestionableIpc.cs
+++ b/Questionable/External/QuestionableIpc.cs
@@ -38,6 +38,8 @@ internal sealed class QuestionableIpc : IDisposable
     private const string IpcStartGathering = "Questionable.StartGathering";
     private const string IpcStartGatheringComplex = "Questionable.StartGatheringComplex";
     private const string IpcStop = "Questionable.Stop";
+    private const string IpcSetPauseRequest = "Questionable.SetPauseRequest";
+    private const string IpcIsPauseRequestEffective = "Questionable.IsPauseRequestEffective";
     private const string IpcRedoLookup = "Questionable.RedoLookup";
     private const string IpcRedoLookupIndex = "Questionable.RedoLookupIndex";
     private readonly ICallGateProvider<string, bool> _addQuestPriority;
@@ -69,6 +71,8 @@ internal sealed class QuestionableIpc : IDisposable
     private readonly ICallGateProvider<string, bool> _startQuest;
     private readonly ICallGateProvider<string, bool> _startSingleQuest;
     private readonly ICallGateProvider<string, bool> _stop;
+    private readonly ICallGateProvider<string, bool, object> _setPauseRequest;
+    private readonly ICallGateProvider<string, bool> _isPauseRequestEffective;
 
     public QuestionableIpc(
         QuestController questController,
@@ -148,6 +152,11 @@ internal sealed class QuestionableIpc : IDisposable
         _stop = pluginInterface.GetIpcProvider<string, bool>(IpcStop);
         _stop.RegisterFunc(Stop);
 
+        _setPauseRequest = pluginInterface.GetIpcProvider<string, bool, object>(IpcSetPauseRequest);
+        _setPauseRequest.RegisterAction(questController.SetPauseRequest);
+        _isPauseRequestEffective = pluginInterface.GetIpcProvider<string, bool>(IpcIsPauseRequestEffective);
+        _isPauseRequestEffective.RegisterFunc(questController.IsPauseRequestEffective);
+
         _redoUtil = redoUtil;
 
         _redoLookup = pluginInterface.GetIpcProvider<uint, string>(IpcRedoLookup);
@@ -178,6 +187,8 @@ internal sealed class QuestionableIpc : IDisposable
         _startGathering.UnregisterFunc();
         _startGatheringComplex.UnregisterFunc();
         _stop.UnregisterFunc();
+        _setPauseRequest.UnregisterAction();
+        _isPauseRequestEffective.UnregisterFunc();
         _redoLookup.UnregisterFunc();
     }
 


### PR DESCRIPTION
## Summary
- add named IPC pause requests and effective-state checks
- let the current task executor finish, then pause before the next queued task without clearing quest state
- synchronize cross-plugin IPC access and expire abandoned leases after ten minutes

## Why
Questionable.Stop clears active execution state. Consumers that temporarily need movement or UI ownership need a cooperative boundary that preserves the user's quest plan and resumes it after release.

## Validation
- dotnet test Questionable.sln --no-restore
- 48 Questionable tests, 1 generator test, and 4,089 quest-path validations passed