### PR TITLE
The Rak'tika Greatwood sidequests and All Too Fleeting

### DIFF
--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3440_Barking Up the Right Tree.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3440_Barking Up the Right Tree.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-13"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027747,
+          "Position": {
+            "X": -15.2438,
+            "Y": -25.0096,
+            "Z": 314.473
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -163.54651,
+            "Y": -10.257885,
+            "Z": 292.6211
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -735.61646,
+            "Y": 6.66683,
+            "Z": 244.76266
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2009779,
+          "Position": {
+            "X": -733.08923,
+            "Y": 8.255066,
+            "Z": 242.63367
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact"
+        },
+        {
+          "Position": {
+            "X": -665.6097,
+            "Y": 15.6246395,
+            "Z": 232.49106
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2009778,
+          "Position": {
+            "X": -668.2994,
+            "Y": 16.617004,
+            "Z": 231.98291
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact"
+        },
+        {
+          "Position": {
+            "X": -716.33325,
+            "Y": 17.327301,
+            "Z": 147.71632
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2009777,
+          "Position": {
+            "X": -717.89124,
+            "Y": 17.868286,
+            "Z": 147.08167
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact"
+        },
+        {
+          "Position": {
+            "X": -849.77484,
+            "Y": 11.277738,
+            "Z": 271.94867
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2009780,
+          "Position": {
+            "X": -847.2267,
+            "Y": 9.292725,
+            "Z": 270.83228
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "Position": {
+            "X": -15.2438,
+            "Y": -25.0096,
+            "Z": 314.473
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Rak'tika - Slitherbough"
+        },
+        {
+          "DataId": 1027747,
+          "Position": {
+            "X": -15.2438,
+            "Y": -25.0096,
+            "Z": 314.473
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3441_Plans Gone Awry.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3441_Plans Gone Awry.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-08"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027746,
+          "Position": {
+            "X": -94.6742,
+            "Y": -19.5428,
+            "Z": 334.733
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -154.88077,
+            "Y": -16.147165,
+            "Z": 293.14914
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "DataId": 1028922,
+          "Position": {
+            "X": -320.685,
+            "Y": 15.2436,
+            "Z": 193.48
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Say",
+          "Fly": true,
+          "ChatMessage": {
+            "Key": "TEXT_LUCKZE007_03441_SYSTEM_100_011"
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1029141,
+          "Position": {
+            "X": -469.273,
+            "Y": 4.36047,
+            "Z": 260.421
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Say",
+          "Fly": true,
+          "ChatMessage": {
+            "Key": "TEXT_LUCKZE007_03441_SYSTEM_100_021"
+          }
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027746,
+          "Position": {
+            "X": -94.6742,
+            "Y": -19.5428,
+            "Z": 334.733
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "AetheryteShortcut": "Rak'tika - Slitherbough",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZE007_03441_Q1_000_020",
+              "Answer": "TEXT_LUCKZE007_03441_A1_000_021"
+            },
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZE007_03441_Q1_000_020",
+              "Answer": "TEXT_LUCKZE007_03441_A1_000_022"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3442_Like Pulling Teeth.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3442_Like Pulling Teeth.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-08"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1029874,
+          "Position": {
+            "X": -29.0446,
+            "Y": -25.0005,
+            "Z": 286.103
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -168.82904,
+            "Y": -12.455409,
+            "Z": 294.79294
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "DataId": 1029875,
+          "Position": {
+            "X": -511.116,
+            "Y": 0,
+            "Z": 262.62
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Snipe",
+          "Fly": true,
+          "Comment": "Use the blowgun on the razor-tusked swine"
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1029875,
+          "Position": {
+            "X": -511.116,
+            "Y": 0,
+            "Z": 262.62
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 2010621,
+          "Position": {
+            "X": -563.888,
+            "Y": 1.06593,
+            "Z": 164.296
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "Position": {
+            "X": -62.4685,
+            "Y": -19.246405,
+            "Z": 305.7575
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "DataId": 1029874,
+          "Position": {
+            "X": -29.0446,
+            "Y": -25.0005,
+            "Z": 286.103
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Slitherbough"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3443_Tea Time.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3443_Tea Time.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027463,
+          "Position": {
+            "X": -130.259,
+            "Y": -18.4867,
+            "Z": 246.595
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2010017,
+          "Position": {
+            "X": -621.857,
+            "Y": 7.81763,
+            "Z": 720.628
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002521,
+          "Fly": true,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 128]
+        },
+        {
+          "DataId": 2010018,
+          "Position": {
+            "X": -611.344,
+            "Y": 14.7296,
+            "Z": 783.063
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002521,
+          "Fly": true,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 64]
+        },
+        {
+          "DataId": 2010019,
+          "Position": {
+            "X": -638.994,
+            "Y": 10.6508,
+            "Z": 732.072
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002521,
+          "Fly": true,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 32]
+        },
+        {
+          "DataId": 2010020,
+          "Position": {
+            "X": -604.883,
+            "Y": 11.5693,
+            "Z": 764.492
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002521,
+          "Fly": true,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 16]
+        },
+        {
+          "DataId": 2010021,
+          "Position": {
+            "X": -617.426,
+            "Y": 14.3475,
+            "Z": 771.908
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002521,
+          "Fly": true,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 8]
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2009786,
+          "Position": {
+            "X": -621.84,
+            "Y": 7.76171,
+            "Z": 720.594
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 128]
+        },
+        {
+          "DataId": 2009787,
+          "Position": {
+            "X": -611.31,
+            "Y": 14.6955,
+            "Z": 783.001
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 64]
+        },
+        {
+          "DataId": 2009791,
+          "Position": {
+            "X": -638.973,
+            "Y": 10.6004,
+            "Z": 731.919
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 32]
+        },
+        {
+          "DataId": 2009792,
+          "Position": {
+            "X": -605.005,
+            "Y": 11.5832,
+            "Z": 764.434
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 16]
+        },
+        {
+          "DataId": 2009793,
+          "Position": {
+            "X": -617.592,
+            "Y": 14.2371,
+            "Z": 772
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 8]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027463,
+          "Position": {
+            "X": -130.259,
+            "Y": -18.4867,
+            "Z": 246.595
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Slitherbough"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3445_In His Memory.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3445_In His Memory.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "Position": {
+            "X": -303.0998,
+            "Y": 8.4904175,
+            "Z": 711.1436
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1029024,
+          "Position": {
+            "X": -301.534,
+            "Y": 8.68231,
+            "Z": 711.299
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1029878,
+          "Position": {
+            "X": -295.125,
+            "Y": 7.49219,
+            "Z": 591.821
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Sprint": false
+        },
+        {
+          "DataId": 1029878,
+          "Position": {
+            "X": -295.125,
+            "Y": 7.49219,
+            "Z": 591.821
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WaitForNpcAtPosition",
+          "NpcWaitDistance": 5,
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "DataId": 1029878,
+          "Position": {
+            "X": -295.12476,
+            "Y": 7.516978,
+            "Z": 591.82104
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Comment": "Speak with Varthon"
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": -444.81573,
+            "Y": 2.4261475,
+            "Z": 530.2357
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "Position": {
+            "X": -444.81573,
+            "Y": 2.4261475,
+            "Z": 530.2357
+          },
+          "StopDistance": 0.5,
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [
+            11114,
+            11115
+          ],
+          "Mount": false,
+          "Sprint": false
+        },
+        {
+          "DataId": 2009794,
+          "Position": {
+            "X": -444.81573,
+            "Y": 2.4261475,
+            "Z": 530.2357
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WaitForNpcAtPosition",
+          "NpcWaitDistance": 2
+        },
+        {
+          "DataId": 2009794,
+          "Position": {
+            "X": -444.81573,
+            "Y": 2.4261475,
+            "Z": 530.2357
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Comment": "Find the abandoned blade"
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1029879,
+          "Position": {
+            "X": -445.465,
+            "Y": 2.46754,
+            "Z": 531.341
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Comment": "Speak with Varthon"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1029024,
+          "Position": {
+            "X": -301.534,
+            "Y": 8.68231,
+            "Z": 711.299
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Slitherbough",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3447_Worth a Candle.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3447_Worth a Candle.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-05-08"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027742,
+          "Position": {
+            "X": -115.26,
+            "Y": -18.8731,
+            "Z": 311.176
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2009788,
+          "Position": {
+            "X": -6.88277,
+            "Y": -24.149,
+            "Z": 296.03
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002526,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 128]
+        },
+        {
+          "DataId": 2009789,
+          "Position": {
+            "X": -122.583,
+            "Y": -19.7087,
+            "Z": 374.476
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002526,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 64]
+        },
+        {
+          "DataId": 2009790,
+          "Position": {
+            "X": -105.979,
+            "Y": -18.766,
+            "Z": 384.894
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002526,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 32]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027742,
+          "Position": {
+            "X": -115.26,
+            "Y": -18.8731,
+            "Z": 311.176
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Slitherbough"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3448_Paved with Good Intentions.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3448_Paved with Good Intentions.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1030825,
+          "Position": {
+            "X": -105.329,
+            "Y": -19.6756,
+            "Z": 377.143
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -149.15567,
+            "Y": -17.420284,
+            "Z": 293.8361
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -237.4252,
+            "Y": -2.634516,
+            "Z": 325.70593
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "DataId": 1030826,
+          "Position": {
+            "X": -235.70612,
+            "Y": 15.298737,
+            "Z": -34.28705
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1031190,
+          "Position": {
+            "X": -234.394,
+            "Y": 15.6813,
+            "Z": -35.3247
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Emote",
+          "Emote": "doubt",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZE014_03448_Q1_000_000",
+              "Answer": "TEXT_LUCKZE014_03448_A1_000_001"
+            },
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZE014_03448_Q1_000_000",
+              "Answer": "TEXT_LUCKZE014_03448_A1_000_002"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031191,
+          "Position": {
+            "X": -124.193,
+            "Y": -19.0535,
+            "Z": 282.856
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Slitherbough",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3449_You're a Gem.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3449_You're a Gem.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027754,
+          "Position": {
+            "X": -108.193,
+            "Y": -19.6844,
+            "Z": 380.263
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -108.14495,
+            "Y": -19.31591,
+            "Z": 339.8015
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "DataId": 1029142,
+          "Position": {
+            "X": -604.073,
+            "Y": 0,
+            "Z": 570.225
+          },
+          "StopDistance": 1,
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": -582.49115,
+            "Y": -0.6,
+            "Z": 538.5119
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -582.49115,
+            "Y": -0.6,
+            "Z": 538.5119
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Dive"
+        },
+        {
+          "DataId": 2009795,
+          "Position": {
+            "X": -548.012,
+            "Y": -38.9125,
+            "Z": 515.257
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 128]
+        },
+        {
+          "DataId": 2009796,
+          "Position": {
+            "X": -600.186,
+            "Y": -54.7925,
+            "Z": 521.921
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 64]
+        },
+        {
+          "DataId": 2009797,
+          "Position": {
+            "X": -586.587,
+            "Y": -59.4006,
+            "Z": 496.783
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 32]
+        },
+        {
+          "DataId": 2009798,
+          "Position": {
+            "X": -594.775,
+            "Y": -38.0159,
+            "Z": 553.157
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 16]
+        },
+        {
+          "DataId": 2009799,
+          "Position": {
+            "X": -596.382,
+            "Y": -55.1217,
+            "Z": 493.466
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 8]
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "Position": {
+            "X": -604.073,
+            "Y": 0,
+            "Z": 570.225
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Mount": true
+        },
+        {
+          "DataId": 1029142,
+          "Position": {
+            "X": -604.073,
+            "Y": 0,
+            "Z": 570.225
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027754,
+          "Position": {
+            "X": -108.193,
+            "Y": -19.6844,
+            "Z": 380.263
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Slitherbough"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3450_Oh, Snap.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3450_Oh, Snap.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027741,
+          "Position": {
+            "X": -80.3239,
+            "Y": -19.1014,
+            "Z": 299.839
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -149.15567,
+            "Y": -17.420284,
+            "Z": 293.8361
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -237.4252,
+            "Y": -2.634516,
+            "Z": 325.70593
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "DataId": 2009800,
+          "Position": {
+            "X": -312.978,
+            "Y": 4.9966,
+            "Z": 86.4728
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterItemUse",
+          "ItemId": 2002524,
+          "KillEnemyDataIds": [
+            11116
+          ],
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027741,
+          "Position": {
+            "X": -80.3239,
+            "Y": -19.1014,
+            "Z": 299.839
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Slitherbough",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3451_Disturbing the Peace.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3451_Disturbing the Peace.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027745,
+          "Position": {
+            "X": -132.076,
+            "Y": -23.3466,
+            "Z": 229.641
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -215.018,
+            "Y": 28.3467,
+            "Z": -97.5255
+          },
+          "StopDistance": 0.5,
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [
+            11091,
+            11091,
+            11117
+          ],
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027745,
+          "Position": {
+            "X": -132.076,
+            "Y": -23.3466,
+            "Z": 229.641
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Slitherbough",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3452_Out of Place.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3452_Out of Place.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1031191,
+          "Position": {
+            "X": -124.193,
+            "Y": -19.0535,
+            "Z": 282.856
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -321.58942,
+            "Y": 20.166122,
+            "Z": 86.88705
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "DataId": 2010610,
+          "Position": {
+            "X": -320.21063,
+            "Y": 20.828491,
+            "Z": 85.74036
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -423.8814,
+            "Y": 10.179164,
+            "Z": 65.81899
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "DataId": 2010611,
+          "Position": {
+            "X": -425.28424,
+            "Y": 11.764648,
+            "Z": 65.659546
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -567.3167,
+            "Y": 3.972926,
+            "Z": 31.589968
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "DataId": 2010612,
+          "Position": {
+            "X": -569.90924,
+            "Y": 3.829956,
+            "Z": 30.71643
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterInteraction",
+          "KillEnemyDataIds": [
+            11118
+          ],
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031191,
+          "Position": {
+            "X": -124.193,
+            "Y": -19.0535,
+            "Z": 282.856
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Slitherbough",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3453_From the Heart.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3453_From the Heart.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1031341,
+          "Position": {
+            "X": -131.456,
+            "Y": -17.5416,
+            "Z": 253.834
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1031343,
+          "Position": {
+            "X": -50.5532,
+            "Y": 19.9921,
+            "Z": -60.4105
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1031344,
+          "Position": {
+            "X": -696.254,
+            "Y": -0.320496,
+            "Z": 114.183
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1031345,
+          "Position": {
+            "X": -705.296,
+            "Y": 2.8089,
+            "Z": 292.443
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031341,
+          "Position": {
+            "X": -131.456,
+            "Y": -17.5416,
+            "Z": 253.834
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Slitherbough",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZE019_03453_Q1_000_000",
+              "Answer": "TEXT_LUCKZE019_03453_A1_000_001"
+            },
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZE019_03453_Q1_000_000",
+              "Answer": "TEXT_LUCKZE019_03453_A1_000_002"
+            },
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZE019_03453_Q1_000_000",
+              "Answer": "TEXT_LUCKZE019_03453_A1_000_003"
+            }
+          ],
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3454_The Arrow Points the Way.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3454_The Arrow Points the Way.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027750,
+          "Position": {
+            "X": -24.7349,
+            "Y": -25.3453,
+            "Z": 305.592
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -62.337532,
+            "Y": -19.236605,
+            "Z": 305.17218
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -128.89526,
+            "Y": 18.205256,
+            "Z": 717.1751
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2010658,
+          "Position": {
+            "X": -127.61127,
+            "Y": 18.875366,
+            "Z": 719.87476
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027750,
+          "Position": {
+            "X": -24.7349,
+            "Y": -25.3453,
+            "Z": 305.592
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Slitherbough",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3455_An Express Delivery.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3455_An Express Delivery.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1031303,
+          "Position": {
+            "X": -144.705,
+            "Y": -23.3466,
+            "Z": 228.549
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -412.8938,
+            "Y": 1.6467507,
+            "Z": 497.75082
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "DataId": 1031350,
+          "Position": {
+            "X": -412.37506,
+            "Y": 1.9149826,
+            "Z": 499.53455
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZE021_03455_Q1_000_000",
+              "Answer": "TEXT_LUCKZE021_03455_A1_000_001"
+            },
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZE021_03455_Q1_000_000",
+              "Answer": "TEXT_LUCKZE021_03455_A1_000_002"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031303,
+          "Position": {
+            "X": -144.705,
+            "Y": -23.3466,
+            "Z": 228.549
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Slitherbough",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3460_Paying Respects.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3460_Paying Respects.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027715,
+          "Position": {
+            "X": 411.241,
+            "Y": 33.6378,
+            "Z": -128.5
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1031351,
+          "Position": {
+            "X": 155.542,
+            "Y": -8.71511,
+            "Z": 324.084
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2009938,
+          "Position": {
+            "X": 185.8396,
+            "Y": -11.7647705,
+            "Z": 396.07837
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2009938,
+          "Position": {
+            "X": 185.8396,
+            "Y": -11.7647705,
+            "Z": 396.07837
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002568,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 128]
+        },
+        {
+          "DataId": 2009939,
+          "Position": {
+            "X": 86.900024,
+            "Y": -20.706482,
+            "Z": 523.58276
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2009939,
+          "Position": {
+            "X": 86.900024,
+            "Y": -20.706482,
+            "Z": 523.58276
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002568,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 64]
+        },
+        {
+          "DataId": 2009940,
+          "Position": {
+            "X": 109.30029,
+            "Y": -25.28424,
+            "Z": 595.6664
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2009940,
+          "Position": {
+            "X": 109.30029,
+            "Y": -25.28424,
+            "Z": 595.6664
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002568,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 32]
+        },
+        {
+          "DataId": 2009941,
+          "Position": {
+            "X": 168.5664,
+            "Y": -27.634155,
+            "Z": 710.2921
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2009941,
+          "Position": {
+            "X": 168.5664,
+            "Y": -27.634155,
+            "Z": 710.2921
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002568,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 16]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "Position": {
+            "X": 411.241,
+            "Y": 33.6378,
+            "Z": -128.5
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true
+        },
+        {
+          "DataId": 1027715,
+          "Position": {
+            "X": 411.241,
+            "Y": 33.6378,
+            "Z": -128.5
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3461_A Recipe for Trouble.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3461_A Recipe for Trouble.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "Position": {
+            "X": 346.97427,
+            "Y": 7.4945126,
+            "Z": -138.33932
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "DataId": 1027732,
+          "Position": {
+            "X": 336.812,
+            "Y": 7.96076,
+            "Z": -154.925
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 346.97427,
+            "Y": 7.4945126,
+            "Z": -138.33932
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 356.29654,
+            "Y": 38.27366,
+            "Z": -129.45145
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 579.638,
+            "Y": 20.0514,
+            "Z": 74.4075
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "ComplexCombatData": [
+            {
+              "DataId": 10286,
+              "MinimumKillCount": 2,
+              "RewardItemId": 2002570,
+              "RewardItemCount": 2
+            }
+          ],
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 2009951,
+          "Position": {
+            "X": 266.751,
+            "Y": 20.8405,
+            "Z": 343.073
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002570,
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 2009952,
+          "Position": {
+            "X": 250.157,
+            "Y": 20.7814,
+            "Z": 350.369
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterInteraction",
+          "KillEnemyDataIds": [
+            11119
+          ],
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "Position": {
+            "X": 346.97427,
+            "Y": 7.4945126,
+            "Z": -138.33932
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true,
+          "AetheryteShortcut": "Rak'tika - Fanow"
+        },
+        {
+          "DataId": 1027732,
+          "Position": {
+            "X": 336.812,
+            "Y": 7.96076,
+            "Z": -154.925
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3462_Blessings of the Wood.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3462_Blessings of the Wood.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027716,
+          "Position": {
+            "X": 494.991,
+            "Y": -6.55534,
+            "Z": -224.915
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1029888,
+          "Position": {
+            "X": 339.285,
+            "Y": 0.512984,
+            "Z": 163.63
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": 336.55447,
+            "Y": 0.37424934,
+            "Z": 164.44731
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 336.55447,
+            "Y": 0.37424934,
+            "Z": 164.44731
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Emote",
+          "Emote": "pray",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027716,
+          "Position": {
+            "X": 494.991,
+            "Y": -6.55534,
+            "Z": -224.915
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3463_Talk of the Town.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3463_Talk of the Town.json
@@ -1,0 +1,192 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027714,
+          "Position": {
+            "X": 349.533,
+            "Y": 7.49451,
+            "Z": -124.802
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 419.3228,
+            "Y": 33.637783,
+            "Z": -107.16951
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031369,
+          "Position": {
+            "X": 418.38696,
+            "Y": 33.63778,
+            "Z": -107.89661
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 1031369,
+          "Position": {
+            "X": 418.38696,
+            "Y": 33.63778,
+            "Z": -107.89661
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002861,
+          "Fly": true,
+          "Land": true,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 128]
+        },
+        {
+          "Position": {
+            "X": 291.646,
+            "Y": 34.2428,
+            "Z": -149.737
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031370,
+          "Position": {
+            "X": 291.646,
+            "Y": 34.2428,
+            "Z": -149.737
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 1031370,
+          "Position": {
+            "X": 291.646,
+            "Y": 34.2428,
+            "Z": -149.737
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002861,
+          "Fly": true,
+          "Land": true,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 64]
+        },
+        {
+          "Position": {
+            "X": 449.538,
+            "Y": 18.9669,
+            "Z": -52.5691
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031371,
+          "Position": {
+            "X": 449.538,
+            "Y": 18.9669,
+            "Z": -52.5691
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 1031371,
+          "Position": {
+            "X": 449.538,
+            "Y": 18.9669,
+            "Z": -52.5691
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002861,
+          "Fly": true,
+          "Land": true,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 32]
+        },
+        {
+          "Position": {
+            "X": 320.385,
+            "Y": 20.5108,
+            "Z": -220.174
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031372,
+          "Position": {
+            "X": 320.385,
+            "Y": 20.5108,
+            "Z": -220.174
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "DataId": 1031372,
+          "Position": {
+            "X": 320.385,
+            "Y": 20.5108,
+            "Z": -220.174
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002861,
+          "Fly": true,
+          "Land": true,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 16]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027714,
+          "Position": {
+            "X": 349.533,
+            "Y": 7.49451,
+            "Z": -124.802
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3464_A Sight Unseen.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3464_A Sight Unseen.json
@@ -1,0 +1,181 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1029992,
+          "Position": {
+            "X": 506.587,
+            "Y": -6.59444,
+            "Z": -223.617
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 544.48724,
+            "Y": 19.734953,
+            "Z": -32.69986
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1029994,
+          "Position": {
+            "X": 544.09094,
+            "Y": 19.614407,
+            "Z": -34.28705
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": 556.0911,
+            "Y": 20.856443,
+            "Z": 27.860317
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "Position": {
+            "X": 556.0911,
+            "Y": 20.856443,
+            "Z": 27.860317
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [
+            11120,
+            11120
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "Position": {
+            "X": 544.2397,
+            "Y": 19.726952,
+            "Z": -32.682693
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1029994,
+          "Position": {
+            "X": 544.09094,
+            "Y": 19.614407,
+            "Z": -34.28705
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 4,
+      "Steps": [
+        {
+          "DataId": 2009973,
+          "Position": {
+            "X": 260.295,
+            "Y": 19.1989,
+            "Z": 426.171
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 5,
+      "Steps": [
+        {
+          "DataId": 1029994,
+          "Position": {
+            "X": 544.09094,
+            "Y": 19.614407,
+            "Z": -34.28705
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 6,
+      "Steps": [
+        {
+          "DataId": 1029995,
+          "Position": {
+            "X": 80.91858,
+            "Y": 23.19898,
+            "Z": 37.827026
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1029992,
+          "Position": {
+            "X": 506.587,
+            "Y": -6.59444,
+            "Z": -223.617
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3465_Back Where It Belongs.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3465_Back Where It Belongs.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "Position": {
+            "X": 427.9154,
+            "Y": 33.637783,
+            "Z": -113.15743
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1027711,
+          "Position": {
+            "X": 429.862,
+            "Y": 34.0517,
+            "Z": -114.855
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 206.10101,
+            "Y": 19.048128,
+            "Z": 123.162636
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2010659,
+          "Position": {
+            "X": 204.48608,
+            "Y": 18.997375,
+            "Z": 121.782104
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": -61.72873,
+            "Y": -19.20542,
+            "Z": 305.18402
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Rak'tika - Slitherbough",
+          "Fly": true
+        },
+        {
+          "DataId": 1031413,
+          "Position": {
+            "X": -15.396423,
+            "Y": -24.84297,
+            "Z": 317.3723
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo"
+        },
+        {
+          "DataId": 1031413,
+          "Position": {
+            "X": -15.396423,
+            "Y": -24.84297,
+            "Z": 317.3723
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027711,
+          "Position": {
+            "X": 429.862,
+            "Y": 34.0517,
+            "Z": -114.855
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3466_Not Unfamiliar.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3466_Not Unfamiliar.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+  "Sequence": 0,
+  "Steps": [
+    {
+      "Position": {
+        "X": 392.00415,
+        "Y": 33.637783,
+        "Z": -127.34448
+      },
+      "TerritoryId": 817,
+      "InteractionType": "WalkTo",
+      "Fly": true,
+      "Land": true
+    },
+    {
+      "DataId": 1031380,
+          "Position": {
+            "X": 390.5,
+            "Y": 33.6378,
+            "Z": -128.446
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1031380,
+          "Position": {
+            "X": 390.5,
+            "Y": 33.6378,
+            "Z": -128.446
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true,
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZF007_03466_Q1_000_000",
+              "Answer": "TEXT_LUCKZF007_03466_A1_000_001"
+            },
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZF007_03466_Q2_000_000",
+              "Answer": "TEXT_LUCKZF007_03466_A2_000_001"
+            },
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZF007_03466_Q3_000_000",
+              "Answer": "TEXT_LUCKZF007_03466_A3_000_001"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031529,
+          "Position": {
+            "X": 291.128,
+            "Y": 34.5424,
+            "Z": -169.485
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3468_Delivery Time.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3468_Delivery Time.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1031379,
+          "Position": {
+            "X": 329.154,
+            "Y": 20.5108,
+            "Z": -221.772
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 445.06396,
+            "Y": 34.05174,
+            "Z": -117.043915
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1027713,
+          "Position": {
+            "X": 446.708,
+            "Y": 34.0429,
+            "Z": -117.174
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 128]
+        },
+        {
+          "Position": {
+            "X": 346.4371,
+            "Y": 7.4945126,
+            "Z": -137.59
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1027732,
+          "Position": {
+            "X": 336.812,
+            "Y": 7.96076,
+            "Z": -154.925
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true,
+          "CompletionQuestVariablesFlags": [null, null, null, null, null, 64]
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "Position": {
+            "X": 347.06573,
+            "Y": 12.121795,
+            "Z": -159.64252
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "DataId": 1031379,
+          "Position": {
+            "X": 329.154,
+            "Y": 20.5108,
+            "Z": -221.772
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031379,
+          "Position": {
+            "X": 329.154,
+            "Y": 20.5108,
+            "Z": -221.772
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002862,
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031379,
+          "Position": {
+            "X": 329.154,
+            "Y": 20.5108,
+            "Z": -221.772
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002863,
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031379,
+          "Position": {
+            "X": 329.154,
+            "Y": 20.5108,
+            "Z": -221.772
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3469_Out on One's Own.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3469_Out on One's Own.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1031384,
+          "Position": {
+            "X": 363.684,
+            "Y": 7.96077,
+            "Z": -110.172
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 403.81396,
+            "Y": 1.2500684,
+            "Z": 115.35318
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "DataId": 1031385,
+          "Position": {
+            "X": 401.96838,
+            "Y": 1.0936476,
+            "Z": 117.96753
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": 670.3939,
+            "Y": 21.32556,
+            "Z": 71.11557
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 670.3939,
+            "Y": 21.32556,
+            "Z": 71.11557
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [
+            11121,
+            11121,
+            11121
+          ],
+          "Fly": true
+        },
+        {
+          "DataId": 1031386,
+          "Position": {
+            "X": 673.6704,
+            "Y": 20.957172,
+            "Z": 71.61047
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WaitForNpcAtPosition",
+          "NpcWaitDistance": 5
+        },
+        {
+          "DataId": 1031386,
+          "Position": {
+            "X": 673.6704,
+            "Y": 20.957172,
+            "Z": 71.61047
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031384,
+          "Position": {
+            "X": 363.684,
+            "Y": 7.96077,
+            "Z": -110.172
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3470_One Last Bite.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3470_One Last Bite.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "Position": {
+            "X": 423.9512,
+            "Y": 34.11471,
+            "Z": -139.3184
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031388,
+          "Position": {
+            "X": 421.8661,
+            "Y": 34.114716,
+            "Z": -140.91711
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1031389,
+          "Position": {
+            "X": 319.837,
+            "Y": 33.7629,
+            "Z": -159.233
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": 266.74936,
+            "Y": -19.493479,
+            "Z": 669.26196
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031536,
+          "Position": {
+            "X": 269.6726,
+            "Y": -19.542128,
+            "Z": 669.2759
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031536,
+          "Position": {
+            "X": 269.6726,
+            "Y": -19.542128,
+            "Z": 669.2759
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002889,
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031389,
+          "Position": {
+            "X": 319.837,
+            "Y": 33.7629,
+            "Z": -159.233
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031389,
+          "Position": {
+            "X": 319.837,
+            "Y": 33.7629,
+            "Z": -159.233
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002890,
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031389,
+          "Position": {
+            "X": 319.837,
+            "Y": 33.7629,
+            "Z": -159.233
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3471_Proving Your Worth.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3471_Proving Your Worth.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1031390,
+          "Position": {
+            "X": 413.182,
+            "Y": 33.6378,
+            "Z": -93.2044
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1031391,
+          "Position": {
+            "X": 165.1178,
+            "Y": -0.3133182,
+            "Z": -579.61395
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": 161.23354,
+            "Y": 1.2180228,
+            "Z": -765.8135
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [
+            10279
+          ],
+          "CombatItemUse": {
+            "ItemId": 2002884,
+            "Condition": "Health%",
+            "Value": 50
+          },
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 3,
+      "Steps": [
+        {
+          "DataId": 1031391,
+          "Position": {
+            "X": 165.1178,
+            "Y": -0.3133182,
+            "Z": -579.61395
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031390,
+          "Position": {
+            "X": 413.182,
+            "Y": 33.6378,
+            "Z": -93.2044
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3472_Reach for the Stars.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3472_Reach for the Stars.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1027712,
+          "Position": {
+            "X": 454.194,
+            "Y": 6.95506,
+            "Z": -193.072
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 11122,
+          "Position": {
+            "X": 253.427,
+            "Y": -19.5168,
+            "Z": -427.718
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterItemUse",
+          "ItemId": 2002580,
+          "KillEnemyDataIds": [
+            11123
+          ],
+          "Fly": true
+        },
+        {
+          "DataId": 11122,
+          "Position": {
+            "X": 270.817,
+            "Y": -12.9606,
+            "Z": -588.606
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AfterItemUse",
+          "ItemId": 2002580,
+          "KillEnemyDataIds": [
+            11123
+          ],
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "Position": {
+            "X": 447.179,
+            "Y": 9.284755,
+            "Z": -193.96558
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "DataId": 1027712,
+          "Position": {
+            "X": 454.1847,
+            "Y": 6.955061,
+            "Z": -193.07245
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3473_Down Feathers.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3473_Down Feathers.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "Position": {
+            "X": 345.6171,
+            "Y": 7.4945126,
+            "Z": -128.36385
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "DataId": 1031416,
+          "Position": {
+            "X": 343.70935,
+            "Y": 7.494513,
+            "Z": -126.05481
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 151.06435,
+            "Y": -9.612667,
+            "Z": 357.59778
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "DataId": 1031392,
+          "Position": {
+            "X": 147.9972,
+            "Y": -9.294524,
+            "Z": 357.90027
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "DataId": 1031393,
+          "Position": {
+            "X": 147.17322,
+            "Y": -9.212592,
+            "Z": 357.1068
+          },
+          "TerritoryId": 817,
+          "InteractionType": "UseItem",
+          "ItemId": 2002883
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031416,
+          "Position": {
+            "X": 343.70935,
+            "Y": 7.494513,
+            "Z": -126.05481
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3474_Out on Patrol.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3474_Out on Patrol.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "Position": {
+            "X": 425.74005,
+            "Y": 33.637783,
+            "Z": -119.50773
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "DataId": 1027713,
+          "Position": {
+            "X": 446.70776,
+            "Y": 34.051743,
+            "Z": -117.17407
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -574.3393,
+            "Y": -0.2748211,
+            "Z": 246.70798
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Rak'tika - Slitherbough",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -574.3393,
+            "Y": -0.2748211,
+            "Z": 246.70798
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Dive",
+          "StopDistance": 1
+        },
+        {
+          "Position": {
+            "X": -592.3887,
+            "Y": -92.6507,
+            "Z": 330.95844
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -592.69855,
+            "Y": -92.30932,
+            "Z": 311.9579
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -590.17487,
+            "Y": -79.80276,
+            "Z": 263.6639
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "DataId": 2009990,
+          "Position": {
+            "X": -592.0043,
+            "Y": -78.75183,
+            "Z": 260.97498
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -592.69855,
+            "Y": -92.30932,
+            "Z": 311.9579
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -592.3887,
+            "Y": -92.6507,
+            "Z": 330.95844
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -593.06824,
+            "Y": -82.50561,
+            "Z": 422.3752
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "DataId": 2009988,
+          "Position": {
+            "X": -593.01135,
+            "Y": -80.82703,
+            "Z": 420.95056
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -794.64276,
+            "Y": -52.391052,
+            "Z": 284.6216
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -799.0626,
+            "Y": -91.151375,
+            "Z": 270.12384
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -799.96466,
+            "Y": -94.43886,
+            "Z": 228.22961
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": -798.172,
+            "Y": -81.18833,
+            "Z": 235.96161
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "DataId": 2009989,
+          "Position": {
+            "X": -800.1373,
+            "Y": -79.75891,
+            "Z": 236.8352
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "Position": {
+            "X": 425.74005,
+            "Y": 33.637783,
+            "Z": -119.50773
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true
+        },
+        {
+          "DataId": 1027713,
+          "Position": {
+            "X": 446.70776,
+            "Y": 34.051743,
+            "Z": -117.17407
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3475_Thoughts and Prayers.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3475_Thoughts and Prayers.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "Position": {
+            "X": 377.01016,
+            "Y": 7.9607677,
+            "Z": -123.62875
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031394,
+          "Position": {
+            "X": 375.63123,
+            "Y": 7.9607677,
+            "Z": -123.73547
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZF016_03475_Q1_000_000",
+              "Answer": "TEXT_LUCKZF016_03475_A1_000_001"
+            }
+          ],
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": -469.28986,
+            "Y": -0.3,
+            "Z": 359.39944
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 2010729,
+          "Position": {
+            "X": -469.28986,
+            "Y": -0.3,
+            "Z": 359.39944
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "AetheryteShortcut": "Rak'tika - Slitherbough",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "Position": {
+            "X": -305.2543,
+            "Y": 12.606354,
+            "Z": 128.09271
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "ComplexCombatData": [
+            {
+              "DataId": 10295,
+              "MinimumKillCount": 1,
+              "RewardItemId": 2002891,
+              "RewardItemCount": 1
+            }
+          ],
+          "Fly": true
+        }
+      ]
+    },
+    {
+    "Sequence": 255,
+    "Steps": [
+        {
+          "Position": {
+            "X": 377.01016,
+            "Y": 7.9607677,
+            "Z": -123.62875
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031394,
+          "Position": {
+            "X": 375.63123,
+            "Y": 7.9607677,
+            "Z": -123.73547
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3476_Rock Solid.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3476_Rock Solid.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "Position": {
+            "X": 332.38208,
+            "Y": 20.51081,
+            "Z": -215.36412
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031395,
+          "Position": {
+            "X": 333.11963,
+            "Y": 20.51081,
+            "Z": -213.30585
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1031396,
+          "Position": {
+            "X": 117.984,
+            "Y": -1.15555,
+            "Z": -376.211
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": 74.693085,
+            "Y": -20.000038,
+            "Z": -560.63
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [
+            11160,
+            11160
+          ],
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031398,
+          "Position": {
+            "X": 74.937,
+            "Y": -20.0046,
+            "Z": -564.446
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WaitForNpcAtPosition",
+          "NpcWaitDistance": 5
+        },
+        {
+          "DataId": 1031398,
+          "Position": {
+            "X": 74.937,
+            "Y": -20.0046,
+            "Z": -564.446
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1031395,
+          "Position": {
+            "X": 333.148,
+            "Y": 20.5108,
+            "Z": -213.277
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3483_In Pursuit of Knowledge.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3483_In Pursuit of Knowledge.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "Position": {
+            "X": 345.36945,
+            "Y": 7.4945126,
+            "Z": -137.96248
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 335.00082,
+            "Y": 7.960762,
+            "Z": -143.8893
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo"
+        },
+        {
+          "DataId": 1027717,
+          "Position": {
+            "X": 334.18774,
+            "Y": 7.960762,
+            "Z": -141.46643
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Rak'tika - Fanow"
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1031399,
+          "Position": {
+            "X": -605.877,
+            "Y": 22.8632,
+            "Z": -173.165
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Emote",
+          "Emote": "doubt",
+          "AetheryteShortcut": "Rak'tika - Slitherbough",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": -614.501,
+            "Y": 28.6302,
+            "Z": -283.261
+          },
+          "StopDistance": 1,
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "OverworldEnemies",
+          "KillEnemyDataIds": [
+            10674,
+            10675,
+            10676
+          ],
+          "Fly": true,
+          "Land": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "Position": {
+            "X": 440.26855,
+            "Y": 34.051743,
+            "Z": -108.2323
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true
+        },
+        {
+          "DataId": 1031400,
+          "Position": {
+            "X": 440.26855,
+            "Y": 34.051743,
+            "Z": -108.2323
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3484_A Test of Strength.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3484_A Test of Strength.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-16"
+  },
+  "$": "Authored with LLM assistance, changes must be reviewed and owned by a human.\nInitial version reviewed and owned by @qianzhouyi2",
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "Position": {
+            "X": 349.69202,
+            "Y": 7.4945126,
+            "Z": -127.00523
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1027714,
+          "Position": {
+            "X": 349.5078,
+            "Y": 7.4945126,
+            "Z": -124.80359
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "Position": {
+            "X": 557.04913,
+            "Y": 26.807156,
+            "Z": 138.81181
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031401,
+          "Position": {
+            "X": 556.75586,
+            "Y": 26.861193,
+            "Z": 139.8794
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 2,
+      "Steps": [
+        {
+          "Position": {
+            "X": 249.18459,
+            "Y": -66.52561,
+            "Z": -123.772446
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 249.18459,
+            "Y": -66.52561,
+            "Z": -123.772446
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [
+            11168
+          ],
+          "CombatDelaySecondsAtStart": 0,
+          "Mount": false
+        },
+        {
+          "DataId": 2010723,
+          "Position": {
+            "X": 241.35193,
+            "Y": -66.331055,
+            "Z": -122.453674
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "DelaySecondsAtStart": 5,
+          "Fly": true,
+          "Mount": false
+        },
+        {
+          "Position": {
+            "X": 102.04852,
+            "Y": 38.524307,
+            "Z": -160.11539
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 102.04852,
+            "Y": 38.524307,
+            "Z": -160.11539
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [
+            11169
+          ],
+          "CombatDelaySecondsAtStart": 0,
+          "Mount": false
+        },
+        {
+          "DataId": 2010724,
+          "Position": {
+            "X": 99.77869,
+            "Y": 38.651123,
+            "Z": -156.17609
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "DelaySecondsAtStart": 5,
+          "Fly": true,
+          "Mount": false
+        },
+        {
+          "Position": {
+            "X": 628.8899,
+            "Y": 12.333022,
+            "Z": -382.83636
+          },
+          "TerritoryId": 817,
+          "InteractionType": "WalkTo",
+          "Fly": true
+        },
+        {
+          "Position": {
+            "X": 628.8899,
+            "Y": 12.333022,
+            "Z": -382.83636
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [
+            11170
+          ],
+          "CombatDelaySecondsAtStart": 0,
+          "Mount": false
+        },
+        {
+          "Position": {
+            "X": 628.8899,
+            "Y": 12.333022,
+            "Z": -382.83636
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Combat",
+          "EnemySpawnType": "AutoOnEnterArea",
+          "KillEnemyDataIds": [
+            11149
+          ],
+          "CombatDelaySecondsAtStart": 5,
+          "Mount": false
+        },
+        {
+          "DataId": 2010725,
+          "Position": {
+            "X": 630.3043,
+            "Y": 11.856201,
+            "Z": -387.50293
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "DelaySecondsAtStart": 5,
+          "Fly": true,
+          "Mount": false
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1027714,
+          "Position": {
+            "X": 349.5078,
+            "Y": 7.4945126,
+            "Z": -124.80359
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "AetheryteShortcut": "Rak'tika - Slitherbough",
+          "Fly": true
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3485_Just the Two of Us.json
+++ b/QuestPaths/5.x - Shadowbringers/Side Quests/The Rak'tika Greatwood/3485_Just the Two of Us.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "$": "Authored with LLM assistance, changes must be reviewed and owned by a human.\nInitial version reviewed and owned by @qianzhouyi2",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "Position": {
+            "X": 462.96976,
+            "Y": 17.897255,
+            "Z": -48.859463
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031405,
+          "Position": {
+            "X": 456.9314,
+            "Y": 18.978712,
+            "Z": -73.10602
+          },
+          "TerritoryId": 817,
+          "InteractionType": "AcceptQuest",
+          "Mount": false,
+          "Fly": false
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 1031406,
+          "Position": {
+            "X": 39.2919,
+            "Y": 8.4,
+            "Z": 365.316
+          },
+          "TerritoryId": 817,
+          "InteractionType": "Interact",
+          "Fly": true
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "Position": {
+            "X": 462.96976,
+            "Y": 17.897255,
+            "Z": -48.859463
+          },
+          "TerritoryId": 817,
+          "InteractionType": "None",
+          "AetheryteShortcut": "Rak'tika - Fanow",
+          "Fly": true,
+          "Land": true
+        },
+        {
+          "DataId": 1031405,
+          "Position": {
+            "X": 456.9314,
+            "Y": 18.978712,
+            "Z": -73.10602
+          },
+          "TerritoryId": 817,
+          "InteractionType": "CompleteQuest",
+          "DialogueChoices": [
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZF204_03485_Q1_000_000",
+              "Answer": "TEXT_LUCKZF204_03485_A1_000_001"
+            },
+            {
+              "Type": "List",
+              "Prompt": "TEXT_LUCKZF204_03485_Q1_000_000",
+              "Answer": "TEXT_LUCKZF204_03485_A1_000_002"
+            }
+          ],
+          "Mount": false,
+          "Fly": false
+        }
+      ]
+    }
+  ]
+}

--- a/QuestPaths/7.x - Dawntrail/Side Stories/Occult Crescent/Relics/5506_All Too Fleeting.json
+++ b/QuestPaths/7.x - Dawntrail/Side Stories/Occult Crescent/Relics/5506_All Too Fleeting.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://qstxiv.github.io/schema/quest-v1.json",
+  "Author": "Saputello",
+  "LastChecked": {
+    "Username": "Saputello",
+    "Date": "2026-08-15"
+  },
+  "QuestSequence": [
+    {
+      "Sequence": 0,
+      "Steps": [
+        {
+          "DataId": 1053906,
+          "Position": {
+            "X": 25.802979,
+            "Y": -2.2634694E-07,
+            "Z": 13.38208
+          },
+          "TerritoryId": 1278,
+          "InteractionType": "AcceptQuest",
+          "AetheryteShortcut": "Tuliyollal",
+          "AethernetShortcut": [
+            "[Tuliyollal] Aetheryte Plaza",
+            "[Tuliyollal] Phantom Village"
+          ]
+        }
+      ]
+    },
+    {
+      "Sequence": 1,
+      "Steps": [
+        {
+          "DataId": 2015436,
+          "Position": {
+            "X": 27.2428,
+            "Y": 0,
+            "Z": 11.2162
+          },
+          "TerritoryId": 1278,
+          "InteractionType": "Interact"
+        }
+      ]
+    },
+    {
+      "Sequence": 255,
+      "Steps": [
+        {
+          "DataId": 1053906,
+          "Position": {
+            "X": 25.802979,
+            "Y": -2.2634694E-07,
+            "Z": 13.38208
+          },
+          "TerritoryId": 1278,
+          "InteractionType": "CompleteQuest"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION

Paths:
- 3440 Barking Up the Right Tree
- 3441 Plans Gone Awry
- 3442 Like Pulling Teeth
- 3443 Tea Time
- 3445 In His Memory
- 3447 Worth a Candle
- 3448 Paved with Good Intentions
- 3449 You're a Gem
- 3450 Oh, Snap
- 3451 Disturbing the Peace
- 3452 Out of Place
- 3453 From the Heart
- 3454 The Arrow Points the Way
- 3455 An Express Delivery
- 3460 Paying Respects
- 3461 A Recipe for Trouble
- 3462 Blessings of the Wood
- 3463 Talk of the Town
- 3464 A Sight Unseen
- 3465 Back Where It Belongs
- 3466 Not Unfamiliar
- 3468 Delivery Time
- 3469 Out on One's Own
- 3470 One Last Bite
- 3471 Proving Your Worth
- 3472 Reach for the Stars
- 3473 Down Feathers
- 3474 Out on Patrol
- 3475 Thoughts and Prayers
- 3476 Rock Solid
- 3483 In Pursuit of Knowledge
- 3484 A Test of Strength
- 3485 Just the Two of Us
- 5506 All Too Fleeting
All paths have been checked in-game.