### PR TITLE
Support Target field in SinglePlayerDutyOptions; unload error fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Feature: Priority preset to unlock Level Cap Dungeons roulette -alydev
+- Feature: Added override so quest paths can specify a target for the start of solo duties -alydev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
+- Bug fix: unload error resolved. You may need to restart your game to properly unload Questionable to load this new update, apologies. -alydev
 - Feature: Added override so quest paths can specify a target for the start of solo duties -alydev

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup Condition="$(MSBuildProjectName) != 'GatheringPathRenderer'">
-        <Version>15.306.3.19</Version>
+        <Version>15.306.3.20</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/QuestPaths/4.x - Stormblood/Allied Societies/Kojin/Story/2977_A Test of Courage.json
+++ b/QuestPaths/4.x - Stormblood/Allied Societies/Kojin/Story/2977_A Test of Courage.json
@@ -76,7 +76,7 @@
           "TerritoryId": 613,
           "InteractionType": "SinglePlayerDuty",
           "Comment": "Please report in discord whether this solo duty works fine.\nIt has not been tested yet and may fail. Thank you.",
-          "SinglePlayerDutyOptions": {"Enabled": true},
+          "SinglePlayerDutyOptions": {"Enabled": false},
           "Fly": true
         }
       ]

--- a/QuestPaths/7.x - Dawntrail/Role Quests/Healer/4829_An Antidote for Anarchy.json
+++ b/QuestPaths/7.x - Dawntrail/Role Quests/Healer/4829_An Antidote for Anarchy.json
@@ -47,7 +47,7 @@
           },
           "TerritoryId": 137,
           "InteractionType": "SinglePlayerDuty",
-          "SinglePlayerDutyOptions": {"Enabled": true}
+          "SinglePlayerDutyOptions": {"Enabled": true, "Target": 16983}
         }
       ]
     },

--- a/QuestPaths/7.x - Dawntrail/Role Quests/Magical Ranged/4847_Heroes and Pretenders.json
+++ b/QuestPaths/7.x - Dawntrail/Role Quests/Magical Ranged/4847_Heroes and Pretenders.json
@@ -31,7 +31,7 @@
           },
           "TerritoryId": 957,
           "InteractionType": "SinglePlayerDuty",
-          "SinglePlayerDutyOptions": {"Enabled": true},
+          "SinglePlayerDutyOptions": {"Enabled": true, "Target": 17034},
           "AetheryteShortcut": "Radz-at-Han",
           "AethernetShortcut": [
             "[Radz-at-Han] Aetheryte Plaza",

--- a/QuestPaths/quest-v1.json
+++ b/QuestPaths/quest-v1.json
@@ -1739,6 +1739,10 @@
                     "maximum": 1,
                     "description": "If a quest has multiple solo instances (which affects 5 quests total), indicates which one this is"
                   },
+                  "Target": {
+                    "type": "integer",
+                    "description": "The DataId to target at the start of the instance"
+                  },
                   "TestedBossModVersion": {
                     "type": "string",
                     "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$"

--- a/Questionable.Model/Questing/SinglePlayerDutyOptions.cs
+++ b/Questionable.Model/Questing/SinglePlayerDutyOptions.cs
@@ -6,4 +6,5 @@ public sealed class SinglePlayerDutyOptions
     public bool Enabled { get; set; }
     public List<string> Notes { get; set; } = [];
     public byte Index { get; set; }
+    public int? Target { get; set; }
 }

--- a/Questionable/Controller/MovementController.cs
+++ b/Questionable/Controller/MovementController.cs
@@ -26,7 +26,7 @@ internal sealed class MovementController
     AetheryteData aetheryteData,
     ICommandManager commandManager,
     IChatGui chatGui,
-    IServiceProvider serviceProvider,
+    Lazy<QuestController> questController,
     ILogger<MovementController> logger) : IDisposable
 {
     public const float DefaultVerticalInteractionDistance = 1.95f;
@@ -168,7 +168,7 @@ internal sealed class MovementController
             }
         }
 
