### PR TITLE
fix(886): Attune to Camp Dragonhead aetheryte earlier

### DIFF
--- a/QuestPaths/2.x - A Realm Reborn/MSQ-2/B6-Coerthas Central Highlands, Camp Dragonhead/886_The Unending War.json
+++ b/QuestPaths/2.x - A Realm Reborn/MSQ-2/B6-Coerthas Central Highlands, Camp Dragonhead/886_The Unending War.json
@@ -34,6 +34,25 @@
           "TaxiStandId": 1179679
         },
         {
+          "$": "Unlock Camp Dragonhead aetheryte now so that we can TP back in case we die",
+          "TerritoryId": 155,
+          "StopDistance": 5,
+          "InteractionType": "AttuneAetheryte",
+          "Aetheryte": "Coerthas Central Highlands - Camp Dragonhead"
+        },
+        {
+          "$": "Camp Dragonhead taxi",
+          "DataId": 1006802,
+          "Position": {
+            "X": 195.81897,
+            "Y": 302.34818,
+            "Z": -167.86456
+          },
+          "TerritoryId": 155,
+          "InteractionType": "UnlockTaxiStand",
+          "TaxiStandId": 1179680
+        },
+        {
           "TerritoryId": 155,
           "InteractionType": "EquipRecommended"
         },

--- a/QuestPaths/2.x - A Realm Reborn/MSQ-2/B6-Coerthas Central Highlands, Camp Dragonhead/890_The Rose and the Unicorn.json
+++ b/QuestPaths/2.x - A Realm Reborn/MSQ-2/B6-Coerthas Central Highlands, Camp Dragonhead/890_The Rose and the Unicorn.json
@@ -45,24 +45,6 @@
       "Sequence": 255,
       "Steps": [
         {
-          "TerritoryId": 155,
-          "StopDistance": 5,
-          "InteractionType": "AttuneAetheryte",
-          "Aetheryte": "Coerthas Central Highlands - Camp Dragonhead"
-        },
-        {
-          "$": "Camp Dragonhead taxi",
-          "DataId": 1006802,
-          "Position": {
-            "X": 195.81897,
-            "Y": 302.34818,
-            "Z": -167.86456
-          },
-          "TerritoryId": 155,
-          "InteractionType": "UnlockTaxiStand",
-          "TaxiStandId": 1179680
-        },
-        {
           "DataId": 1006384,
           "Position": {
             "X": 263.5996,


### PR DESCRIPTION
fix(886): Attune to Camp Dragonhead aetheryte earlier so questing can resume if the character dies in the zone

This takes us slightly out of the way, but it allows the character to get back if they somehow die, like during the combat step.