### PR TITLE
Interact step: Auto switch classes to resume partially completed quests

### DIFF
--- a/Questionable/Controller/QuestPriorityManager.cs
+++ b/Questionable/Controller/QuestPriorityManager.cs
@@ -113,7 +113,11 @@ internal sealed class QuestPriorityManager(
 
     public void RemoveCompleted(Func<ElementId, bool> isComplete, Func<ElementId, bool> isAccepted)
     {
-        _quests.RemoveAll(q => _acceptOnly.Contains(q.Id) ? isAccepted(q.Id) : isComplete(q.Id));
+        // First remove everything that's completed (any kind), then remove accept-only quests that have
+        // been accepted (picked up) but not completed. Normal priority quests that are merely accepted and
+        // still in progress are left alone. Keeps the accept-only flags in sync with whatever remains.
+        _quests.RemoveAll(q => isComplete(q.Id));
+        _quests.RemoveAll(q => _acceptOnly.Contains(q.Id) && isAccepted(q.Id));
         _acceptOnly.RemoveWhere(id => _quests.All(q => q.Id != id));
     }
 

--- a/Questionable/Controller/Steps/Interactions/Interact.cs
+++ b/Questionable/Controller/Steps/Interactions/Interact.cs
@@ -312,6 +312,30 @@ internal static class Interact
                 }
             }
 
+            // A class/job quest can only be progressed on the class it was accepted with — otherwise the game
+            // blocks with "You cannot continue this quest until the following conditions are met: Required
+            // Class/Job: X". Accepting a batch of quests (e.g. the accept-only flow) can leave a different
+            // class active, so before interacting to progress/complete an accepted quest, switch back to its
+            // accept class if needed. LookupQuestStartJob returns Job.ADV for quests with no such lock.
+            // So, even if a user manually interferes this allows us to resume questing with the correct class type :)
+            if (Task.Quest != null &&
+                InteractionType is EInteractionType.CompleteQuest or EInteractionType.Interact &&
+                objectTable[0] is IPlayerCharacter completionPlayer)
+            {
+                Job requiredJob = classJobUtils.LookupQuestStartJob(Task.Quest.Id);
+                if (requiredJob != Job.ADV && (Job)completionPlayer.ClassJob.Value.RowId != requiredJob)
+                {
+                    logger.LogInformation("Quest {QuestId} must be continued as {RequiredJob}, switching from {CurrentJob}",
+                        Task.Quest.Id, requiredJob, (Job)completionPlayer.ClassJob.Value.RowId);
+                    if (!classJobUtils.SwitchClassJob(requiredJob))
+                        throw new Exception($"Quest {Task.Quest.Info.Name} must be continued as {requiredJob}, " +
+                                            "but you do not have a gearset for that job.");
+
+                    _continueAt = DateTime.Now.AddSeconds(0.2);
+                    return ETaskResult.StillRunning;
+                }
+            }
+
             bool isTargetable = gameObject.IsTargetable;
             bool hasAnyMarker = HasAnyMarker(gameObject);
             if (!isTargetable || !hasAnyMarker)


### PR DESCRIPTION
Accept-only quest acception caught this edge case, where a quest accepted as one type needs to be switched back to resume. Example: Accept quest A as combat class, switch to class B as crafter, then complete quest B, resume quest A as crafter will fail. Now we switch back to combat class to resume.