### PR TITLE
705 The Weaponsmith of Legend (ARR relic unlock) - fixed navigation

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/Relics/705_The Weaponsmith of Legend.json
+++ b/QuestPaths/2.x - A Realm Reborn/Relics/705_The Weaponsmith of Legend.json
@@ -1,7 +1,7 @@
 ﻿{
   "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
   "Author": "liza",
-  "LastChecked": {"Username": "goopy_brain", "Date": "2026-06-19"},
+  "LastChecked": {"Username": "ShermTank", "Date": "2026-07-13"},
   "QuestSequence": [
     {
       "Sequence": 0,
@@ -56,6 +56,17 @@
       "Sequence": 255,
       "Steps": [
         {
+          "Position": {
+            "X": 436.96893,
+            "Y": -3.3962386,
+            "Z": -67.97297
+          },
+          "TerritoryId": 154,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
           "DataId": 1003075,
           "Position": {
             "X": 440.7262,
@@ -69,7 +80,7 @@
             "[Gridania] Aetheryte Plaza",
             "[Gridania] Yellow Serpent Gate (North Shroud)"
           ],
-          "Fly": true
+          "Fly": false
         }
       ]
     }


### PR DESCRIPTION
Added landing nearby Gerolt then walking up to him; flying into his head didn't seem to do well for conversation