### PR TITLE
Accept Only Priority Quests

### DIFF
--- a/Questionable/Controller/QuestController.cs
+++ b/Questionable/Controller/QuestController.cs
@@ -535,6 +535,16 @@ internal sealed class QuestController : MiniTaskController<QuestController>
                 }
             }
 
+            // any priority quest is flagged accept-only and can be picked up right now,
+            // queue it as the next quest so only its accept step (sequence 0) runs.
+            // Completing the accepted quests is deferred until every flagged quest has been accepted,
+            // so the user can several allied societies / quests and have them all picked up before any turn-ins start.
+            if (SimulatedQuest == null && NextQuest == null &&
+                AutomationType == EAutomationType.Automatic)
+            {
+                TryQueueNextAcceptOnlyQuest();
+            }
+
             // Stop checks run before the NextQuest/priority cascade — otherwise a
             // queued NextQuest (e.g. an MSQ chain or priority list pick) is started
             // before the user's "stop after this quest" toggle is ever consulted.
@@ -609,6 +619,7 @@ internal sealed class QuestController : MiniTaskController<QuestController>
                 (ElementId? currentQuestId, currentSequence, MainScenarioQuestState msqState) = _questFunctions.GetCurrentQuest(allowNewMsq: AutomationType != EAutomationType.SingleQuestB);
                 (ElementId, byte)? priorityQuestOption =
                     _priorityManager.Quests
+                        .Where(x => !_priorityManager.IsAcceptOnly(x.Id))
                         .Where(x => _questFunctions.IsReadyToAcceptQuest(x.Id) || _questFunctions.IsQuestAccepted(x.Id))
                         .Select(x => (x.Id, QuestFunctions.GetQuestProgressInfo(x.Id)?.Sequence ?? 0))
                         .FirstOrDefault();
@@ -1099,6 +1110,9 @@ internal sealed class QuestController : MiniTaskController<QuestController>
     {
         ClearTasksInternal();
 
+        if (AutomationType == EAutomationType.Automatic && TryQueueNextAcceptOnlyQuest())
+            _logger.LogInformation("Accepting queued accept-only quests before other work");
+
         if (TryPickPriorityQuest())
             _logger.LogInformation("Using priority quest over current quest");
 
@@ -1253,6 +1267,31 @@ internal sealed class QuestController : MiniTaskController<QuestController>
         return currentStep?.AetheryteShortcut != null &&
                (currentStep.SkipConditions?.AetheryteShortcutIf?.QuestsCompleted.Count ?? 0) == 0 &&
                (currentStep.SkipConditions?.AetheryteShortcutIf?.QuestsAccepted.Count ?? 0) == 0;
+    }
+
+    /// <summary>
+    ///     While any priority quest is flagged accept-only and is ready to be accepted, it is queued as <see cref="NextQuest"/> 
+    ///     so only its accept step (sequence 0) runs; the quest stays in the priority list to be completed later. 
+    ///     The completion phase is therefore deferred until every flagged quest has been accepted (or can no longer be accepted this session)
+    /// </summary>
+    private bool TryQueueNextAcceptOnlyQuest()
+    {
+        if (!_priorityManager.HasPendingAcceptOnly)
+            return false;
+
+        Quest? next = _priorityManager.AcceptOnlyQuests
+            .FirstOrDefault(quest => _questFunctions.IsReadyToAcceptQuest(quest.Id));
+        if (next == null)
+            return false;
+
+        // We are already trying to accept this quest: don't call SetNextQuest again. It rebuilds NextQuest with Step = 0,
+        // which would reset the accept sequence every step boundary and loop it forever before it ever reaches the Interact/accept step.
+        if (NextQuest?.Quest.Id == next.Id)
+            return true;
+
+        _logger.LogInformation("Accept-all: queueing {QuestId} to be accepted before other work", next.Id);
+        SetNextQuest(next);
+        return true;
     }
 
     public bool TryPickPriorityQuest()

