### PR TITLE
Handle combat during post-interaction waits

### DIFF
--- a/Questionable.Tests/Steps/WaitAtEndTests.cs
+++ b/Questionable.Tests/Steps/WaitAtEndTests.cs
@@ -1,0 +1,22 @@
+// Authored with LLM assistance, changes must be reviewed and owned by a human.
+// Initial version reviewed and owned by @eternalwaitt
+
+using Questionable.Controller.Steps.Shared;
+using Xunit;
+
+namespace Questionable.Tests.Steps;
+
+public sealed class WaitAtEndTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void WaitDelay_UsesConfiguredDamageInterruption(bool interruptOnDamage)
+    {
+        WaitAtEnd.WaitDelay task = new() { InterruptOnDamage = interruptOnDamage };
+        WaitAtEnd.WaitDelayExecutor executor = new();
+
+        Assert.True(executor.Start(task));
+        Assert.Equal(interruptOnDamage, executor.ShouldInterruptOnDamage());
+    }
+}

--- a/Questionable/Controller/Steps/Shared/WaitAtEnd.cs
+++ b/Questionable/Controller/Steps/Shared/WaitAtEnd.cs
@@ -130,6 +130,8 @@ internal static class WaitAtEnd
                     }
 
                 case EInteractionType.Interact:
+                    return [new WaitDelay { InterruptOnDamage = true }, Next(quest, sequence)];
+
                 default:
                     return [new WaitDelay(), Next(quest, sequence)];
             }
@@ -141,6 +143,8 @@ internal static class WaitAtEnd
     internal sealed record WaitDelay(TimeSpan Delay, string? Message,
                    [CallerFilePath] string file = "", [CallerLineNumber] int line = 0) : ITask
     {
+        public bool InterruptOnDamage { get; init; }
+
         public WaitDelay([CallerFilePath] string file = "", [CallerLineNumber] int line = 0)
             : this(TimeSpan.FromMilliseconds(750), Message: null, file: file, line: line)
         {
@@ -164,7 +168,7 @@ internal static class WaitAtEnd
             return true;
         }
 
-        public override bool ShouldInterruptOnDamage() => false;
+        public override bool ShouldInterruptOnDamage() => Task.InterruptOnDamage;
     }
 
     internal sealed class WaitNextStepOrSequence : ITask


### PR DESCRIPTION
## Summary

- allow the short delay after an ordinary NPC interaction to be interrupted by damage
- reuse the existing combat-interruption queue so the interaction is retried after combat
- keep all other post-step delays non-interruptible by default
- add regression coverage for the opt-in delay behavior

## Evidence

With Questionable v15.306.3.32 on quest 2111, For All the Nights to Come, the runtime log showed:

- the NPC interaction task completed at 21:08:22
- Questionable entered the post-interaction WaitAtEnd delay
- the player was attacked by an overworld enemy during that transition
- no combat-interruption task was queued
- at 21:08:30, Questionable advanced its internal step without game quest progress and logged: Could not retrieve next quest step, not doing anything [2111, 1, 255]

The interaction executor already opts into damage interruption. The immediately following WaitDelay did not, leaving a window where combat could cancel quest progress while the task queue continued to NextStep. This change makes only the delay created for an ordinary Interact step opt into the existing interruption behavior.

## Testing

- dotnet test Questionable.sln -c Release -p:DalamudLibPath=<local Dalamud dev path> --no-restore
  - Questionable.Tests: 8,700 passed
  - QuestPaths.JsonValidator: 4,320 passed
  - QuestPathGenerator.Tests: 1 passed
- dotnet build Questionable/Questionable.csproj -c Release -f net10.0-windows -p:DalamudLibPath=<local Dalamud dev path> --no-restore
  - succeeded with 0 warnings and 0 errors
- post-fix in-game reproduction has not been performed; the one-off quest had already progressed and the game remained running while the patch was built

## AI assistance

GPT-5.6 via Codex was used to inspect the runtime evidence and draft the change. The code and this pull request were reviewed and are owned by @eternalwaitt.