### PR TITLE
Wait for Rising Stones transition before interior pathfinding

### DIFF
--- a/Questionable/Controller/Steps/Shared/AetheryteShortcut.cs
+++ b/Questionable/Controller/Steps/Shared/AetheryteShortcut.cs
@@ -80,6 +80,7 @@ internal static class AetheryteShortcut
                             Destination: new(21.133728f, 22.323914f, -631.281f),
                             Sprint: true);
                         yield return new Interact.Task(2002881, quest, EInteractionType.Interact);
+                        yield return new WaitAtEnd.WaitForTerritory(351);
                     }
                     // if target is in Solar and we are not currently there, interact to get there
                     if (step.Position != null && matchesCondition(EExtraSkipCondition.RisingStonesSolar, step.Position.Value) &&


### PR DESCRIPTION
## Summary

- wait for the Rising Stones territory transition after interacting with its entrance
- prevent the following interior movement task from pathfinding while the player is still in Mor Dhona

## Evidence

The runtime log showed the entrance interaction completing before the zone transition. The next synthetic movement task then asked vnavmesh to path from Mor Dhona coordinates to a Rising Stones interior coordinate, which returned zero points and stopped automation. Restarting after entering the Rising Stones succeeded.

## Testing

- `dotnet build Questionable/Questionable.csproj -c Release -f net10.0-windows -p:DalamudLibPath=<local Dalamud dev path>`
- Build succeeded with 0 warnings and 0 errors
- Post-fix in-game verification has not been performed

## AI assistance

GPT-5.6 via Codex was used to inspect the runtime log and draft this one-line change. The change and this pull request were reviewed and are owned by @eternalwaitt.