-        if (serviceProvider.GetRequiredService<QuestController>().IsQuestingStopped)
+        if (questController.Value.IsQuestingStopped)
         {
             // if (EzThrottler.Throttle("qstwouldhavejumpedin", 5000))
             //     logger.LogDebug("Questionable would have jumped in here to do something, but decided against it.");

--- a/Questionable/Controller/Steps/Interactions/SinglePlayerDuty.cs
+++ b/Questionable/Controller/Steps/Interactions/SinglePlayerDuty.cs
@@ -46,6 +46,7 @@ internal static class SinglePlayerDuty
         public const ushort EgistentialCrisis = 701;
         public const ushort Nightkin = 676;
         public const ushort WarmthOfFamily = 1244;
+        public const ushort BarThePassage = 1246;
     }
 
     internal sealed class Factory
@@ -253,6 +254,40 @@ internal static class SinglePlayerDuty
                         "Wait(leg exposed)");
                     yield return new SetTarget(17992);
                 }
+                else if (tId == SpecialTerritories.BarThePassage)
+                {
+                    yield return new EnableAi();
+                    yield return new WaitCondition.Task(
+                    () =>
+                    {
+                        if (clientState.TerritoryType != SpecialTerritories.BarThePassage)
+                            return true;
+                        return !condition[ConditionFlag.SufferingStatusAffliction63];
+                    },
+                    "Wait(in event)");
+                    Vector3[] points = [
+                            new(0f, 0f, -300f),
+                            new(0f, 0f, -300f),
+                            new(0f, 0f, -270f),
+                            new(0f, 0f, 78f),
+                            new(0f, 0f, 103f),
+                            new(0f, 0f, 361f),
+                    ];
+                    foreach (Vector3 point in points)
+                    {
+                        yield return new WaitAtEnd.WaitDelay(TimeSpan.FromSeconds(2));
+                        yield return new WaitCondition.Task(
+                            () =>
+                            {
+                                if (clientState.TerritoryType != SpecialTerritories.BarThePassage)
+                                    return true;
+                                return !condition[ConditionFlag.InCombat];
+                            },
+                            "Wait(in combat)");
+                        yield return new MoveTask(SpecialTerritories.BarThePassage, point);
+                    }
+                    yield return new SetTarget(18032);
+                }
 
                 //else if (tId == SpecialTerritories.ViperTutorial)
                 //{
@@ -287,6 +322,9 @@ internal static class SinglePlayerDuty
                 //}
                 else
                     yield return new EnableAi(tId == SpecialTerritories.Naadam);
+
+                if (step.SinglePlayerDutyOptions?.Target != null)
+                    yield return new SetTarget((uint)step.SinglePlayerDutyOptions.Target);
 
                 yield return new WaitSinglePlayerDuty(cfcId);
                 yield return new DisableAi();

--- a/Questionable/DalamudInitializer.cs
+++ b/Questionable/DalamudInitializer.cs
@@ -20,6 +20,7 @@ internal sealed class DalamudInitializer : IDisposable
     private readonly IChatGui _chatGui;
     private readonly IToastGui _toastGui;
     private readonly WindowSystem _windowSystem;
