### PR TITLE
Add Completed Quests filter to Journal

### DIFF
--- a/Questionable/Windows/JournalComponents/QuestJournalComponent.cs
+++ b/Questionable/Windows/JournalComponents/QuestJournalComponent.cs
@@ -438,7 +438,9 @@ internal sealed class QuestJournalComponent
         if (filter.HideNoPaths &&
             (!questRegistry.TryGetQuest(questInfo.QuestId, out Quest? quest) || quest.Root.Disabled))
             return false;
-
+        
+        if (filter.HideCompleted && questFunctions.IsQuestComplete(questInfo.QuestId))
+            return false;
         return true;
     }
 
@@ -460,16 +462,21 @@ internal sealed class QuestJournalComponent
     {
         public bool AvailableOnly;
         public bool HideNoPaths;
+        public bool HideCompleted;
         public string SearchText = string.Empty;
 
-        public bool AdvancedFiltersActive => AvailableOnly || HideNoPaths;
+        public bool AdvancedFiltersActive =>
+            AvailableOnly ||
+            HideNoPaths ||
+            HideCompleted;
 
         public FilterConfiguration WithoutName()
         {
             return new()
             {
                 AvailableOnly = AvailableOnly,
-                HideNoPaths = HideNoPaths
+                HideNoPaths = HideNoPaths,
+                HideCompleted = HideCompleted
             };
         }
     }

--- a/Questionable/Windows/JournalComponents/QuestJournalUtils.cs
+++ b/Questionable/Windows/JournalComponents/QuestJournalUtils.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Interface;
@@ -195,7 +195,8 @@ internal sealed class QuestJournalUtils
             return;
 
         if (ImGui.Checkbox(_L("Show only Available Quests"), ref journalUi.Filter.AvailableOnly) ||
-            ImGui.Checkbox(_L("Hide Quests Without Path"), ref journalUi.Filter.HideNoPaths))
+            ImGui.Checkbox(_L("Hide Quests Without Path"), ref journalUi.Filter.HideNoPaths) ||
+            ImGui.Checkbox(_L("Hide Completed Quests"), ref journalUi.Filter.HideCompleted))
         {
             journalUi.UpdateFilter();
         }


### PR DESCRIPTION
Added a checkbox for filter historically completed quests from the journal - Doesn't hide unobtainable quests from different branches, like mutually exclusive GC quests for starting cities.