--- a/Questionable/Controller/QuestPriorityManager.cs
+++ b/Questionable/Controller/QuestPriorityManager.cs
@@ -15,9 +15,36 @@ internal sealed class QuestPriorityManager(
     private const char ClipboardSeparator = ';';
     private readonly List<Quest> _quests = [];
 
+    /// <summary>
+    ///     Quests in the priority list that should only be <em>accepted</em>, not driven to completion.
+    ///     They are initially automated to acceptance; once accepted they are left to the normal questing rules (to-do list order, same-society batch turn-ins, ...)
+    ///     to complete. They remain visible in the priority list, and marked as accepted, but the priority completion selection always skips them once accepted.
+    /// </summary>
+    private readonly HashSet<ElementId> _acceptOnly = [];
+
     public IReadOnlyList<Quest> Quests => _quests;
     public int Count => _quests.Count;
     public bool IsEmpty => _quests.Count == 0;
+
+    /// <summary>Priority-list quests flagged accept-only, in list order.</summary>
+    public IEnumerable<Quest> AcceptOnlyQuests => _quests.Where(q => _acceptOnly.Contains(q.Id));
+
+    public bool HasPendingAcceptOnly => _acceptOnly.Count > 0;
+
+    public bool IsAcceptOnly(ElementId elementId) => _acceptOnly.Contains(elementId);
+
+    /// <summary>Adds the quest to the priority list (if needed) and flags it as accept-only.</summary>
+    public void MarkAcceptOnly(ElementId elementId)
+    {
+        Add(elementId);
+        if (Contains(elementId))
+            _acceptOnly.Add(elementId);
+    }
+
+    public void ClearAcceptOnly(ElementId elementId) => _acceptOnly.Remove(elementId);
+
+    /// <summary>Clears every accept-only flag (the quests remain in the priority list).</summary>
+    public void ClearAllAcceptOnly() => _acceptOnly.Clear();
 
     public bool Contains(Quest quest) => _quests.Any(q => q.Id == quest.Id);
 
@@ -69,6 +96,8 @@ internal sealed class QuestPriorityManager(
             logger.LogDebug($"Removing {index}: {_quests[index].Info.Name}");
             _quests.RemoveAt(index);
         }
+
+        _acceptOnly.Remove(elementId);
     }
 
     /// <summary>Moves the quest at <paramref name="oldIndex"/> to <paramref name="newIndex"/> (used by drag-drop).</summary>
@@ -82,9 +111,17 @@ internal sealed class QuestPriorityManager(
         _quests.Insert(newIndex, quest);
     }
 
-    public void RemoveCompleted(Func<ElementId, bool> isComplete) => _quests.RemoveAll(q => isComplete(q.Id));
+    public void RemoveCompleted(Func<ElementId, bool> isComplete)
+    {
+        _quests.RemoveAll(q => isComplete(q.Id));
+        _acceptOnly.RemoveWhere(id => isComplete(id));
+    }
 
-    public void Clear() => _quests.Clear();
+    public void Clear()
+    {
+        _quests.Clear();
+        _acceptOnly.Clear();
+    }
 
     public void Import(IEnumerable<ElementId> questElements)
     {

--- a/Questionable/Controller/QuestPriorityManager.cs
+++ b/Questionable/Controller/QuestPriorityManager.cs
@@ -111,10 +111,10 @@ internal sealed class QuestPriorityManager(
         _quests.Insert(newIndex, quest);
     }
 
-    public void RemoveCompleted(Func<ElementId, bool> isComplete)
+    public void RemoveCompleted(Func<ElementId, bool> isComplete, Func<ElementId, bool> isAccepted)
     {
-        _quests.RemoveAll(q => isComplete(q.Id));
-        _acceptOnly.RemoveWhere(id => isComplete(id));
+        _quests.RemoveAll(q => _acceptOnly.Contains(q.Id) ? isAccepted(q.Id) : isComplete(q.Id));
+        _acceptOnly.RemoveWhere(id => _quests.All(q => q.Id != id));
     }
 
     public void Clear()

--- a/Questionable/Windows/JournalComponents/AlliedSocietyJournalComponent.cs
+++ b/Questionable/Windows/JournalComponents/AlliedSocietyJournalComponent.cs
@@ -207,13 +207,25 @@ internal sealed class AlliedSocietyJournalComponent
 
         questJournalUtils.ShowContextMenu(questInfo, quest, nameof(AlliedSocietyJournalComponent));
 
-        if (quest != null && questController.PriorityManager.Contains(quest))
+        if (quest != null)
         {
-            ImGui.SameLine();
-            using (pluginInterface.UiBuilder.IconFontFixedWidthHandle.Push())
-                ImGui.TextColored(QstTheme.Amber, FontAwesomeIcon.ExclamationCircle.ToIconString());
-            if (ImGui.IsItemHovered())
-                ImGui.SetTooltip(_L("This quest is in Priority Quests."));
+            bool acceptOnly = questController.PriorityManager.IsAcceptOnly(quest.Id);
+            bool inPriority = questController.PriorityManager.Contains(quest);
+            if (acceptOnly || inPriority)
+            {
+                bool accepted = acceptOnly && questFunctions.IsQuestAccepted(quest.Id);
+                ImGui.SameLine();
+                using (pluginInterface.UiBuilder.IconFontFixedWidthHandle.Push())
+                    ImGui.TextColored(
+                        acceptOnly ? (accepted ? QstTheme.Success : QstTheme.Accent) : QstTheme.Amber,
+                        (acceptOnly ? FontAwesomeIcon.Inbox : FontAwesomeIcon.ExclamationCircle).ToIconString());
+                if (ImGui.IsItemHovered())
+                    ImGui.SetTooltip(acceptOnly
+                        ? (accepted
+                            ? _L("Accepted; completion follows the normal quest order.")
+                            : _L("Queued to be accepted"))
+                        : _L("This quest is in Priority Quests."));
+            }
         }
     }
 }

