### PR TITLE
Update jobGearSets in interact.cs to force include non-combat

### DIFF
--- a/Questionable/Controller/Steps/Interactions/Interact.cs
+++ b/Questionable/Controller/Steps/Interactions/Interact.cs
@@ -137,7 +137,7 @@ internal static class Interact
         ///     prior to the next step (in case we're attacked).
         /// </summary>
         private bool delayedFinalCheck;
-        private ReadOnlyCollection<(Job ClassJob, short Level, short ItemLevel)> jobGearSets = classJobUtils.GetJobGearSets();
+        private ReadOnlyCollection<(Job ClassJob, short Level, short ItemLevel)> jobGearSets = classJobUtils.GetJobGearSets(combat: false);
 
         public Quest? Quest => Task.Quest;
         public EInteractionType InteractionType { get; set; }


### PR DESCRIPTION
seems to work perfectly, tested across multiple quests, including role specific