+    private bool _disposed;
 
     public DalamudInitializer(
         IDalamudPluginInterface pluginInterface,
@@ -87,6 +88,13 @@ internal sealed class DalamudInitializer : IDisposable
 
     public void Dispose()
     {
+        // Idempotent: QuestionablePlugin.DisposeAsync calls this up-front to unhook Dalamud event
+        // sources before the DI container is disposed, and MS.DI then calls it again during the
+        // container's own disposal walk. Second call must be a no-op.
+        if (_disposed)
+            return;
+        _disposed = true;
+
         _toastGui.QuestToast -= OnQuestToast;
         _toastGui.ErrorToast -= OnErrorToast;
         _toastGui.Toast -= OnToast;

--- a/Questionable/QuestionablePlugin.cs
+++ b/Questionable/QuestionablePlugin.cs
@@ -52,6 +52,24 @@ public sealed class QuestionablePlugin(
     public async ValueTask DisposeAsync()
     {
         var serviceProvider = Interlocked.Exchange(ref _serviceProvider, value: null);
+
+        // Unhook Dalamud event sources (Framework.Update, UiBuilder callbacks, toast hooks, ...)
+        // before disposing the container. MS.DI marks the root scope as disposed at the *start* of
+        // Dispose/DisposeAsync, so any GetService call after that point throws ObjectDisposedException.
+        // Under IAsyncDalamudPlugin.DisposeAsync the framework thread can tick between "scope flagged
+        // disposed" and DalamudInitializer being reached in the disposal walk, and other singletons'
+        // per-frame container access would blow up. Disposing DalamudInitializer up-front removes the
+        // event subscriptions before that window opens; its Dispose is idempotent so MS.DI's later
+        // disposal pass is a no-op.
+        try
+        {
+            serviceProvider?.GetService<DalamudInitializer>()?.Dispose();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Container already torn down elsewhere — nothing to unhook.
+        }
+
         if (serviceProvider is IAsyncDisposable asyncDisposable)
             await asyncDisposable.DisposeAsync().ConfigureAwait(false);
         else
@@ -136,6 +154,11 @@ public sealed class QuestionablePlugin(
         // a second independently-constructed instance.
         serviceCollection.AddSingleton<IAetheryteTerritoryProvider>(sp => sp.GetRequiredService<AetheryteData>());
         serviceCollection.AddSingleton<IQuestValidator>(sp => sp.GetRequiredService<JsonSchemaValidator>());
+
+        // Breaks the QuestController <-> MovementController ctor cycle without handing MovementController
+        // the whole IServiceProvider. Once .Value is evaluated the container isn't touched again, so a
+        // framework tick during shutdown can't hit a disposed scope through this path.
+        serviceCollection.AddSingleton(sp => new Lazy<QuestController>(sp.GetRequiredService<QuestController>));
 
         var serviceProvider = serviceCollection.BuildServiceProvider();
         Initialize(serviceProvider);

--- a/Questionable/Windows/QuestComponents/CreationUtilsComponent.cs
+++ b/Questionable/Windows/QuestComponents/CreationUtilsComponent.cs
@@ -264,7 +264,8 @@ internal sealed class CreationUtilsComponent
         {
             if (objectTable[0] != null)
             {
-                ImGui.Text(_LF("Distance: {0:F2} ({1}y)",
+                ImGui.Text($"<{_savedPos.Value.X:F3},{_savedPos.Value.Y:F3},{_savedPos.Value.Z:F3}>" +
+                        _LF("Distance: {0:F2} ({1}y)",
                     (_savedPos.Value - objectTable[0]!.Position).Length(),
                     Math.Floor(_savedPos.Value.DistanceTo_XZ(objectTable[0]!.Position)) - 1));
                 ImGui.SameLine();


### PR DESCRIPTION
Added ability to set initial target of a solo duty in a quest path. might fix a lot of cases where the only thing preventing a solo duty from running is targeting a boss. Below is summary of LLM-assisted fix for unload error introduced by IAsyncDalamudPlugin change @Kagekazu 

---

   **Fix ObjectDisposedException on plugin unload**

   Since moving to `IAsyncDalamudPlugin`, unloading Questionable could throw `ObjectDisposedException` from
 `MovementController.Update` via `IFramework.Update`. MS.DI's `ServiceProviderEngineScope` marks itself disposed at the
 *start* of `DisposeAsync`, before walking the disposable list. Under the async plugin lifecycle Dalamud's framework
 thread can tick between "scope flagged disposed" and `DalamudInitializer` being reached in the disposal walk, so
 `MovementController.Update`'s per-frame `IServiceProvider.GetRequiredService<QuestController>()` blew up on a dead
 container. The classic sync `Dispose` path masked this because teardown ran inline without yielding the framework
 thread.

   Changes:

   - **`QuestionablePlugin.DisposeAsync`**: resolve and `Dispose()` `DalamudInitializer` before disposing the container
 (wrapped in `try/catch (ObjectDisposedException)` for the already-torn-down case), so Dalamud event subscriptions
 (`Framework.Update`, `UiBuilder.*`, toast hooks) are gone before the scope is flagged disposed.
   - **`DalamudInitializer.Dispose`**: added a `_disposed` guard so the explicit pre-container call plus MS.DI's later
 disposal walk are both safe.
   - **`MovementController`**: replaced the `IServiceProvider` constructor parameter with `Lazy<QuestController>`,
 breaking the `QuestController` ↔ `MovementController` ctor cycle without a runtime container lookup on the hot path.
 Registered explicitly as `AddSingleton(sp => new Lazy<QuestController>(sp.GetRequiredService<QuestController>))`
 (MS.DI doesn't auto-provide `Lazy<T>`).

   Verified with `dotnet build -c Release Questionable/Questionable.csproj` (0 warnings, 0 errors) and by reloading the
 plugin locally — the unload error no longer reproduces.

   **AI/LLM disclosure**: implemented with Claude Opus 4.7 via pi. Diagnosis, fix design, and code were reviewed and
 are owned by @alydevs.