--- a/Questionable/Windows/JournalComponents/QuestJournalUtils.cs
+++ b/Questionable/Windows/JournalComponents/QuestJournalUtils.cs
@@ -39,7 +39,8 @@ internal sealed class QuestJournalUtils
         if (!popup)
             return;
 
-        if (label != nameof(PriorityWindow))
+        bool inPriority = quest != null && questController.PriorityManager.Contains(quest);
+        if (label != nameof(PriorityWindow) || inPriority)
         {
             using (ImRaii.Disabled(disabled: true))
             {
@@ -48,18 +49,44 @@ internal sealed class QuestJournalUtils
 
             using (ImRaii.PushIndent())
             {
-                using (ImRaii.Disabled(quest == null))
+                if (label != nameof(PriorityWindow))
                 {
-                    if (ImGui.MenuItem(_L("Add to Priority Quests")) && quest != null)
-                        questController.PriorityManager.Add(quest.Id);
-                }
-                using (ImRaii.Disabled(prereqs.Count == 0 || quest == null))
-                {
-                    if (ImGui.MenuItem(_L("Add all to Priority Quests")) && quest != null)
+                    using (ImRaii.Disabled(quest == null))
                     {
-                        foreach (var qInfo in prereqs)
-                            questController.PriorityManager.Add(qInfo.QuestId);
-                        questController.PriorityManager.Add(quest.Id);
+                        if (ImGui.MenuItem(_L("Add to Priority Quests")) && quest != null)
+                            questController.PriorityManager.Add(quest.Id);
+
+                        if (ImGui.MenuItem(_L("Add to Priority Quests as Accept Only")) && quest != null)
+                            questController.PriorityManager.MarkAcceptOnly(quest.Id);
+                    }
+                    using (ImRaii.Disabled(prereqs.Count == 0 || quest == null))
+                    {
+                        if (ImGui.MenuItem(_L("Add all to Priority Quests")) && quest != null)
+                        {
+                            foreach (var qInfo in prereqs)
+                                questController.PriorityManager.Add(qInfo.QuestId);
+                            questController.PriorityManager.Add(quest.Id);
+                        }
+
+                        if (ImGui.MenuItem(_L("Add all to Priority Quests as Accept Only")) && quest != null)
+                        {
+                            foreach (var qInfo in prereqs)
+                                questController.PriorityManager.MarkAcceptOnly(qInfo.QuestId);
+                            questController.PriorityManager.MarkAcceptOnly(quest.Id);
+                        }
+                    }
+                }
+                else if (inPriority && quest != null)
+                {
+                    if (questController.PriorityManager.IsAcceptOnly(quest.Id))
+                    {
+                        if (ImGui.MenuItem(_L("Change to normal priority quest")))
+                            questController.PriorityManager.ClearAcceptOnly(quest.Id);
+                    }
+                    else
+                    {
+                        if (ImGui.MenuItem(_L("Change to accept only")))
+                            questController.PriorityManager.MarkAcceptOnly(quest.Id);
                     }
                 }
             }

--- a/Questionable/Windows/JournalComponents/QuestJournalUtils.cs
+++ b/Questionable/Windows/JournalComponents/QuestJournalUtils.cs
@@ -194,6 +194,24 @@ internal sealed class QuestJournalUtils
                 questController.PriorityManager.Remove(quest.QuestId);
         }
 
+        // Queues every quest in the group to be accepted before any of them is completed. Unlike
+        // "Add all to Priority Quests" (which does each quest start-to-finish one at a time), this lets the
+        // user pick up several quests in a group (such as allied societies' dailies) at once,
+        // the completion/turn-ins only start once everything queued has been accepted from the priority queue.
+        // Does not auto-start questionable, that is up to the user.
+        if (ImGui.MenuItem(_L("Accept all quests")))
+        {
+            foreach (IQuestInfo quest in quests)
+            {
+                // Only queue quests we can actually accept right now. This skips ones already completed
+                // (e.g. today's daily is done) and ones already accepted (the normal rules complete those).
+                // FIXME: This probably could allow you to add upcoming quests to get auto-accepted too, or at least better understand why you can't accept them.
+                //        For example: if you have a lvl 90 quest and lvl 80 class, it says you are not ready, but you might have a lvl 100 class you could accept with.
+                if (questFunctions.IsReadyToAcceptQuest(quest.QuestId))
+                    questController.PriorityManager.MarkAcceptOnly(quest.QuestId);
+            }
+        }
+
         if (ImGui.MenuItem(_L("Sim first quest")))
             if (quests.Count >= 1)
                 questController.SimulateQuest(quests[0], 0, 0);

--- a/Questionable/Windows/PriorityWindow.cs
+++ b/Questionable/Windows/PriorityWindow.cs
@@ -108,7 +108,7 @@ internal sealed class PriorityWindow : LWindow
             if (ImGuiComponentsLocal.IconButtonWithText(FontAwesomeIcon.Upload, _L("Export to Clipboard")))
                 ExportToClipboard();
             if (ImGuiComponentsLocal.IconButtonWithText(FontAwesomeIcon.Check, _L("Remove finished Quests")))
-                _questController.PriorityManager.RemoveCompleted(_questFunctions.IsQuestComplete);
+                _questController.PriorityManager.RemoveCompleted(_questFunctions.IsQuestComplete, _questFunctions.IsQuestAccepted);
             ImGui.SameLine();
 
             using (ImRaii.Disabled(!ImGui.IsKeyDown(ImGuiKey.ModCtrl)))

--- a/Questionable/Windows/PriorityWindow.cs
+++ b/Questionable/Windows/PriorityWindow.cs
@@ -153,6 +153,20 @@ internal sealed class PriorityWindow : LWindow
                 ImGui.Text(quest.Info.Name);
                 hovered |= ImGui.IsItemHovered();
 
+                if (_questController.PriorityManager.IsAcceptOnly(quest.Id))
+                {
+                    bool accepted = _questFunctions.IsQuestAccepted(quest.Id);
+                    ImGui.SameLine();
+                    ImGui.AlignTextToFramePadding();
+                    using (_pluginInterface.UiBuilder.IconFontFixedWidthHandle.Push())
+                        ImGui.TextColored(accepted ? QstTheme.Success : QstTheme.Accent,
+                            FontAwesomeIcon.Inbox.ToIconString());
+                    if (ImGui.IsItemHovered())
+                        ImGui.SetTooltip(accepted
+                            ? _L("Accepted — completion follows the normal quest order.")
+                            : _L("Accept only — picked up before any queued quest is completed."));
+                }
+
                 if (hovered)
                     _questTooltipComponent.Draw(quest.Info);
 

--- a/Questionable/Windows/PriorityWindow.cs
+++ b/Questionable/Windows/PriorityWindow.cs
@@ -153,6 +153,11 @@ internal sealed class PriorityWindow : LWindow
                 ImGui.Text(quest.Info.Name);
                 hovered |= ImGui.IsItemHovered();
 
+                if (hovered)
+                    _questTooltipComponent.Draw(quest.Info);
+
+                _questJournalUtils.ShowContextMenu(quest.Info, quest, nameof(PriorityWindow));
+
                 if (_questController.PriorityManager.IsAcceptOnly(quest.Id))
                 {
                     bool accepted = _questFunctions.IsQuestAccepted(quest.Id);
@@ -166,11 +171,6 @@ internal sealed class PriorityWindow : LWindow
                             ? _L("Accepted — completion follows the normal quest order.")
                             : _L("Accept only — picked up before any queued quest is completed."));
                 }
-
-                if (hovered)
-                    _questTooltipComponent.Draw(quest.Info);
-
-                _questJournalUtils.ShowContextMenu(quest.Info, quest, nameof(PriorityWindow));
 
                 if (priorityQuests.Count > 1)
                 {


### PR DESCRIPTION
Changes made to introduce accept only quests into the priority queue.

This was changed to decrease questing time, as well as appear more natural when completing allied society quests.

Claude Opus 4.8 was used to help understand the codebase and make some suggestions, but every line of code in here was written or copy+pasted manually by myself during editing and testing.