### PR TITLE
Proposed fix for available or active Allied Quests being removed from Priority window by 'remove finished' button

### DIFF
--- a/Questionable/Functions/QuestFunctions.cs
+++ b/Questionable/Functions/QuestFunctions.cs
@@ -688,6 +688,20 @@ internal sealed unsafe class QuestFunctions
 
     public bool IsQuestComplete(UnlockLinkId unlockLinkId) => UIState.Instance()->IsUnlockLinkUnlocked(unlockLinkId.Value);
 
+    public bool IsQuestFinishedForPriorityRemoval(ElementId elementId)
+    {
+        if (elementId is QuestId questId && IsDailyAlliedSocietyQuest(questId))
+        {
+            // If currently accepted, not removable
+            if (IsQuestAccepted(questId))
+                return false;
+            // Allied only remove if completed today
+            return QuestManager.Instance()->IsDailyQuestCompleted(questId.Value);
+        }
+
+        return IsQuestComplete(elementId);
+    }
+    
     public (bool, string[]?) IsQuestLocked(ElementId elementId, ElementId? extraCompletedQuest = null)
     {
         if (elementId is QuestId questId)

--- a/Questionable/Windows/PriorityWindow.cs
+++ b/Questionable/Windows/PriorityWindow.cs
@@ -115,7 +115,7 @@ internal sealed class PriorityWindow : LWindow
             if (ImGuiComponentsLocal.IconButtonWithText(FontAwesomeIcon.Upload, _L("Export to Clipboard")))
                 ExportToClipboard();
             if (ImGuiComponentsLocal.IconButtonWithText(FontAwesomeIcon.Check, _L("Remove finished Quests")))
-                _questController.PriorityManager.RemoveCompleted(_questFunctions.IsQuestComplete, _questFunctions.IsQuestAccepted);
+                _questController.PriorityManager.RemoveCompleted(_questFunctions.IsQuestFinishedForPriorityRemoval,_questFunctions.IsQuestAccepted);
             ImGui.SameLine();
 
             using (ImRaii.Disabled(!ImGui.IsKeyDown(ImGuiKey.ModCtrl)))


### PR DESCRIPTION
Added helper and changed button behaviour slightly